### PR TITLE
Track targets hit for multi-attack cards

### DIFF
--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -142,6 +142,7 @@ public static class CardHoverShowPatch
         // div-by-zero for the unplayed case.
         float avgIntended = agg.Plays > 0 ? (float)agg.TotalIntended / agg.Plays : 0f;
         float avgEffective = agg.Plays > 0 ? (float)agg.TotalEffective / agg.Plays : 0f;
+        float avgTargetsHit = agg.Plays > 0 ? (float)agg.TotalTargetsHit / agg.Plays : 0f;
         float overkillPct = agg.TotalIntended > 0 ? 100f * agg.TotalOverkill / agg.TotalIntended : 0f;
         float blockedPct = agg.TotalIntended > 0 ? 100f * agg.TotalBlocked / agg.TotalIntended : 0f;
 
@@ -269,6 +270,11 @@ public static class CardHoverShowPatch
             // Avg intended intentionally omitted pending issue #15.
             Row3(sb, "Total damage", agg.TotalEffective.ToString(), "");
             Row3(sb, "Avg effective", $"{avgEffective:F1}", "");
+            if (agg.TotalTargetsHit > 0)
+            {
+                Row3(sb, "Targets hit", agg.TotalTargetsHit.ToString(), "");
+                Row3(sb, "Avg targets", $"{avgTargetsHit:F1}", "");
+            }
             _ = avgIntended;  // still computed above; silence unused warning
 
             // Clarify 0 damage for attacks that played without dealing any:
@@ -353,8 +359,9 @@ public static class CardHoverShowPatch
     /// numbers only — the player's deciding what to play, not studying
     /// lifetime performance.
     ///
-    /// Shows: Played/Drawn ratio, Total damage (if attack), Energy gained
-    /// (if any), Block gained (if any), Kills (if any). Skips: lineage, most energy details, per-play
+    /// Shows: Played/Drawn ratio, Total damage (if attack), Targets hit (for
+    /// multi-target cards), Energy gained (if any), Block gained (if any),
+    /// Kills (if any). Skips: lineage, most energy details, per-play
     /// averages, overkill/blocked percentages. Everything uses the same
     /// 3-col layout as the full view for visual consistency.
     /// </summary>
@@ -377,6 +384,9 @@ public static class CardHoverShowPatch
 
         if (isAttack || agg.TotalEffective > 0)
             Row3(sb, "Total damage", agg.TotalEffective.ToString(), "");
+
+        if (agg.TotalTargetsHit > agg.Plays)
+            Row3(sb, "Targets hit", agg.TotalTargetsHit.ToString(), "");
 
         if (agg.TotalEnergyGenerated > 0)
             Row3(sb, "Energy gained", agg.TotalEnergyGenerated.ToString(), "");

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 5;
+    public const int CurrentSchemaVersion = 6;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -24,6 +24,10 @@ public class RunData
     //     remain resumable with the new field defaulting to 0.
     // v5: add block absorption / waste aggregates. Also additive; older v4
     //     files remain resumable with the new fields defaulting to 0.
+    // v6: add target-coverage aggregation for multi-target attacks. Counts
+    //     unique enemy receivers per play, summed across the run. Also
+    //     additive; older v5 files remain resumable with the new field
+    //     defaulting to 0.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -99,6 +103,7 @@ public class CardAggregate
     public int TotalOverkill { get; set; }   // damage past target HP (wasted)
     public int TotalEffective { get; set; }  // damage that actually moved HP (intended - blocked - overkill)
     public int Kills { get; set; }           // times the card landed a killing blow
+    public int TotalTargetsHit { get; set; } // unique enemy receivers hit, summed once per play per receiver
 
     // M3a: Energy spent. Sum of CardPlay.Resources.EnergySpent across every
     // play of this card instance. Uses EnergySpent (actual energy paid) not

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -106,6 +106,7 @@ public static class RunStorage
             case 2:
             case 3:
             case 4:
+            case 5:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -36,7 +36,9 @@ public static class RunTracker
     private static RunData? _currentRun;
     private static PendingCombat? _pendingCombat;
     private static CardPlay? _currentPlayerCardPlay;
+    private static HashSet<string>? _currentPlayerCardTargetsHit;
     private static CardPlay? _recentCompletedPlayerCardPlay;
+    private static HashSet<string>? _recentCompletedPlayerCardTargetsHit;
     private static int _recentCompletedPlayerCardPlayHistoryCount;
     private static CardModel? _pendingDrawSourceCard;
     private static CardModel? _pendingEffectSourceCard;
