### PR TITLE
Add pooled Shiv deck-view stats

### DIFF
--- a/CardUtilityStats.csproj
+++ b/CardUtilityStats.csproj
@@ -52,16 +52,19 @@
              If we don't explicitly exclude Core/, the default glob in Godot.NET.Sdk
              will sweep it in and we'd get duplicate type definitions. -->
         <Compile Remove="Core/**" />
+        <Compile Remove="Tests/**" />
         <Compile Remove="CardUtilityStats/**" />
         <Compile Remove="materials/**" />
         <Compile Remove="shaders/**" />
         <Compile Remove="images/**" />
         <EmbeddedResource Remove="Core/**" />
+        <EmbeddedResource Remove="Tests/**" />
         <EmbeddedResource Remove="CardUtilityStats/**" />
         <EmbeddedResource Remove="materials/**" />
         <EmbeddedResource Remove="shaders/**" />
         <EmbeddedResource Remove="images/**" />
         <None Remove="Core/**" />
+        <None Remove="Tests/**" />
     </ItemGroup>
 
     <ItemGroup>
@@ -78,7 +81,7 @@
                 Condition="'$(Sts2DataDir)' == '' or !Exists('$(Sts2DataDir)')" />
     </Target>
 
-    <Target Name="CopyToModsFolderOnBuild" AfterTargets="PostBuildEvent">
+    <Target Name="CopyToModsFolderOnBuild" AfterTargets="PostBuildEvent" Condition="'$(SkipModsDeploy)' != 'true'">
         <Message Text="Copying .dll, manifest, and dependencies to mods folder." Importance="high" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModsPath)$(MSBuildProjectName)/" />
         <Copy SourceFiles="$(AssemblyName).json" DestinationFolder="$(ModsPath)$(MSBuildProjectName)/" />
@@ -91,7 +94,7 @@
         <Copy SourceFiles="@(LoaderRuntimeDeps)" DestinationFolder="$(ModsPath)$(MSBuildProjectName)/" />
     </Target>
 
-    <Target Name="CopyQuickPck" AfterTargets="PackPck" Condition="Exists('$(PckPackerOutputPath)') And '$(PckPackerSkipped)' != 'true'">
+    <Target Name="CopyQuickPck" AfterTargets="PackPck" Condition="Exists('$(PckPackerOutputPath)') And '$(PckPackerSkipped)' != 'true' And '$(SkipModsDeploy)' != 'true'">
         <Message Text="Copying quick .pck to mods folder." Importance="high"/>
         <Copy SourceFiles="$(PckPackerOutputPath)"
               DestinationFolder="$(ModsPath)/$(MSBuildProjectName)" />

--- a/Core/CardAggregatePooler.cs
+++ b/Core/CardAggregatePooler.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace CardUtilityStats.Core;
+
+internal static class CardAggregatePooler
+{
+    public static bool IsAggregateForDefinition(string aggregateKey, string definitionId)
+    {
+        return aggregateKey.StartsWith(definitionId, StringComparison.Ordinal)
+            && aggregateKey.Length > definitionId.Length
+            && aggregateKey[definitionId.Length] == '#';
+    }
+
+    public static CardAggregate? PoolByDefinition(
+        IEnumerable<KeyValuePair<string, CardAggregate>> aggregates,
+        string definitionId)
+    {
+        CardAggregate? pooled = null;
+
+        foreach (var (aggregateKey, aggregate) in aggregates)
+        {
+            if (!IsAggregateForDefinition(aggregateKey, definitionId)) continue;
+            pooled ??= new CardAggregate();
+            MergeInto(pooled, aggregate);
+        }
+
+        return pooled;
+    }
+
+    public static void MergeInto(CardAggregate target, CardAggregate source)
+    {
+        target.Plays += source.Plays;
+        target.TotalIntended += source.TotalIntended;
+        target.TotalBlocked += source.TotalBlocked;
+        target.TotalOverkill += source.TotalOverkill;
+        target.TotalEffective += source.TotalEffective;
+        target.Kills += source.Kills;
+        target.TotalEnergySpent += source.TotalEnergySpent;
+        target.TotalEnergyGenerated += source.TotalEnergyGenerated;
+        target.TotalBlockGained += source.TotalBlockGained;
+        target.TotalBlockEffective += source.TotalBlockEffective;
+        target.TotalBlockWasted += source.TotalBlockWasted;
+        target.TimesDrawn += source.TimesDrawn;
+        target.TimesDiscarded += source.TimesDiscarded;
+        target.TimesPlacedOnTopFromHand += source.TimesPlacedOnTopFromHand;
+        target.TimesPlacedOnTopFromDiscard += source.TimesPlacedOnTopFromDiscard;
+        target.TimesExhaustedOtherCards += source.TimesExhaustedOtherCards;
+        target.TimesExhausted += source.TimesExhausted;
+        target.TotalHpLost += source.TotalHpLost;
+        target.TimesCardsDrawn += source.TimesCardsDrawn;
+        MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
+    }
+
+    private static void MergeAppliedEffectsInto(
+        Dictionary<string, AppliedEffectAggregate> target,
+        Dictionary<string, AppliedEffectAggregate> source)
+    {
+        foreach (var kv in source)
+        {
+            if (!target.TryGetValue(kv.Key, out var effect))
+            {
+                effect = new AppliedEffectAggregate
+                {
+                    EffectId = kv.Value.EffectId,
+                    DisplayName = kv.Value.DisplayName,
+                    IconPath = kv.Value.IconPath,
+                };
+                target[kv.Key] = effect;
+            }
+
+            effect.TimesApplied += kv.Value.TimesApplied;
+            effect.TotalAmountApplied += kv.Value.TotalAmountApplied;
+            effect.TimesBlockedByArtifact += kv.Value.TimesBlockedByArtifact;
+            effect.TotalAmountBlockedByArtifact += kv.Value.TotalAmountBlockedByArtifact;
+            if (string.IsNullOrWhiteSpace(effect.DisplayName) && !string.IsNullOrWhiteSpace(kv.Value.DisplayName))
+                effect.DisplayName = kv.Value.DisplayName;
+            if (string.IsNullOrWhiteSpace(effect.IconPath) && !string.IsNullOrWhiteSpace(kv.Value.IconPath))
+                effect.IconPath = kv.Value.IconPath;
+        }
+    }
+}

--- a/Core/CardUtilityStats.Core.csproj
+++ b/Core/CardUtilityStats.Core.csproj
@@ -60,6 +60,8 @@
     <ItemGroup>
         <Compile Remove="..\**\*.cs" />
         <Compile Include="**\*.cs" />
+        <Compile Remove="bin\**\*.cs" />
+        <Compile Remove="obj\**\*.cs" />
         <!-- Don't include the asset image from the Loader's asset folder. -->
         <None Remove="**\*.png" />
     </ItemGroup>
@@ -72,7 +74,7 @@
 
     <!-- Deploy the Core DLL alongside the Loader's DLL in the mods folder.
          The Loader reads it from there and copies to a temp path for loading. -->
-    <Target Name="CopyCoreToModsFolderOnBuild" AfterTargets="PostBuildEvent">
+    <Target Name="CopyCoreToModsFolderOnBuild" AfterTargets="PostBuildEvent" Condition="'$(SkipModsDeploy)' != 'true'">
         <Message Text="Copying Core .dll to mods folder." Importance="high" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModsPath)CardUtilityStats/" />
     </Target>