@@ -344,7 +346,9 @@ public static class RunTracker
     private static void ResetCombatContextState()
     {
         _currentPlayerCardPlay = null;
+        _currentPlayerCardTargetsHit = null;
         _recentCompletedPlayerCardPlay = null;
+        _recentCompletedPlayerCardTargetsHit = null;
         _recentCompletedPlayerCardPlayHistoryCount = 0;
         _pendingDrawSourceCard = null;
         _pendingEffectSourceCard = null;
@@ -802,7 +806,9 @@ public static class RunTracker
         lock (_lock)
         {
             _currentPlayerCardPlay = cardPlay;
+            _currentPlayerCardTargetsHit = new HashSet<string>(StringComparer.Ordinal);
             _recentCompletedPlayerCardPlay = null;
+            _recentCompletedPlayerCardTargetsHit = null;
             _recentCompletedPlayerCardPlayHistoryCount = 0;
             _pendingDrawSourceCard = null;
             _pendingEffectSourceCard = null;
@@ -819,6 +825,12 @@ public static class RunTracker
                 && ReferenceEquals(Canonical(_currentPlayerCardPlay.Card), Canonical(cardPlay.Card)))
             {
                 _currentPlayerCardPlay = null;
+                _recentCompletedPlayerCardTargetsHit = _currentPlayerCardTargetsHit;
+                _currentPlayerCardTargetsHit = null;
+            }
+            else
+            {
+                _recentCompletedPlayerCardTargetsHit = new HashSet<string>(StringComparer.Ordinal);
             }
 
             _recentCompletedPlayerCardPlay = cardPlay;
@@ -1541,12 +1553,14 @@ public static class RunTracker
             else
             {
                 // Enemy damage — offensive stats.
+                string? receiverId = entry.Receiver.Monster?.Id.ToString();
                 int intended = result.BlockedDamage + result.UnblockedDamage;
                 int effective = result.UnblockedDamage - result.OverkillDamage;
                 agg.TotalIntended += intended;
                 agg.TotalBlocked += result.BlockedDamage;
                 agg.TotalOverkill += result.OverkillDamage;
                 agg.TotalEffective += effective;
+                NoteTargetCoverageHitLocked(entry.CardSource!, agg, receiverId);
                 if (result.WasTargetKilled) agg.Kills++;
             }
 
@@ -1564,6 +1578,41 @@ public static class RunTracker
                 Killed = result.WasTargetKilled,
             });
         }
+    }
+
+    private static void NoteTargetCoverageHitLocked(CardModel sourceCard, CardAggregate agg, string? receiverId)
+    {
+        if (string.IsNullOrWhiteSpace(receiverId)) return;
+
+        var seenThisPlay = GetTargetCoverageWindowLocked(sourceCard);
+        if (seenThisPlay == null) return;
+
+        if (seenThisPlay.Add(receiverId))
+            agg.TotalTargetsHit++;
+    }
+
+    private static HashSet<string>? GetTargetCoverageWindowLocked(CardModel sourceCard)
+    {
+        var canonicalSource = Canonical(sourceCard);
+        if (_currentPlayerCardPlay?.Card != null
+            && ReferenceEquals(Canonical(_currentPlayerCardPlay.Card), canonicalSource))
+        {
+            _currentPlayerCardTargetsHit ??= new HashSet<string>(StringComparer.Ordinal);
+            return _currentPlayerCardTargetsHit;
+        }
+
+        if (_recentCompletedPlayerCardPlay?.Card != null
+            && ReferenceEquals(Canonical(_recentCompletedPlayerCardPlay.Card), canonicalSource))
+        {
+            int historyCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
+            if (historyCount <= _recentCompletedPlayerCardPlayHistoryCount + 1)
+            {
+                _recentCompletedPlayerCardTargetsHit ??= new HashSet<string>(StringComparer.Ordinal);
+                return _recentCompletedPlayerCardTargetsHit;
+            }
+        }
+
+        return null;
     }
 
     // -------- Helpers --------
@@ -1598,6 +1647,7 @@ public static class RunTracker
             TotalOverkill = source.TotalOverkill,
             TotalEffective = source.TotalEffective,
             Kills = source.Kills,
+            TotalTargetsHit = source.TotalTargetsHit,
             TotalEnergySpent = source.TotalEnergySpent,
             TotalEnergyGenerated = source.TotalEnergyGenerated,
             TotalBlockGained = source.TotalBlockGained,
@@ -1629,6 +1679,7 @@ public static class RunTracker
         target.TotalOverkill += source.TotalOverkill;
         target.TotalEffective += source.TotalEffective;
         target.Kills += source.Kills;