--- a/Core/InternalsVisibleTo.cs
+++ b/Core/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CardUtilityStats.Core.Tests")]

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -120,13 +120,15 @@ public static class CardHoverShowPatch
     {
         var run = RunTracker.Current;
         var sb = new StringBuilder();
-        bool isShivMetaCard = RunTracker.IsShivDeckViewCard(cardModel);
+        bool isSupplementalMetaCard = RunTracker.IsShivDeckViewCard(cardModel);
 
         // The card identity now lives in the gold title slot for both compact
         // and full views, so repeating it again in the body just adds noise.
-
-        if (isShivMetaCard)
-            sb.Append($"[color=#b5b5b5]{ShivMetaNote}[/color]\n");
+        // Supplemental meta cards (pooled Shiv today; Sovereign Blade later)
+        // get a red explanatory banner instead of the generic ephemeral
+        // "not present in deck" note.
+        if (isSupplementalMetaCard)
+            sb.Append($"[color=#e04c4c][b]{ShivMetaNote}[/b][/color]\n");
 
         // Merges committed run + current pending combat so mid-combat plays
         // show up immediately (don't wait for CombatEnded). If we have no
@@ -203,11 +205,13 @@ public static class CardHoverShowPatch
             // Distinguish "was removed from deck" from "never entered deck"
             // (combat-generated ephemerals like Souls/Shivs). Removed gets
             // a red bold banner since it's an important run decision to
-            // flag at a glance; ephemerals get the subdued "not present"
-            // note since it's expected and less attention-worthy.
+            // flag at a glance. Supplemental deck-view meta cards already
+            // emitted their own explanatory red banner above, so we suppress
+            // the generic "not present" line for them. Other ephemerals keep
+            // the subdued grey note.
             if (agg.Removed)
                 sb.Append("[color=#e04c4c][b]Card Removed[/b][/color]\n");
-            else
+            else if (!isSupplementalMetaCard)
                 sb.Append("[color=#b5b5b5]Card not present in deck[/color]\n");
         }
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -24,6 +24,7 @@ namespace CardUtilityStats.Core.Patches;
 public static class CardHoverShowPatch
 {
     private const int InlineKeywordIconSize = 16;
+    private const string ShivMetaNote = "Reflects All Shiv Usage";
 
     [HarmonyPostfix]
     public static void Postfix(NCardHolder __instance)
@@ -119,9 +120,13 @@ public static class CardHoverShowPatch
     {
         var run = RunTracker.Current;
         var sb = new StringBuilder();
+        bool isShivMetaCard = RunTracker.IsShivDeckViewCard(cardModel);
 
         // The card identity now lives in the gold title slot for both compact
         // and full views, so repeating it again in the body just adds noise.
+
+        if (isShivMetaCard)
+            sb.Append($"[color=#b5b5b5]{ShivMetaNote}[/color]\n");
 
         // Merges committed run + current pending combat so mid-combat plays
         // show up immediately (don't wait for CombatEnded). If we have no

--- a/Core/Patches/DeckViewInjectRemovedPatch.cs
+++ b/Core/Patches/DeckViewInjectRemovedPatch.cs
@@ -7,10 +7,11 @@ using MegaCrit.Sts2.Core.Nodes.Screens;
 namespace CardUtilityStats.Core.Patches;
 
 /// <summary>
-/// Extend the deck-view display with removed cards when our ViewStats
+/// Extend the deck-view display with supplemental cards when our ViewStats
 /// checkbox is ticked. Harmony prefix on <c>NDeckViewScreen.DisplayCards</c>
 /// mutates the screen's private <c>_cards</c> list (via Publicizer access)
-/// to append removed-card refs before the grid renders them.
+/// to append removed-card refs plus the synthetic deck-level Shiv before the
+/// grid renders them.
 ///
 /// Why prefix not postfix: the grid's <c>SetCards</c> call uses <c>_cards</c>
 /// directly as its source. Mutating before the body runs is simpler than
@@ -20,7 +21,8 @@ namespace CardUtilityStats.Core.Patches;
 /// <c>CardModel.RemoveFromState</c> only sets <c>HasBeenRemovedFromState</c>
 /// (a flag) — it doesn't free the object. The grid renders them normally;
 /// the hover tooltip fires via the existing <c>NCardHolder.CreateHoverTips</c>
-/// patch and shows our stats including the "Removed floor X" lineage line.
+/// patch and shows our stats including the "Removed floor X" lineage line
+/// or the existing "Card not present in deck" banner for Shiv.
 ///
 /// Gate: only appends if the ViewStats checkbox is currently ticked. If the
 /// tickbox isn't injected yet (deck view never opened this session), behaves
@@ -40,7 +42,7 @@ public static class DeckViewInjectRemovedPatch
             // untick events also call DisplayCards, and without the reset
             // the previously-appended removed-card refs stayed in the list.
             // Resetting here guarantees clean state every render: the list
-            // reflects the current deck plus (if ticked) our removed refs.
+            // reflects the current deck plus (if ticked) our supplemental refs.
             //
             // Safe to reset: the grid's sort logic reads _sortingPriority
             // (a separate field on the screen), not the order of _cards.
@@ -49,16 +51,20 @@ public static class DeckViewInjectRemovedPatch
             var tickbox = ViewStatsInjectorPatch.LastInjectedTickbox;
             if (tickbox == null || !tickbox.IsTicked) return;
 
-            var removed = RunTracker.GetRemovedCards();
-            if (removed.Count == 0) return;
+            var supplemental = RunTracker.GetSupplementalDeckViewCards();
+            if (supplemental.Count == 0) return;
 
-            foreach (var card in removed)
+            int appended = 0;
+            foreach (var card in supplemental)
             {
                 if (card != null && !__instance._cards.Contains(card))
+                {
                     __instance._cards.Add(card);
+                    appended++;
+                }
             }
 
-            CoreMain.LogDebug($"DeckViewInject: appended {removed.Count} removed cards to deck view");
+            CoreMain.LogDebug($"DeckViewInject: appended {appended} supplemental cards to deck view");
         }
         catch (Exception e)
         {

--- a/Core/Patches/HookAfterCardGeneratedForCombatPatch.cs
+++ b/Core/Patches/HookAfterCardGeneratedForCombatPatch.cs
@@ -1,0 +1,27 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Marks the synthetic deck-view Shiv overlay as available once the run has
+/// generated its first in-combat Shiv. We patch the generic generated-card
+/// hook so all Shiv sources flow through one place.
+/// </summary>
+[HarmonyPatch(typeof(Hook), nameof(Hook.AfterCardGeneratedForCombat))]
+public static class HookAfterCardGeneratedForCombatPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(CardModel card)
+    {
+        try
+        {
+            RunTracker.RecordShivGenerated(card);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"HookAfterCardGeneratedForCombatPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -34,6 +34,9 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public static class RunTracker
 {
+    private const string ShivDefinitionId = "CARD.SHIV";
+    private const string ShivGeneratedEventType = "shiv_generated";
+
     private static readonly object _lock = new();
     private static RunData? _currentRun;
     private static PendingCombat? _pendingCombat;
@@ -46,6 +49,8 @@ public static class RunTracker
     private static readonly List<PendingPowerChangeAttempt> _pendingPowerChangeAttempts = new();
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
+    private static bool _shivAvailableThisRun;
+    private static CardModel? _shivDeckViewCard;
 
     // Per-instance identity. Every physical card in the player's deck gets
     // a stable number the first time we observe it — NOT just when it's
@@ -127,6 +132,9 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (IsShivDeckViewCardLocked(card))
+                return GetShivDeckViewAggregateLocked();
+
             // Non-assigning: if the card isn't tracked (preview/template
             // not yet a real deck member), return null so the tooltip
             // shows the empty-aggregate layout without creating a spurious
@@ -179,6 +187,84 @@ public static class RunTracker
             var key = Canonical(card);
             return _instanceNumbers.TryGetValue(key, out var existing) ? existing : 0;
         }
+    }
+
+    public static bool IsShivDeckViewCard(CardModel card)
+    {
+        if (card == null) return false;
+        lock (_lock) return IsShivDeckViewCardLocked(card);
+    }
+
+    private static bool IsShivDeckViewCardLocked(CardModel card)
+    {
+        return _shivDeckViewCard != null
+            && ReferenceEquals(Canonical(card), _shivDeckViewCard);
+    }
+
+    private static CardAggregate? GetShivDeckViewAggregateLocked()
+    {
+        CardAggregate? pooled = null;
+
+        if (_currentRun != null)
+            pooled = CardAggregatePooler.PoolByDefinition(_currentRun.Aggregates, ShivDefinitionId);
+
+        if (_pendingCombat != null)
+        {
+            var pending = CardAggregatePooler.PoolByDefinition(
+                _pendingCombat.CombatAggregates,
+                ShivDefinitionId);
+            if (pending != null)
+            {
+                pooled ??= new CardAggregate();
+                CardAggregatePooler.MergeInto(pooled, pending);
+            }
+        }
+
+        return pooled;
+    }
+
+    private static bool HasShivDataLocked()
+    {
+        if (_currentRun?.Events.Any(e => e.Type == ShivGeneratedEventType) == true)
+            return true;
+
+        if (_pendingCombat?.CombatEvents.Any(e => e.Type == ShivGeneratedEventType) == true)
+            return true;
+
+        if (_currentRun?.Aggregates.Keys.Any(key =>
+                CardAggregatePooler.IsAggregateForDefinition(key, ShivDefinitionId)) == true)
+            return true;
+
+        if (_pendingCombat?.CombatAggregates.Keys.Any(key =>
+                CardAggregatePooler.IsAggregateForDefinition(key, ShivDefinitionId)) == true)
+            return true;
+
+        return false;
+    }
+
+    private static void RefreshShivAvailabilityLocked()
+    {
+        _shivAvailableThisRun = HasShivDataLocked();
+        if (!_shivAvailableThisRun)
+            _shivDeckViewCard = null;
+    }
+
+    private static CardModel? GetShivDeckViewCardLocked()
+    {
+        if (!_shivAvailableThisRun) return null;
+        if (_shivDeckViewCard != null) return _shivDeckViewCard;
+
+        try
+        {
+            var modelId = ModelId.Deserialize(ShivDefinitionId);
+            _shivDeckViewCard = ModelDb.GetById<CardModel>(modelId).ToMutable();
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"GetShivDeckViewCardLocked failed: {e.Message}");
+        }
+
+        return _shivDeckViewCard;
     }
 
     /// <summary>
@@ -418,6 +504,7 @@ public static class RunTracker
                 _pendingCombat = null;
                 _instanceNumbers.Clear();
                 _defCounters.Clear();
+                _shivDeckViewCard = null;
 
                 // Restore monotonic counters first so any lazy-assign after
                 // this picks up the next unused number (not a conflict).
@@ -510,6 +597,8 @@ public static class RunTracker
                     $"game_start_time={gameStartTime} aggregates={_currentRun.Aggregates?.Count ?? 0} " +
                     $"reconstructed_removed={reconstructedRemoved} " +
                     $"restored_numbers={restored} unmatched_in_deck={unmatched}");
+
+                RefreshShivAvailabilityLocked();
             }
             catch (Exception e)
             {
@@ -537,6 +626,8 @@ public static class RunTracker
             _instanceNumbers.Clear();
             _defCounters.Clear();
             ResetCombatContextState();
+            _shivAvailableThisRun = false;
+            _shivDeckViewCard = null;
 
             string now = Now();
             _currentRun = new RunData
@@ -601,6 +692,8 @@ public static class RunTracker
             _currentRun = null;
             _pendingCombat = null;
             ResetCombatContextState();
+            _shivAvailableThisRun = false;
+            _shivDeckViewCard = null;
         }
     }
 
@@ -1026,16 +1119,44 @@ public static class RunTracker
     {
         lock (_lock)
         {
-            if (_currentRun == null) return Array.Empty<CardModel>();
-            var result = new List<CardModel>();
-            foreach (var kv in _instanceNumbers)
+            return GetRemovedCardsLocked();
+        }
+    }
+
+    private static List<CardModel> GetRemovedCardsLocked()
+    {
+        if (_currentRun == null) return new List<CardModel>();
+
+        var result = new List<CardModel>();
+        foreach (var kv in _instanceNumbers)
+        {
+            var instanceId = $"{kv.Key.Id}#{kv.Value}";
+            if (_currentRun.Aggregates.TryGetValue(instanceId, out var agg) && agg.Removed)
             {
-                var instanceId = $"{kv.Key.Id}#{kv.Value}";
-                if (_currentRun.Aggregates.TryGetValue(instanceId, out var agg) && agg.Removed)
-                {
-                    result.Add(kv.Key);
-                }
+                result.Add(kv.Key);
             }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Additional cards to surface in the full-deck screen when ViewStats is
+    /// enabled. Today that includes removed cards plus the synthetic
+    /// deck-level Shiv once the run has generated one.
+    /// </summary>
+    public static IReadOnlyList<CardModel> GetSupplementalDeckViewCards()
+    {
+        lock (_lock)
+        {
+            RefreshShivAvailabilityLocked();
+
+            var result = GetRemovedCardsLocked();
+
+            var shiv = GetShivDeckViewCardLocked();
+            if (shiv != null && !result.Contains(shiv))
+                result.Add(shiv);
+
             return result;
         }
     }
@@ -1209,6 +1330,40 @@ public static class RunTracker
                 _pendingEffectSourceCard = Canonical(sourceCard);
                 _pendingEffectSourceHistoryCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
             }
+        }
+    }
+
+    public static void RecordShivGenerated(CardModel? card)
+    {
+        if (card == null) return;
+
+        lock (_lock)
+        {
+            if (!string.Equals(Canonical(card).Id.ToString(), ShivDefinitionId, StringComparison.Ordinal))
+                return;
+
+            _shivAvailableThisRun = true;
+
+            _currentRun ??= new RunData
+            {
+                RunId = Guid.NewGuid().ToString("N"),
+                StartedAt = Now(),
+                UpdatedAt = Now(),
+            };
+            _pendingCombat ??= new PendingCombat();
+
+            bool alreadyRecorded =
+                _currentRun.Events.Any(e => e.Type == ShivGeneratedEventType) ||
+                _pendingCombat.CombatEvents.Any(e => e.Type == ShivGeneratedEventType);
+            if (alreadyRecorded) return;
+
+            _pendingCombat.CombatEvents.Add(new CardEvent
+            {
+                T = Now(),
+                Type = ShivGeneratedEventType,
+                CardId = ShivDefinitionId,
+                Floor = RunManager.Instance.State?.TotalFloor,
+            });
         }
     }
 

--- a/Tests/CardUtilityStats.Core.Tests/CardAggregatePoolerTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/CardAggregatePoolerTests.cs
@@ -1,0 +1,84 @@
+using CardUtilityStats.Core;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class CardAggregatePoolerTests
+{
+    [Fact]
+    public void PoolByDefinition_MergesOnlyMatchingDefinitionInstances()
+    {
+        var first = new CardAggregate
+        {
+            Plays = 1,
+            TotalEffective = 4,
+            TotalBlocked = 1,
+            TimesExhausted = 1,
+        };
+        first.AppliedEffects["POWER.ARTIFACT"] = new AppliedEffectAggregate
+        {
+            EffectId = "POWER.ARTIFACT",
+            DisplayName = "Artifact",
+            TimesBlockedByArtifact = 1,
+            TotalAmountBlockedByArtifact = 1m,
+        };
+
+        var second = new CardAggregate
+        {
+            Plays = 2,
+            TotalEffective = 11,
+            TotalBlocked = 2,
+            TimesExhausted = 2,
+        };
+        second.AppliedEffects["POWER.VULNERABLE"] = new AppliedEffectAggregate
+        {
+            EffectId = "POWER.VULNERABLE",
+            DisplayName = "Vulnerable",
+            TimesApplied = 2,
+            TotalAmountApplied = 4m,
+        };
+
+        var otherDefinition = new CardAggregate
+        {
+            Plays = 99,
+            TotalEffective = 999,
+            TimesExhausted = 99,
+        };
+
+        var pooled = CardAggregatePooler.PoolByDefinition(
+            new[]
+            {
+                new KeyValuePair<string, CardAggregate>("CARD.SHIV#1", first),
+                new KeyValuePair<string, CardAggregate>("CARD.SHIV#2", second),
+                new KeyValuePair<string, CardAggregate>("CARD.STRIKE_SILENT#1", otherDefinition),
+            },
+            "CARD.SHIV");
+
+        Assert.NotNull(pooled);
+        Assert.Equal(3, pooled!.Plays);
+        Assert.Equal(15, pooled.TotalEffective);
+        Assert.Equal(3, pooled.TotalBlocked);
+        Assert.Equal(3, pooled.TimesExhausted);
+
+        var artifact = pooled.AppliedEffects["POWER.ARTIFACT"];
+        Assert.Equal(1, artifact.TimesBlockedByArtifact);
+        Assert.Equal(1m, artifact.TotalAmountBlockedByArtifact);
+
+        var vulnerable = pooled.AppliedEffects["POWER.VULNERABLE"];
+        Assert.Equal(2, vulnerable.TimesApplied);
+        Assert.Equal(4m, vulnerable.TotalAmountApplied);
+    }
+
+    [Fact]
+    public void PoolByDefinition_ReturnsNullWhenDefinitionIsAbsent()
+    {
+        var pooled = CardAggregatePooler.PoolByDefinition(
+            new[]
+            {
+                new KeyValuePair<string, CardAggregate>("CARD.STRIKE_SILENT#1", new CardAggregate()),
+            },
+            "CARD.SHIV");
+
+        Assert.Null(pooled);
+    }
+}


### PR DESCRIPTION
## Summary
- surface a synthetic Shiv card in full deck view once the run generates its first Shiv
- pool deck-view Shiv stats across all real in-combat Shiv instances while keeping combat tracking per instance
- add a tooltip note for the synthetic card: `Reflects All Shiv Usage`
- include build/test plumbing so the scratch clone can be validated with `SkipModsDeploy=true`

## Verification
- `dotnet build CardUtilityStats.csproj -p:SkipModsDeploy=true`
- `dotnet build Core\\CardUtilityStats.Core.csproj -p:SkipModsDeploy=true`
- `dotnet test Tests\\CardUtilityStats.Core.Tests\\CardUtilityStats.Core.Tests.csproj -p:SkipModsDeploy=true`