+        target.TotalTargetsHit += source.TotalTargetsHit;
         target.TotalEnergySpent += source.TotalEnergySpent;
         target.TotalEnergyGenerated += source.TotalEnergyGenerated;
         target.TotalBlockGained += source.TotalBlockGained;

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -14,15 +14,18 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds the per-card "times exhausted"
   count on top of the v3 effect summaries.
 - `v5-per-instance-block-ledger-run.json`
-  Current schema. Adds absorbed/wasted block aggregates on top of the v4
-  effect and exhaust fields.
+  Legacy-but-resumable additive schema. Adds absorbed/wasted block aggregates
+  on top of the v4 effect and exhaust fields.
+- `v6-target-coverage-run.json`
+  Current schema. Adds target-coverage aggregates on top of the v5 block-ledger
+  fields.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3` and `v4 -> v5`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, and `v5 -> v6`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v6-target-coverage-run.json
+++ b/Fixtures/RunSchema/v6-target-coverage-run.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 6,
+  "run_id": "fixture-v6-target-coverage",
+  "started_at": "2026-04-20T12:05:00Z",
+  "updated_at": "2026-04-20T12:17:00Z",
+  "ended_at": "2026-04-20T12:18:20Z",
+  "character": "KIN",
+  "ascension": 6,
+  "floor_reached": 23,
+  "outcome": "win",
+  "game_start_time": 1713614700,
+  "aggregates": {
+    "CARD.CLEAVE_KIN#1": {
+      "plays": 3,
+      "total_intended": 32,
+      "total_blocked": 5,
+      "total_overkill": 2,
+      "total_effective": 25,
+      "kills": 1,
+      "total_targets_hit": 7,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 3,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {},
+      "floor_added": 7,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-20T12:08:00Z",
+      "type": "card_played",
+      "card_id": "CARD.CLEAVE_KIN#1",
+      "energy_spent": 1,
+      "target": "KIN_SLIME_M_0",
+      "floor": 11
+    },
+    {
+      "t": "2026-04-20T12:08:01Z",
+      "type": "damage_received",
+      "card_id": "CARD.CLEAVE_KIN#1",
+      "receiver": "KIN_SLIME_M_0",
+      "blocked": 0,
+      "unblocked": 8,
+      "overkill": 0,
+      "killed": false
+    },
+    {
+      "t": "2026-04-20T12:08:01Z",
+      "type": "damage_received",
+      "card_id": "CARD.CLEAVE_KIN#1",
+      "receiver": "KIN_SLIME_S_0",
+      "blocked": 2,
+      "unblocked": 6,
+      "overkill": 1,
+      "killed": true
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.CLEAVE_KIN": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.CLEAVE_KIN": 1
+  }
+}

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -73,18 +73,34 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV5Fixture()
+    public void HistoricalLoad_AcceptsLegacyResumableV5Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v5-per-instance-block-ledger-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(5, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        var agg = loaded.Data.Aggregates["CARD.DEFEND_KIN#1"];
+        Assert.Equal(6, agg.TotalBlockEffective);
+        Assert.Equal(4, agg.TotalBlockWasted);
+        Assert.Equal(0, agg.TotalTargetsHit);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsCurrentV6Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v6-target-coverage-run.json"));
 
         Assert.NotNull(loaded);
         Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
         Assert.False(loaded.IsLegacy);
         Assert.True(loaded.SupportsResume);
         Assert.True(loaded.HasPerInstanceIdentity);
-        var agg = loaded.Data.Aggregates["CARD.DEFEND_KIN#1"];
-        Assert.Equal(6, agg.TotalBlockEffective);
-        Assert.Equal(4, agg.TotalBlockWasted);
+        var agg = loaded.Data.Aggregates["CARD.CLEAVE_KIN#1"];
+        Assert.Equal(7, agg.TotalTargetsHit);
+        Assert.Equal(25, agg.TotalEffective);
     }
 
     [Fact]
@@ -135,14 +151,26 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV5Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV5Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v5-per-instance-block-ledger-run.json"));
 
         Assert.NotNull(resumed);
-        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(5, resumed!.SchemaVersion);
         Assert.Equal(6, resumed.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         Assert.Equal(4, resumed.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockWasted);
+        Assert.Equal(0, resumed.Aggregates["CARD.DEFEND_KIN#1"].TotalTargetsHit);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV6Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v6-target-coverage-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(7, resumed.Aggregates["CARD.CLEAVE_KIN#1"].TotalTargetsHit);
+        Assert.Equal(25, resumed.Aggregates["CARD.CLEAVE_KIN#1"].TotalEffective);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #25.

## Summary
- track `total_targets_hit` by counting unique enemy receivers per resolving play
- surface target coverage in the hover tooltip with total and average targets hit
- bump the additive run schema to v6 and add fixture/test coverage for v5 compatibility and v6 loading

## Testing
- dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj