### PR TITLE
Add dedicated poison tooltip stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS
+
+This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attribution: not just what a card says it should do, but what it actually caused in the run.
+
+## Current Truths
+
+- Runtime is split into a stable loader and a hot-reloaded core.
+  - [Loader/LoaderMain.cs](D:/repos/CardUtilityStats/Loader/LoaderMain.cs:14) owns the long-lived bootstrap and `F5` reload flow.
+  - [Core/CoreMain.cs](D:/repos/CardUtilityStats/Core/CoreMain.cs:8) owns Harmony patch install/uninstall and re-entry on each reload.
+- Persistence is combat-boundary based.
+  - [Core/RunTracker.cs](D:/repos/CardUtilityStats/Core/RunTracker.cs:18) buffers live combat data in `_pendingCombat`.
+  - Nothing is promoted to the permanent run file until combat ends.
+  - Reload between combats / between floors is supported and expected.
+  - Mid-combat restore is intentionally out of scope.
+- The data model is additive through schema `v8`.
+  - [Core/RunData.cs](D:/repos/CardUtilityStats/Core/RunData.cs:13) is the source of truth for the current schema.
+  - [Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs](D:/repos/CardUtilityStats/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs:1) and the checked-in fixtures pin what remains resumable.
+- Card identity is per physical card when the card has stable deck identity.
+  - Instance numbers never get reused within a run.
+  - Combat-generated cards that do not meaningfully exist in the deck may use pooled summaries instead of fake deck-instance identities.
+- Attribution prefers observed outcomes over listed card text whenever the game can diverge from the card face.
+  - Examples already in tree: actual energy gained, Regent stars spent/gained, observed cards drawn, Artifact-blocked debuffs, and downstream poison damage.
+- Tooltip style is intentionally quiet.
+  - Hand view stays compact.
+  - Rows should be self-describing without noisy section headers.
+  - Inline keyword icons are preferred when they improve scanability without making the layout louder.
+  - When the game already has a recognizable asset for the stat, prefer that in-game icon over a generic label.
+
+## Start Here
+
+- Read [README.md](D:/repos/CardUtilityStats/README.md:1) for the product-level overview.
+- Read [docs/architecture.md](D:/repos/CardUtilityStats/docs/architecture.md:1) for subsystem layout and data flow.
+- For tracking behavior, start in [Core/RunTracker.cs](D:/repos/CardUtilityStats/Core/RunTracker.cs:18).
+- For tooltip/UI behavior, start in:
+  - [Core/Patches/ViewStatsInjectorPatch.cs](D:/repos/CardUtilityStats/Core/Patches/ViewStatsInjectorPatch.cs:11)
+  - [Core/Patches/CardHoverTooltipPatch.cs](D:/repos/CardUtilityStats/Core/Patches/CardHoverTooltipPatch.cs:11)
+
+## When Changing Behavior
+
+- If you add persisted fields:
+  - bump `RunData.CurrentSchemaVersion`
+  - add or update fixture files under [Fixtures/RunSchema](D:/repos/CardUtilityStats/Fixtures/RunSchema/README.md:1)
+  - update [SchemaLoadingTests.cs](D:/repos/CardUtilityStats/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs:1)
+- If you change tooltip presentation:
+  - preserve the compact-vs-full distinction
+  - keep labels self-describing
+  - avoid adding loud headers unless they clearly earn their space
+- If you add new attribution:
+  - prefer empirical results over intent text
+  - be explicit when attribution is heuristic, pooled, or case-specific
+
+## Useful Commands
+
+- Build/tests:
+  - `dotnet test D:\repos\CardUtilityStats\Tests\CardUtilityStats.Core.Tests\CardUtilityStats.Core.Tests.csproj -c Debug`
+- Focused schema tests:
+  - `dotnet test D:\repos\CardUtilityStats\Tests\CardUtilityStats.Core.Tests\CardUtilityStats.Core.Tests.csproj -c Debug --filter SchemaLoadingTests`
+- Focused tooltip tests:
+  - `dotnet test D:\repos\CardUtilityStats\Tests\CardUtilityStats.Core.Tests\CardUtilityStats.Core.Tests.csproj -c Debug --filter PoisonTooltipTests`

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -24,6 +24,10 @@ namespace CardUtilityStats.Core.Patches;
 public static class CardHoverShowPatch
 {
     private const int InlineKeywordIconSize = 16;
+    private const string BlockIconPath = "res://images/ui/combat/block.png";
+    private const string DrawCardsNextTurnPowerIconPath = "res://images/atlases/power_atlas.sprites/draw_cards_next_turn_power.tres";
+    private const string EnergyPotionIconPath = "res://images/atlases/potion_atlas.sprites/energy_potion.tres";
+    private const string StarIconPath = "res://images/packed/sprite_fonts/star_icon.png";
 
     [HarmonyPostfix]
     public static void Postfix(NCardHolder __instance)
@@ -218,7 +222,7 @@ public static class CardHoverShowPatch
         if (isUnplayable)
         {
             // For unplayable cards, just show Drawn. Played is always 0.
-            Row3(sb, "Drawn", agg.TimesDrawn.ToString(), "");
+            Row3(sb, GetDrawStatLabel("drawn"), agg.TimesDrawn.ToString(), "");
         }
         else
         {
@@ -237,8 +241,15 @@ public static class CardHoverShowPatch
         if (agg.TotalEnergyGenerated > 0)
         {
             float avgGenerated = agg.Plays > 0 ? (float)agg.TotalEnergyGenerated / agg.Plays : 0f;
-            Row3(sb, "Energy gained", agg.TotalEnergyGenerated.ToString(), "");
-            Row3(sb, "Avg gained", $"{avgGenerated:F1}", "");
+            Row3(sb, GetEnergyStatLabel("gained"), agg.TotalEnergyGenerated.ToString(), "");
+            Row3(sb, GetEnergyStatLabel("avg gained"), $"{avgGenerated:F1}", "");
+        }
+
+        if (agg.TotalStarsGenerated > 0)
+        {
+            float avgGenerated = agg.Plays > 0 ? (float)agg.TotalStarsGenerated / agg.Plays : 0f;
+            Row3(sb, GetStarStatLabel("gained"), agg.TotalStarsGenerated.ToString(), "");
+            Row3(sb, GetStarStatLabel("avg gained"), $"{avgGenerated:F1}", "");
         }
 
         // Energy-spent rows — only rendered when the card's cost is actually
@@ -248,8 +259,15 @@ public static class CardHoverShowPatch
         if (IsEnergyInteresting(cardModel, agg))
         {
             float avgEnergy = agg.Plays > 0 ? (float)agg.TotalEnergySpent / agg.Plays : 0f;
-            Row3(sb, "Total energy spent", agg.TotalEnergySpent.ToString(), "");
-            Row3(sb, "Avg energy", $"{avgEnergy:F1}", "");
+            Row3(sb, GetEnergyStatLabel("total spent"), agg.TotalEnergySpent.ToString(), "");
+            Row3(sb, GetEnergyStatLabel("avg cost"), $"{avgEnergy:F1}", "");
+        }
+
+        if (IsStarInteresting(cardModel, agg))
+        {
+            float avgStars = agg.Plays > 0 ? (float)agg.TotalStarsSpent / agg.Plays : 0f;
+            Row3(sb, GetStarStatLabel("total spent"), agg.TotalStarsSpent.ToString(), "");
+            Row3(sb, GetStarStatLabel("avg cost"), $"{avgStars:F1}", "");
         }
 
         // Damage section rules:
@@ -299,9 +317,9 @@ public static class CardHoverShowPatch
             float avgBlock = agg.Plays > 0 ? (float)agg.TotalBlockGained / agg.Plays : 0f;
             float absorbedPct = 100f * agg.TotalBlockEffective / agg.TotalBlockGained;
             float wastedPct = 100f * agg.TotalBlockWasted / agg.TotalBlockGained;
-            RowDual(sb, "Block gained", agg.TotalBlockGained.ToString(), "Avg block", $"{avgBlock:F1}");
-            Row3(sb, "Absorbed", agg.TotalBlockEffective.ToString(), $"{absorbedPct:F0}%");
-            Row3(sb, "Wasted", agg.TotalBlockWasted.ToString(), $"{wastedPct:F0}%");
+            RowDual(sb, GetBlockStatLabel("gained"), agg.TotalBlockGained.ToString(), GetBlockStatLabel("avg"), $"{avgBlock:F1}");
+            Row3(sb, GetBlockStatLabel("absorbed"), agg.TotalBlockEffective.ToString(), $"{absorbedPct:F0}%");
+            Row3(sb, GetBlockStatLabel("wasted"), agg.TotalBlockWasted.ToString(), $"{wastedPct:F0}%");
         }
 
         // Discarded count — shown only when > 0 because for most cards
@@ -333,7 +351,7 @@ public static class CardHoverShowPatch
         // Draw attribution — cards drawn as a result of playing THIS card.
         // Counts only card-effect draws (not turn-start auto-draw).
         if (agg.TimesCardsDrawn > 0)
-            Row3(sb, "Cards drawn", agg.TimesCardsDrawn.ToString(), "");
+            Row3(sb, GetDrawStatLabel("cards drawn"), agg.TimesCardsDrawn.ToString(), "");
 
         // HP lost from playing this card — Ironclad self-damage cards.
         // POST-reduction value, so Tungsten Rod / buffer interactions
@@ -371,7 +389,7 @@ public static class CardHoverShowPatch
 
         if (isUnplayable)
         {
-            Row3(sb, "Drawn", agg.TimesDrawn.ToString(), "");
+            Row3(sb, GetDrawStatLabel("drawn"), agg.TimesDrawn.ToString(), "");
         }
         else
         {
@@ -383,10 +401,13 @@ public static class CardHoverShowPatch
             Row3(sb, "Total damage", agg.TotalEffective.ToString(), "");
 
         if (agg.TotalEnergyGenerated > 0)
-            Row3(sb, "Energy gained", agg.TotalEnergyGenerated.ToString(), "");
+            Row3(sb, GetEnergyStatLabel("gained"), agg.TotalEnergyGenerated.ToString(), "");
+
+        if (agg.TotalStarsGenerated > 0)
+            Row3(sb, GetStarStatLabel("gained"), agg.TotalStarsGenerated.ToString(), "");
 
         if (agg.TotalBlockGained > 0)
-            Row3(sb, "Block gained", agg.TotalBlockGained.ToString(), "");
+            Row3(sb, GetBlockStatLabel("gained"), agg.TotalBlockGained.ToString(), "");
 
         bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: true);
         AppendAppliedEffects(sb, agg, compact: true, excludePoison: hasDedicatedPoison);
@@ -476,26 +497,38 @@ public static class CardHoverShowPatch
 
         if (compact)
         {
+            if (poison.Value.TimesApplied <= 0 && poison.Value.TotalAmountApplied == 0m)
+                return false;
+
             var extra = poison.Value.TimesApplied > 0
                 ? poison.Value.TimesApplied > 1 ? $"{poison.Value.TimesApplied}x" : "1x"
                 : "";
-            Row3(sb, "Poison applied", FormatDecimal(poison.Value.TotalAmountApplied), extra);
+            Row3(sb, GetPoisonStatLabel(poison.Value, "applied"), FormatDecimal(poison.Value.TotalAmountApplied), extra);
             return true;
         }
 
         decimal avgPoison = agg.Plays > 0 ? poison.Value.TotalAmountApplied / agg.Plays : 0m;
 
-        sb.Append("[color=#b5b5b5]Poison applied[/color]\n");
-        Row3(sb, "Total poison", FormatDecimal(poison.Value.TotalAmountApplied), "");
-        Row3(sb, "Avg poison", FormatDecimal(avgPoison), "");
-        Row3(sb, "Applications", poison.Value.TimesApplied.ToString(), "");
+        Row3(sb, GetPoisonStatLabel(poison.Value, "total"), FormatDecimal(poison.Value.TotalAmountApplied), "");
+        Row3(sb, GetPoisonStatLabel(poison.Value, "avg"), FormatDecimal(avgPoison), "");
+        Row3(sb, GetPoisonStatLabel(poison.Value, "applications"), poison.Value.TimesApplied.ToString(), "");
+
+        if (poison.Value.TotalTriggeredEffectiveDamage > 0m || poison.Value.TotalTriggeredOverkill > 0m)
+        {
+            decimal avgPoisonDamage = agg.Plays > 0 ? poison.Value.TotalTriggeredEffectiveDamage / agg.Plays : 0m;
+            Row3(sb, GetPoisonStatLabel(poison.Value, "damage"), FormatDecimal(poison.Value.TotalTriggeredEffectiveDamage), "");
+            Row3(sb, GetPoisonStatLabel(poison.Value, "avg dmg"), FormatDecimal(avgPoisonDamage), "");
+
+            if (poison.Value.TotalTriggeredOverkill > 0m)
+                Row3(sb, GetPoisonStatLabel(poison.Value, "overkill"), FormatDecimal(poison.Value.TotalTriggeredOverkill), "");
+        }
 
         if (poison.Value.TimesBlockedByArtifact > 0)
         {
             string extra = poison.Value.TimesBlockedByArtifact > 1
                 ? $"{poison.Value.TimesBlockedByArtifact}x"
                 : "1x";
-            Row3(sb, "Blocked by Artifact", FormatDecimal(poison.Value.TotalAmountBlockedByArtifact), extra);
+            Row3(sb, GetPoisonStatLabel(poison.Value, "blocked by Artifact"), FormatDecimal(poison.Value.TotalAmountBlockedByArtifact), extra);
         }
 
         return true;
@@ -509,6 +542,9 @@ public static class CardHoverShowPatch
         decimal totalAmountApplied = 0m;
         int timesBlockedByArtifact = 0;
         decimal totalAmountBlockedByArtifact = 0m;
+        decimal totalTriggeredEffectiveDamage = 0m;
+        decimal totalTriggeredOverkill = 0m;
+        string? iconPath = null;
 
         foreach (var effect in agg.AppliedEffects.Values)
         {
@@ -518,19 +554,72 @@ public static class CardHoverShowPatch
             totalAmountApplied += effect.TotalAmountApplied;
             timesBlockedByArtifact += effect.TimesBlockedByArtifact;
             totalAmountBlockedByArtifact += effect.TotalAmountBlockedByArtifact;
+            totalTriggeredEffectiveDamage += effect.TotalTriggeredEffectiveDamage;
+            totalTriggeredOverkill += effect.TotalTriggeredOverkill;
+            if (string.IsNullOrWhiteSpace(iconPath) && !string.IsNullOrWhiteSpace(effect.IconPath))
+                iconPath = effect.IconPath;
         }
 
         if (timesApplied <= 0 &&
             totalAmountApplied == 0m &&
             timesBlockedByArtifact <= 0 &&
-            totalAmountBlockedByArtifact == 0m)
+            totalAmountBlockedByArtifact == 0m &&
+            totalTriggeredEffectiveDamage == 0m &&
+            totalTriggeredOverkill == 0m)
             return null;
 
         return new PoisonEffectSummary(
             timesApplied,
             totalAmountApplied,
             timesBlockedByArtifact,
-            totalAmountBlockedByArtifact);
+            totalAmountBlockedByArtifact,
+            totalTriggeredEffectiveDamage,
+            totalTriggeredOverkill,
+            iconPath);
+    }
+
+    private static string GetPoisonStatLabel(PoisonEffectSummary poison, string suffix)
+    {
+        if (!string.IsNullOrWhiteSpace(poison.IconPath))
+            return GetInlineIconStatLabel(poison.IconPath, suffix);
+
+        return $"Poison {suffix}";
+    }
+
+    private static string GetBlockStatLabel(string suffix)
+    {
+        return GetInlineIconStatLabel(BlockIconPath, suffix);
+    }
+
+    private static string GetDrawStatLabel(string suffix)
+    {
+        return GetInlineIconStatLabel(DrawCardsNextTurnPowerIconPath, suffix);
+    }
+
+    private static string GetEnergyStatLabel(string suffix)
+    {
+        return GetInlineIconStatLabel(EnergyPotionIconPath, suffix);
+    }
+
+    private static string GetStarStatLabel(string suffix)
+    {
+        return GetInlineIconStatLabel(StarIconPath, suffix);
+    }
+
+    private static string GetInlineIconStatLabel(string iconPath, string suffix)
+    {
+        var normalizedPath = NormalizeResourcePath(iconPath);
+        return $"[img={InlineKeywordIconSize}x{InlineKeywordIconSize}]{normalizedPath}[/img] {suffix}";
+    }
+
+    private static string NormalizeResourcePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        return path.StartsWith("res://", StringComparison.Ordinal)
+            ? path
+            : $"res://{path.TrimStart('/')}";
     }
 
     private static void AppendAppliedEffects(StringBuilder sb, CardAggregate agg, bool compact, bool excludePoison)
@@ -553,7 +642,7 @@ public static class CardHoverShowPatch
         {
             if (compact && shown >= 2) break;
 
-            var label = string.IsNullOrWhiteSpace(effect.DisplayName) ? effect.EffectId : effect.DisplayName;
+            var label = GetAppliedEffectLabel(effect);
             var value = FormatDecimal(effect.TotalAmountApplied);
             var extra = effect.TimesApplied > 1 ? $"{effect.TimesApplied}x" : "1x";
             Row3(sb, label, value, extra);
@@ -636,6 +725,72 @@ public static class CardHoverShowPatch
         return string.Equals(effect.DisplayName, "Poison", StringComparison.OrdinalIgnoreCase);
     }
 
+    private static string GetAppliedEffectLabel(AppliedEffectAggregate effect)
+    {
+        var label = string.IsNullOrWhiteSpace(effect.DisplayName) ? effect.EffectId : effect.DisplayName;
+        if (IsEnergyEffect(effect))
+            return GetEnergyEffectLabel(label);
+        if (IsStarEffect(effect))
+            return GetStarEffectLabel(label);
+
+        return label;
+    }
+
+    private static bool IsEnergyEffect(AppliedEffectAggregate effect)
+    {
+        if (!string.IsNullOrWhiteSpace(effect.EffectId) &&
+            effect.EffectId.Contains("ENERGY", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return !string.IsNullOrWhiteSpace(effect.DisplayName) &&
+               effect.DisplayName.Contains("Energy", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetEnergyEffectLabel(string label)
+    {
+        const string energyPrefix = "Energy ";
+        if (label.StartsWith(energyPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var suffix = label.Substring(energyPrefix.Length).Trim();
+            if (!string.IsNullOrWhiteSpace(suffix))
+                return GetInlineIconStatLabel(EnergyPotionIconPath, suffix);
+        }
+
+        return GetInlineIconStatLabel(EnergyPotionIconPath, label);
+    }
+
+    private static bool IsStarEffect(AppliedEffectAggregate effect)
+    {
+        if (!string.IsNullOrWhiteSpace(effect.EffectId) &&
+            effect.EffectId.Contains("STAR", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return !string.IsNullOrWhiteSpace(effect.DisplayName) &&
+               effect.DisplayName.StartsWith("Star", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetStarEffectLabel(string label)
+    {
+        const string pluralPrefix = "Stars ";
+        const string singularPrefix = "Star ";
+
+        if (label.StartsWith(pluralPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var suffix = label.Substring(pluralPrefix.Length).Trim();
+            if (!string.IsNullOrWhiteSpace(suffix))
+                return GetInlineIconStatLabel(StarIconPath, suffix);
+        }
+
+        if (label.StartsWith(singularPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var suffix = label.Substring(singularPrefix.Length).Trim();
+            if (!string.IsNullOrWhiteSpace(suffix))
+                return GetInlineIconStatLabel(StarIconPath, suffix);
+        }
+
+        return GetInlineIconStatLabel(StarIconPath, label);
+    }
+
     private static string FormatDecimal(decimal value)
     {
         return decimal.Truncate(value) == value
@@ -678,13 +833,34 @@ public static class CardHoverShowPatch
             return false;
         }
     }
+
+    private static bool IsStarInteresting(
+        MegaCrit.Sts2.Core.Models.CardModel card, CardAggregate agg)
+    {
+        try
+        {
+            if (agg.Plays <= 0 || agg.TotalStarsSpent <= 0) return false;
+            if (card.HasStarCostX) return true;
+
+            int expectedPerPlay = Math.Max(0, card.GetStarCostWithModifiers());
+            return agg.TotalStarsSpent != expectedPerPlay * agg.Plays;
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"IsStarInteresting failed: {e.Message}");
+            return false;
+        }
+    }
 }
 
 internal readonly record struct PoisonEffectSummary(
     int TimesApplied,
     decimal TotalAmountApplied,
     int TimesBlockedByArtifact,
-    decimal TotalAmountBlockedByArtifact);
+    decimal TotalAmountBlockedByArtifact,
+    decimal TotalTriggeredEffectiveDamage,
+    decimal TotalTriggeredOverkill,
+    string? IconPath);
 
 [HarmonyPatch(typeof(NCardHolder), "ClearHoverTips")]
 public static class CardHoverHidePatch

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -227,8 +227,9 @@ public static class CardHoverShowPatch
             Row3(sb, "Played/Drawn", $"{agg.Plays}/{agg.TimesDrawn}", $"{playRate:F0}%");
         }
 
-        AppendAppliedEffects(sb, agg, compact: false);
-        AppendArtifactBlockedSummary(sb, agg);
+        bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: false);
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: hasDedicatedPoison);
+        AppendArtifactBlockedSummary(sb, agg, excludePoison: hasDedicatedPoison);
 
         // Energy-gain rows — cards like Adrenaline / Concentrate / energy
         // pot-style effects need a direct "what did this card give me?"
@@ -387,8 +388,9 @@ public static class CardHoverShowPatch
         if (agg.TotalBlockGained > 0)
             Row3(sb, "Block gained", agg.TotalBlockGained.ToString(), "");
 
-        AppendAppliedEffects(sb, agg, compact: true);
-        AppendArtifactBlockedSummary(sb, agg);
+        bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: true);
+        AppendAppliedEffects(sb, agg, compact: true, excludePoison: hasDedicatedPoison);
+        AppendArtifactBlockedSummary(sb, agg, excludePoison: hasDedicatedPoison);
 
         if (agg.Kills > 0)
             Row3(sb, "Kills", agg.Kills.ToString(), "");
@@ -467,12 +469,76 @@ public static class CardHoverShowPatch
         sb.Append("[/table]\n");
     }
 
-    private static void AppendAppliedEffects(StringBuilder sb, CardAggregate agg, bool compact)
+    private static bool AppendDedicatedPoisonStats(StringBuilder sb, CardAggregate agg, bool compact)
+    {
+        var poison = GetPoisonSummary(agg);
+        if (poison == null) return false;
+
+        if (compact)
+        {
+            var extra = poison.Value.TimesApplied > 0
+                ? poison.Value.TimesApplied > 1 ? $"{poison.Value.TimesApplied}x" : "1x"
+                : "";
+            Row3(sb, "Poison applied", FormatDecimal(poison.Value.TotalAmountApplied), extra);
+            return true;
+        }
+
+        decimal avgPoison = agg.Plays > 0 ? poison.Value.TotalAmountApplied / agg.Plays : 0m;
+
+        sb.Append("[color=#b5b5b5]Poison applied[/color]\n");
+        Row3(sb, "Total poison", FormatDecimal(poison.Value.TotalAmountApplied), "");
+        Row3(sb, "Avg poison", FormatDecimal(avgPoison), "");
+        Row3(sb, "Applications", poison.Value.TimesApplied.ToString(), "");
+
+        if (poison.Value.TimesBlockedByArtifact > 0)
+        {
+            string extra = poison.Value.TimesBlockedByArtifact > 1
+                ? $"{poison.Value.TimesBlockedByArtifact}x"
+                : "1x";
+            Row3(sb, "Blocked by Artifact", FormatDecimal(poison.Value.TotalAmountBlockedByArtifact), extra);
+        }
+
+        return true;
+    }
+
+    private static PoisonEffectSummary? GetPoisonSummary(CardAggregate agg)
+    {
+        if (agg.AppliedEffects == null || agg.AppliedEffects.Count == 0) return null;
+
+        int timesApplied = 0;
+        decimal totalAmountApplied = 0m;
+        int timesBlockedByArtifact = 0;
+        decimal totalAmountBlockedByArtifact = 0m;
+
+        foreach (var effect in agg.AppliedEffects.Values)
+        {
+            if (!IsPoisonEffect(effect)) continue;
+
+            timesApplied += effect.TimesApplied;
+            totalAmountApplied += effect.TotalAmountApplied;
+            timesBlockedByArtifact += effect.TimesBlockedByArtifact;
+            totalAmountBlockedByArtifact += effect.TotalAmountBlockedByArtifact;
+        }
+
+        if (timesApplied <= 0 &&
+            totalAmountApplied == 0m &&
+            timesBlockedByArtifact <= 0 &&
+            totalAmountBlockedByArtifact == 0m)
+            return null;
+
+        return new PoisonEffectSummary(
+            timesApplied,
+            totalAmountApplied,
+            timesBlockedByArtifact,
+            totalAmountBlockedByArtifact);
+    }
+
+    private static void AppendAppliedEffects(StringBuilder sb, CardAggregate agg, bool compact, bool excludePoison)
     {
         if (agg.AppliedEffects == null || agg.AppliedEffects.Count == 0) return;
-        bool hasArtifactBlockedSummary = GetArtifactBlockedTotals(agg).Times > 0;
+        bool hasArtifactBlockedSummary = GetArtifactBlockedTotals(agg, excludePoison).Times > 0;
         var visibleEffects = agg.AppliedEffects.Values
-            .Where(effect => ShouldShowAppliedEffectRow(effect, hasArtifactBlockedSummary))
+            .Where(effect => ShouldShowAppliedEffectRow(effect, hasArtifactBlockedSummary, excludePoison))
             .OrderByDescending(e => e.TimesApplied)
             .ThenBy(e => e.DisplayName)
             .ToList();
@@ -495,18 +561,18 @@ public static class CardHoverShowPatch
         }
     }
 
-    private static void AppendArtifactBlockedSummary(StringBuilder sb, CardAggregate agg)
+    private static void AppendArtifactBlockedSummary(StringBuilder sb, CardAggregate agg, bool excludePoison)
     {
-        var (times, amount) = GetArtifactBlockedTotals(agg);
+        var (times, amount) = GetArtifactBlockedTotals(agg, excludePoison);
         if (times <= 0) return;
 
-        var label = GetArtifactStrippedLabel(agg);
+        var label = GetArtifactStrippedLabel(agg, excludePoison);
         var value = times.ToString();
         var extra = amount != times ? $"{FormatDecimal(amount)} amt" : "";
         Row3(sb, label, value, extra);
     }
 
-    private static (int Times, decimal Amount) GetArtifactBlockedTotals(CardAggregate agg)
+    private static (int Times, decimal Amount) GetArtifactBlockedTotals(CardAggregate agg, bool excludePoison)
     {
         if (agg.AppliedEffects == null || agg.AppliedEffects.Count == 0)
             return (0, 0m);
@@ -515,6 +581,7 @@ public static class CardHoverShowPatch
         decimal amount = 0m;
         foreach (var effect in agg.AppliedEffects.Values)
         {
+            if (excludePoison && IsPoisonEffect(effect)) continue;
             times += effect.TimesBlockedByArtifact;
             amount += effect.TotalAmountBlockedByArtifact;
         }
@@ -522,8 +589,11 @@ public static class CardHoverShowPatch
         return (times, amount);
     }
 
-    private static bool ShouldShowAppliedEffectRow(AppliedEffectAggregate effect, bool hasArtifactBlockedSummary)
+    private static bool ShouldShowAppliedEffectRow(AppliedEffectAggregate effect, bool hasArtifactBlockedSummary, bool excludePoison)
     {
+        if (excludePoison && IsPoisonEffect(effect))
+            return false;
+
         if (effect.TotalAmountApplied == 0m && effect.TimesBlockedByArtifact > 0)
             return false;
 
@@ -533,12 +603,13 @@ public static class CardHoverShowPatch
         return true;
     }
 
-    private static string GetArtifactStrippedLabel(CardAggregate agg)
+    private static string GetArtifactStrippedLabel(CardAggregate agg, bool excludePoison)
     {
         if (agg.AppliedEffects != null)
         {
             foreach (var effect in agg.AppliedEffects.Values)
             {
+                if (excludePoison && IsPoisonEffect(effect)) continue;
                 if (!IsArtifactEffect(effect) || string.IsNullOrWhiteSpace(effect.IconPath)) continue;
                 return $"[img={InlineKeywordIconSize}x{InlineKeywordIconSize}]{effect.IconPath}[/img] stripped";
             }
@@ -554,6 +625,15 @@ public static class CardHoverShowPatch
             return true;
 
         return string.Equals(effect.DisplayName, "Artifact", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPoisonEffect(AppliedEffectAggregate effect)
+    {
+        if (!string.IsNullOrWhiteSpace(effect.EffectId) &&
+            effect.EffectId.Contains("POISON", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return string.Equals(effect.DisplayName, "Poison", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string FormatDecimal(decimal value)
@@ -599,6 +679,12 @@ public static class CardHoverShowPatch
         }
     }
 }
+
+internal readonly record struct PoisonEffectSummary(
+    int TimesApplied,
+    decimal TotalAmountApplied,
+    int TimesBlockedByArtifact,
+    decimal TotalAmountBlockedByArtifact);
 
 [HarmonyPatch(typeof(NCardHolder), "ClearHoverTips")]
 public static class CardHoverHidePatch

--- a/Core/Patches/PlayerGainStarsPatch.cs
+++ b/Core/Patches/PlayerGainStarsPatch.cs
@@ -1,0 +1,35 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Track direct card-driven star gain by patching the player's actual
+/// <c>GainStars</c> mutation point. We capture the before/after pool so the
+/// recorded amount is the REAL delta applied to the player, not just the
+/// requested input amount.
+/// </summary>
+[HarmonyPatch(typeof(PlayerCombatState), nameof(PlayerCombatState.GainStars))]
+public static class PlayerGainStarsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(PlayerCombatState __instance, out int __state)
+    {
+        __state = __instance.Stars;
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(PlayerCombatState __instance, int __state)
+    {
+        try
+        {
+            int gained = __instance.Stars - __state;
+            if (gained > 0) RunTracker.RecordStarsGained(__instance, gained);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"PlayerGainStarsPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/PoisonPowerAfterSideTurnStartPatch.cs
+++ b/Core/Patches/PoisonPowerAfterSideTurnStartPatch.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Arm a one-shot attribution window right as Poison begins its start-of-turn
+/// tick for a creature. The resulting DamageReceivedEntry often arrives with
+/// CardSource=null, so we need this hook to recognize the next null-source hit
+/// on that creature as poison instead of generic anonymous damage.
+/// </summary>
+[HarmonyPatch]
+public static class PoisonPowerAfterSideTurnStartPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        var poisonType = AccessTools.TypeByName("MegaCrit.Sts2.Core.Models.Powers.PoisonPower");
+        return poisonType == null ? null : AccessTools.Method(poisonType, "AfterSideTurnStart");
+    }
+
+    [HarmonyPrefix]
+    public static void Prefix(object __instance)
+    {
+        try
+        {
+            if (__instance != null)
+                RunTracker.NotePoisonTickStarting(__instance);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"PoisonPowerAfterSideTurnStartPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 6;
+    public const int CurrentSchemaVersion = 8;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -26,6 +26,13 @@ public class RunData
     //     files remain resumable with the new fields defaulting to 0.
     // v6: add per-effect Artifact-blocked debuff counters. Also additive;
     //     older v5 files remain resumable with the new fields defaulting to 0.
+    // v7: add per-effect downstream damage / overkill counters so effect-
+    //     oriented tooltips (starting with Poison) can report observed
+    //     outcomes instead of only application totals. Also additive; older
+    //     v6 files remain resumable with the new fields defaulting to 0.
+    // v8: add Regent star-resource spend / gain tracking alongside the
+    //     existing energy fields. Also additive; older v7 files remain
+    //     resumable with the new fields defaulting to 0.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -115,6 +122,11 @@ public class CardAggregate
     // clamping / prevention, not the raw text on the card, so "gain 1" under
     // a no-energy-gain effect correctly records 0.
     public int TotalEnergyGenerated { get; set; }
+
+    // M3k: Regent star spend / generation mirrors the energy fields above,
+    // but for the character's separate star resource.
+    public int TotalStarsSpent { get; set; }
+    public int TotalStarsGenerated { get; set; }
 
     // M2a: Block gained (how much block this card contributed over the run,
     // summed across plays). M2b extends this with absorbed/wasted splits
@@ -229,6 +241,8 @@ public class AppliedEffectAggregate
     public decimal TotalAmountApplied { get; set; }
     public int TimesBlockedByArtifact { get; set; }
     public decimal TotalAmountBlockedByArtifact { get; set; }
+    public decimal TotalTriggeredEffectiveDamage { get; set; }
+    public decimal TotalTriggeredOverkill { get; set; }
 }
 
 /// <summary>
@@ -245,6 +259,8 @@ public class CardEvent
     public string? Target { get; set; }          // if the card targeted an enemy, their entity id (e.g. "KIN_PRIEST_0")
     public int? EnergySpent { get; set; }        // actual energy paid for this play (accounts for cost modifiers)
     public int? EnergyGained { get; set; }       // actual energy added to the pool while this card was resolving
+    public int? StarsSpent { get; set; }         // actual stars paid for this play
+    public int? StarsGained { get; set; }        // actual stars added while this card was resolving
 
     // card_upgraded fields (and general-purpose: Floor also stamped on
     // other event types when useful). UpgradeLevel is the NEW level AFTER

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -107,6 +107,8 @@ public static class RunStorage
             case 3:
             case 4:
             case 5:
+            case 6:
+            case 7:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Combat.History.Entries;
 using MegaCrit.Sts2.Core.Entities.Cards;
@@ -27,10 +28,11 @@ namespace CardUtilityStats.Core;
 /// Thread safety: game events all fire on the main thread. We still lock
 /// defensively since file I/O is on a background task.
 ///
-/// Milestone scope:
-///   M1 (this file):     card plays + attack damage attribution
-///   M2 (future):        block attribution (per issue #1 heuristic)
-///   M3 (future):        energy / draw closure
+/// Current scope:
+///   - per-instance card identity and run persistence
+///   - combat-boundary aggregation into committed run data
+///   - attack, block, energy, draw, exhaust, and effect attribution
+///   - case-specific downstream attribution such as poison tick damage
 /// </summary>
 public static class RunTracker
 {
@@ -46,6 +48,7 @@ public static class RunTracker
     private static readonly List<PendingPowerChangeAttempt> _pendingPowerChangeAttempts = new();
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
+    private const decimal PoisonOwnershipEpsilon = 0.0001m;
 
     // Per-instance identity. Every physical card in the player's deck gets
     // a stable number the first time we observe it — NOT just when it's
@@ -734,6 +737,10 @@ public static class RunTracker
                         CoreMain.LogDebug($"  -> RecordDamage from '{dre.CardSource.Title}' intended={dre.Result.BlockedDamage + dre.Result.UnblockedDamage} canonicalHash={Canonical(dre.CardSource).GetHashCode()}");
                         RecordDamageFromCard(dre);
                     }
+                    else if (!dre.Receiver.IsPlayer && TryRecordPoisonTickDamage(dre))
+                    {
+                        break;
+                    }
                     else
                     {
                         if (!dre.Receiver.IsPlayer)
@@ -789,6 +796,7 @@ public static class RunTracker
             // cost, but that's less useful for "how much does this card
             // actually cost me on average" analysis.
             agg.TotalEnergySpent += cardPlay.Resources.EnergySpent;
+            agg.TotalStarsSpent += cardPlay.Resources.StarsSpent;
 
             _pendingCombat.CombatEvents.Add(new CardEvent
             {
@@ -797,6 +805,7 @@ public static class RunTracker
                 CardId = instanceId,
                 Target = cardPlay.Target?.Monster?.Id.ToString(),
                 EnergySpent = cardPlay.Resources.EnergySpent,
+                StarsSpent = cardPlay.Resources.StarsSpent,
             });
         }
     }
@@ -874,6 +883,48 @@ public static class RunTracker
             catch (Exception e)
             {
                 CoreMain.LogDebug($"RecordEnergyGained failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Record stars added to the player's pool while a card is currently
+    /// resolving. Mirrors <see cref="RecordEnergyGained"/> but targets
+    /// Regent's separate star resource.
+    /// </summary>
+    public static void RecordStarsGained(MegaCrit.Sts2.Core.Entities.Players.PlayerCombatState combatState, int amount)
+    {
+        if (amount <= 0) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                var causingPlay = FindCurrentlyResolvingCardPlay();
+                if (causingPlay?.Card == null) return;
+
+                var sourceCard = causingPlay.Card;
+                var targetPlayer = combatState._player;
+                if (targetPlayer != null && sourceCard.Owner != null
+                    && !ReferenceEquals(sourceCard.Owner, targetPlayer))
+                    return;
+
+                _pendingCombat ??= new PendingCombat();
+                var instanceId = GetOrAssignInstanceId(sourceCard);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                agg.TotalStarsGenerated += amount;
+
+                _pendingCombat.CombatEvents.Add(new CardEvent
+                {
+                    T = Now(),
+                    Type = "stars_gained",
+                    CardId = instanceId,
+                    StarsGained = amount,
+                });
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordStarsGained failed: {e.Message}");
             }
         }
     }
@@ -1212,6 +1263,28 @@ public static class RunTracker
         }
     }
 
+    public static void NotePoisonTickStarting(object poisonPower)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                var target = TryResolvePoisonPowerTarget(poisonPower);
+                if (target == null || target.IsPlayer) return;
+
+                _pendingCombat ??= new PendingCombat();
+                _pendingCombat.PendingPoisonTicks[target] = new PendingPoisonTick
+                {
+                    ArmedAtHistoryCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0,
+                };
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"NotePoisonTickStarting failed: {e.Message}");
+            }
+        }
+    }
+
     public static void NotePowerAmountChangeAttempt(
         PowerModel power,
         decimal amount,
@@ -1461,12 +1534,124 @@ public static class RunTracker
                 var effect = GetOrCreateAppliedEffect(agg, entry.Power);
                 effect.TimesApplied++;
                 effect.TotalAmountApplied += entry.Amount;
+
+                if (entry.Amount > 0m && IsPoisonPower(entry.Power))
+                {
+                    var target = TryResolvePowerReceivedTarget(entry);
+                    if (target != null && !target.IsPlayer)
+                        AddPoisonOwnershipLocked(target, instanceId, entry.Power, entry.Amount);
+                }
             }
             catch (Exception e)
             {
                 CoreMain.LogDebug($"RecordPowerReceived failed: {e.Message}");
             }
         }
+    }
+
+    private static bool TryRecordPoisonTickDamage(DamageReceivedEntry entry)
+    {
+        lock (_lock)
+        {
+            if (_pendingCombat == null) return false;
+            if (!_pendingCombat.PoisonOwnershipByTarget.TryGetValue(entry.Receiver, out var ownership)
+                || ownership.Count == 0)
+                return false;
+
+            decimal totalAttempted = entry.Result.BlockedDamage + entry.Result.UnblockedDamage;
+            if (totalAttempted <= 0m) return false;
+
+            bool armedTick = false;
+            if (_pendingCombat.PendingPoisonTicks.Remove(entry.Receiver, out var pendingTick))
+            {
+                int historyCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
+                armedTick = historyCount >= pendingTick.ArmedAtHistoryCount;
+            }
+
+            decimal trackedTotal = ownership.Values.Sum(share => Math.Max(0m, share.Amount));
+            if (trackedTotal <= 0m) return false;
+
+            bool fallbackAmountMatch = AreClose(trackedTotal, totalAttempted);
+            bool fallbackDealerMatch = entry.Dealer == null;
+            if (!armedTick && !(fallbackDealerMatch && fallbackAmountMatch))
+            {
+                if (entry.Result.WasTargetKilled)
+                    _pendingCombat.PoisonOwnershipByTarget.Remove(entry.Receiver);
+                return false;
+            }
+
+            if (trackedTotal > totalAttempted)
+            {
+                decimal normalize = totalAttempted / trackedTotal;
+                foreach (var share in ownership.Values)
+                    share.Amount *= normalize;
+            }
+
+            decimal effectiveDamage = Math.Max(0m, entry.Result.UnblockedDamage - entry.Result.OverkillDamage);
+            decimal overkillDamage = Math.Max(0m, entry.Result.OverkillDamage);
+
+            foreach (var share in ownership.Values.ToList())
+            {
+                if (share.Amount <= PoisonOwnershipEpsilon)
+                {
+                    ownership.Remove(share.Key);
+                    continue;
+                }
+
+                decimal fraction = share.Amount / totalAttempted;
+                var agg = GetOrCreateAggregate(_pendingCombat, share.CardInstanceId);
+                var effect = GetOrCreateAppliedEffect(agg, share.EffectId, share.DisplayName, share.IconPath);
+                effect.TotalTriggeredEffectiveDamage += effectiveDamage * fraction;
+                effect.TotalTriggeredOverkill += overkillDamage * fraction;
+            }
+
+            if (entry.Result.WasTargetKilled || totalAttempted <= 1m)
+            {
+                _pendingCombat.PoisonOwnershipByTarget.Remove(entry.Receiver);
+                return true;
+            }
+
+            decimal decay = (totalAttempted - 1m) / totalAttempted;
+            foreach (var key in ownership.Keys.ToList())
+            {
+                ownership[key].Amount *= decay;
+                if (ownership[key].Amount <= PoisonOwnershipEpsilon)
+                    ownership.Remove(key);
+            }
+
+            if (ownership.Count == 0)
+                _pendingCombat.PoisonOwnershipByTarget.Remove(entry.Receiver);
+
+            return true;
+        }
+    }
+
+    private static void AddPoisonOwnershipLocked(Creature target, string instanceId, PowerModel power, decimal amount)
+    {
+        if (_pendingCombat == null || target.IsPlayer || amount <= 0m) return;
+
+        if (!_pendingCombat.PoisonOwnershipByTarget.TryGetValue(target, out var ownership))
+        {
+            ownership = new Dictionary<PoisonOwnershipKey, PoisonOwnershipShare>();
+            _pendingCombat.PoisonOwnershipByTarget[target] = ownership;
+        }
+
+        string effectId = power.Id.ToString();
+        var key = new PoisonOwnershipKey(instanceId, effectId);
+        if (!ownership.TryGetValue(key, out var share))
+        {
+            share = new PoisonOwnershipShare
+            {
+                Key = key,
+                CardInstanceId = instanceId,
+                EffectId = effectId,
+                DisplayName = GetPowerDisplayName(power),
+                IconPath = GetPowerIconPath(power),
+            };
+            ownership[key] = share;
+        }
+
+        share.Amount += amount;
     }
 
     private static void RecordBlockGainedEntry(BlockGainedEntry entry)
@@ -1740,6 +1925,8 @@ public static class RunTracker
             Kills = source.Kills,
             TotalEnergySpent = source.TotalEnergySpent,
             TotalEnergyGenerated = source.TotalEnergyGenerated,
+            TotalStarsSpent = source.TotalStarsSpent,
+            TotalStarsGenerated = source.TotalStarsGenerated,
             TotalBlockGained = source.TotalBlockGained,
             TotalBlockEffective = source.TotalBlockEffective,
             TotalBlockWasted = source.TotalBlockWasted,
@@ -1771,6 +1958,8 @@ public static class RunTracker
         target.Kills += source.Kills;
         target.TotalEnergySpent += source.TotalEnergySpent;
         target.TotalEnergyGenerated += source.TotalEnergyGenerated;
+        target.TotalStarsSpent += source.TotalStarsSpent;
+        target.TotalStarsGenerated += source.TotalStarsGenerated;
         target.TotalBlockGained += source.TotalBlockGained;
         target.TotalBlockEffective += source.TotalBlockEffective;
         target.TotalBlockWasted += source.TotalBlockWasted;
@@ -1806,6 +1995,8 @@ public static class RunTracker
             effect.TotalAmountApplied += kv.Value.TotalAmountApplied;
             effect.TimesBlockedByArtifact += kv.Value.TimesBlockedByArtifact;
             effect.TotalAmountBlockedByArtifact += kv.Value.TotalAmountBlockedByArtifact;
+            effect.TotalTriggeredEffectiveDamage += kv.Value.TotalTriggeredEffectiveDamage;
+            effect.TotalTriggeredOverkill += kv.Value.TotalTriggeredOverkill;
             if (string.IsNullOrWhiteSpace(effect.DisplayName) && !string.IsNullOrWhiteSpace(kv.Value.DisplayName))
                 effect.DisplayName = kv.Value.DisplayName;
             if (string.IsNullOrWhiteSpace(effect.IconPath) && !string.IsNullOrWhiteSpace(kv.Value.IconPath))
@@ -1816,15 +2007,31 @@ public static class RunTracker
     private static AppliedEffectAggregate GetOrCreateAppliedEffect(CardAggregate agg, PowerModel power)
     {
         var effectId = power.Id.ToString();
+        return GetOrCreateAppliedEffect(agg, effectId, GetPowerDisplayName(power), GetPowerIconPath(power));
+    }
+
+    private static AppliedEffectAggregate GetOrCreateAppliedEffect(
+        CardAggregate agg,
+        string effectId,
+        string displayName,
+        string? iconPath)
+    {
         if (!agg.AppliedEffects.TryGetValue(effectId, out var effect))
         {
             effect = new AppliedEffectAggregate
             {
                 EffectId = effectId,
-                DisplayName = GetPowerDisplayName(power),
-                IconPath = !string.IsNullOrWhiteSpace(power.IconPath) ? power.IconPath : power.PackedIconPath,
+                DisplayName = displayName,
+                IconPath = iconPath,
             };
             agg.AppliedEffects[effectId] = effect;
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(effect.DisplayName) && !string.IsNullOrWhiteSpace(displayName))
+                effect.DisplayName = displayName;
+            if (string.IsNullOrWhiteSpace(effect.IconPath) && !string.IsNullOrWhiteSpace(iconPath))
+                effect.IconPath = iconPath;
         }
         return effect;
     }
@@ -1844,6 +2051,174 @@ public static class RunTracker
         }
         catch { }
         return power.Id.ToString();
+    }
+
+    private static string? GetPowerIconPath(PowerModel power)
+    {
+        return !string.IsNullOrWhiteSpace(power.IconPath) ? power.IconPath : power.PackedIconPath;
+    }
+
+    private static bool IsPoisonPower(PowerModel power)
+    {
+        var effectId = power.Id.ToString();
+        if (effectId.Contains("POISON", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (power.GetType().Name.Contains("Poison", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return string.Equals(GetPowerDisplayName(power), "Poison", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Creature? TryResolvePowerReceivedTarget(PowerReceivedEntry entry)
+    {
+        return TryResolveCreatureMember(
+            entry,
+            preferredNames: ["Target", "Receiver", "Creature", "Owner", "Holder"],
+            excludedNames: ["Applier", "Giver", "Dealer"]);
+    }
+
+    private static Creature? TryResolvePoisonPowerTarget(object poisonPower)
+    {
+        return TryResolveCreatureMember(
+            poisonPower,
+            preferredNames: ["Target", "Receiver", "Creature", "Owner", "Holder"],
+            excludedNames: []);
+    }
+
+    private static Creature? TryResolveCreatureMember(
+        object source,
+        IReadOnlyList<string> preferredNames,
+        IReadOnlyCollection<string> excludedNames)
+    {
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        return TryResolveCreatureMemberRecursive(source, preferredNames, excludedNames, depthRemaining: 2, visited);
+    }
+
+    private static bool TryReadCreatureMember(Type type, object source, string memberName, out Creature? creature)
+    {
+        var prop = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (prop != null && prop.CanRead && typeof(Creature).IsAssignableFrom(prop.PropertyType))
+        {
+            try
+            {
+                creature = prop.GetValue(source) as Creature;
+                if (creature != null) return true;
+            }
+            catch { }
+        }
+
+        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null && typeof(Creature).IsAssignableFrom(field.FieldType))
+        {
+            try
+            {
+                creature = field.GetValue(source) as Creature;
+                if (creature != null) return true;
+            }
+            catch { }
+        }
+
+        creature = null;
+        return false;
+    }
+
+    private static Creature? TryResolveCreatureMemberRecursive(
+        object? source,
+        IReadOnlyList<string> preferredNames,
+        IReadOnlyCollection<string> excludedNames,
+        int depthRemaining,
+        HashSet<object> visited)
+    {
+        if (source == null) return null;
+        if (source is Creature directCreature) return directCreature;
+        if (depthRemaining < 0) return null;
+        if (!visited.Add(source)) return null;
+
+        var type = source.GetType();
+        foreach (var name in preferredNames)
+        {
+            if (TryReadCreatureMember(type, source, name, out var preferredCreature))
+                return preferredCreature;
+        }
+
+        var candidates = new List<Creature>();
+        var nestedValues = new List<object>();
+
+        foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (!prop.CanRead) continue;
+            if (excludedNames.Contains(prop.Name)) continue;
+
+            object? value;
+            try { value = prop.GetValue(source); }
+            catch { continue; }
+
+            if (value == null) continue;
+            if (value is Creature propCreature)
+            {
+                candidates.Add(propCreature);
+                continue;
+            }
+
+            if (!IsSimpleObject(value))
+                nestedValues.Add(value);
+        }
+
+        foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (excludedNames.Contains(field.Name)) continue;
+
+            object? value;
+            try { value = field.GetValue(source); }
+            catch { continue; }
+
+            if (value == null) continue;
+            if (value is Creature fieldCreature)
+            {
+                candidates.Add(fieldCreature);
+                continue;
+            }
+
+            if (!IsSimpleObject(value))
+                nestedValues.Add(value);
+        }
+
+        var distinctCandidates = candidates.Distinct().ToList();
+        if (distinctCandidates.Count == 1) return distinctCandidates[0];
+
+        if (depthRemaining == 0) return null;
+
+        foreach (var nested in nestedValues)
+        {
+            var nestedCreature = TryResolveCreatureMemberRecursive(
+                nested,
+                preferredNames,
+                excludedNames,
+                depthRemaining - 1,
+                visited);
+            if (nestedCreature != null)
+                return nestedCreature;
+        }
+
+        return null;
+    }
+
+    private static bool IsSimpleObject(object value)
+    {
+        var type = value.GetType();
+        return type.IsPrimitive
+            || type.IsEnum
+            || type == typeof(string)
+            || type == typeof(decimal)
+            || type == typeof(DateTime)
+            || type == typeof(TimeSpan)
+            || type == typeof(Guid);
+    }
+
+    private static bool AreClose(decimal left, decimal right)
+    {
+        return decimal.Abs(left - right) <= PoisonOwnershipEpsilon;
     }
 
     private static string Now() => DateTime.UtcNow.ToString("o");
@@ -1877,6 +2252,10 @@ internal class PendingCombat
     public Dictionary<string, CardAggregate> CombatAggregates { get; } = new();
     public List<CardEvent> CombatEvents { get; } = new();
     public List<BlockChunk> PlayerBlockLedger { get; } = new();
+    public Dictionary<Creature, Dictionary<PoisonOwnershipKey, PoisonOwnershipShare>> PoisonOwnershipByTarget { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Creature, PendingPoisonTick> PendingPoisonTicks { get; }
+        = new(ReferenceEqualityComparer.Instance);
     public int NextBlockSequence { get; set; }
 }
 
@@ -1895,4 +2274,21 @@ internal sealed class PendingPowerChangeAttempt
     public Creature? Applier { get; init; }
     public required decimal RequestedAmount { get; init; }
     public CardModel? CardSource { get; init; }
+}
+
+internal readonly record struct PoisonOwnershipKey(string CardInstanceId, string EffectId);
+
+internal sealed class PoisonOwnershipShare
+{
+    public required PoisonOwnershipKey Key { get; init; }
+    public required string CardInstanceId { get; init; }
+    public required string EffectId { get; init; }
+    public required string DisplayName { get; init; }
+    public string? IconPath { get; init; }
+    public decimal Amount { get; set; }
+}
+
+internal sealed class PendingPoisonTick
+{
+    public int ArmedAtHistoryCount { get; init; }
 }

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -17,15 +17,21 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds absorbed/wasted block aggregates
   on top of the v4 effect and exhaust fields.
 - `v6-per-instance-artifact-block-run.json`
-  Current schema. Adds per-effect Artifact-blocked debuff counters on top of
+  Legacy-but-resumable additive schema. Adds per-effect Artifact-blocked debuff counters on top of
   the v5 block ledger fields.
+- `v7-per-instance-poison-damage-run.json`
+  Legacy-but-resumable additive schema. Adds per-effect downstream damage and overkill counters so
+  dedicated poison rows can report observed poison outcomes, not just poison applied.
+- `v8-per-instance-regent-stars-run.json`
+  Current schema. Adds Regent star-resource spend/gain fields alongside the
+  existing energy and per-instance attribution data.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, and `v5 -> v6`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, and `v7 -> v8`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v7-per-instance-poison-damage-run.json
+++ b/Fixtures/RunSchema/v7-per-instance-poison-damage-run.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 7,
+  "run_id": "fixture-v7-per-instance-poison-damage",
+  "started_at": "2026-04-21T09:00:00Z",
+  "updated_at": "2026-04-21T09:14:00Z",
+  "ended_at": "2026-04-21T09:15:30Z",
+  "character": "SIL",
+  "ascension": 10,
+  "floor_reached": 12,
+  "outcome": "win",
+  "game_start_time": 1713690000,
+  "aggregates": {
+    "CARD.DEADLY_POISON#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {
+        "POWER.POISON": {
+          "effect_id": "POWER.POISON",
+          "display_name": "Poison",
+          "icon_path": "res://art/powers/poison.png",
+          "times_applied": 2,
+          "total_amount_applied": 11,
+          "times_blocked_by_artifact": 1,
+          "total_amount_blocked_by_artifact": 2,
+          "total_triggered_effective_damage": 9,
+          "total_triggered_overkill": 3
+        }
+      },
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-21T09:05:00Z",
+      "type": "card_played",
+      "card_id": "CARD.DEADLY_POISON#1",
+      "energy_spent": 1,
+      "floor": 3
+    },
+    {
+      "t": "2026-04-21T09:08:00Z",
+      "type": "card_played",
+      "card_id": "CARD.DEADLY_POISON#1",
+      "energy_spent": 1,
+      "floor": 5
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.DEADLY_POISON": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.DEADLY_POISON": 1
+  }
+}

--- a/Fixtures/RunSchema/v8-per-instance-regent-stars-run.json
+++ b/Fixtures/RunSchema/v8-per-instance-regent-stars-run.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 8,
+  "run_id": "fixture-v8-per-instance-regent-stars",
+  "started_at": "2026-04-21T10:00:00Z",
+  "updated_at": "2026-04-21T10:08:00Z",
+  "ended_at": "2026-04-21T10:10:00Z",
+  "character": "REG",
+  "ascension": 10,
+  "floor_reached": 8,
+  "outcome": "win",
+  "game_start_time": 1713693600,
+  "aggregates": {
+    "CARD.VENERATE#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 2,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.STARDUST#1": {
+      "plays": 1,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 1,
+      "total_energy_generated": 0,
+      "total_stars_spent": 2,
+      "total_stars_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {},
+      "floor_added": 2,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-21T10:02:00Z",
+      "type": "card_played",
+      "card_id": "CARD.VENERATE#1",
+      "energy_spent": 1,
+      "stars_gained": 1,
+      "floor": 1
+    },
+    {
+      "t": "2026-04-21T10:05:00Z",
+      "type": "card_played",
+      "card_id": "CARD.STARDUST#1",
+      "energy_spent": 1,
+      "stars_spent": 2,
+      "floor": 2
+    },
+    {
+      "t": "2026-04-21T10:07:00Z",
+      "type": "card_played",
+      "card_id": "CARD.VENERATE#1",
+      "energy_spent": 2,
+      "stars_gained": 1,
+      "floor": 3
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.VENERATE": [
+      1
+    ],
+    "CARD.STARDUST": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.VENERATE": 1,
+    "CARD.STARDUST": 1
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # CardUtilityStats
 
-Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/). For every card you play, tracks what actually happened — effective damage vs. overkill, block that absorbed vs. wasted, drawn cards played vs. idle, energy generated vs. unused.
+Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/). For every card you play, it tracks what actually happened: effective damage vs. overkill, block that absorbed vs. wasted, drawn cards played vs. idle, energy generated vs. unused, and effect-oriented outcomes like poison damage.
 
-**Status:** Dev build — M1 through M5a shipped (damage attribution, intended block, energy/draw, in-game UI, removed-card viewing). Not yet published to Nexus (M6).
+**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
+
+For codebase orientation, start with [AGENTS.md](D:/repos/CardUtilityStats/AGENTS.md:1) and [docs/architecture.md](D:/repos/CardUtilityStats/docs/architecture.md:1).
 
 ## Why
 
@@ -10,57 +12,64 @@ Existing stats mods answer "how often did I *pick* this card" ([SlayTheStats](ht
 
 ## What it tracks (target design)
 
-**Attack cards** — four numbers per play:
+**Attack cards** - four numbers per play:
 
-- `raw_damage_intended` — damage the card tried to deal (after buffs/debuffs)
-- `blocked_by_target` — enemy block that absorbed some
-- `overkill` — damage past enemy HP (wasted)
-- `effective_damage` — what actually counted
+- `raw_damage_intended` - damage the card tried to deal (after buffs/debuffs)
+- `blocked_by_target` - enemy block that absorbed some
+- `overkill` - damage past enemy HP (wasted)
+- `effective_damage` - what actually counted
 
-**Block cards** — how much of the generated block actually absorbed incoming damage vs. expired unused. Per-card block attribution uses a heuristic (see [issue #1](https://github.com/nelsong6/card-utility-stats/issues/1)).
+**Block cards** - how much of the generated block actually absorbed incoming damage vs. expired unused. Per-card block attribution uses a heuristic (see [issue #1](https://github.com/nelsong6/card-utility-stats/issues/1)).
 
-**Utility cards** — closure tracking:
+**Utility cards** - closure tracking:
 
 - Energy generated: was it spent or end-of-turn wasted?
+- Regent stars generated/spent: what did the card actually add to or consume from the star pool?
 - Cards drawn: were they played this turn/run or sit in hand?
+
+**Effect cards** - effect-oriented summaries:
+
+- Effect applications credited back to the card instance that applied them
+- Artifact-blocked debuffs counted separately so failed debuffs still surface
+- Dedicated poison rows for poison applied, observed poison damage, and poison overkill
 
 ## How you'd use it
 
-A **"View Stats"** checkbox sits next to the game's existing "View Upgrades" toggle on the in-run deck view. When ticked, hovering a card shows a side-panel tooltip with per-instance stats (plays, damage, block gained, energy spent, etc.) — coexists with the game's built-in hover tips rather than replacing them. Hand hovers get a compact version; deck-view hovers get the full elaborate view.
+A **"View Stats"** checkbox sits next to the game's existing "View Upgrades" toggle on the in-run deck view. When ticked, hovering a card shows a side-panel tooltip with per-instance stats (plays, damage, block gained, energy spent, etc.) - it coexists with the game's built-in hover tips rather than replacing them. Hand hovers get a compact version; deck-view hovers get the full elaborate view.
 
-The checkbox also toggles a **removed-card overlay**: cards you've removed this run (Smith, events, curse dispose) appear inline in the deck grid, marked with a red "Card Removed" banner in their tooltip so you can review their stats post-removal. Checkbox state persists across hot reloads via a small `prefs.json`.
+The checkbox also toggles a **removed-card overlay**: cards you've removed this run (Smith, events, curse dispose) appear inline in the deck grid, marked with a red "Card Removed" banner in their tooltip so you can review their stats post-removal. Generated combat-only cards that do not live in the deck permanently can also render as pooled summaries when that is a better representation than pretending each temporary copy is a normal deck instance. Checkbox state persists across hot reloads via a small `prefs.json`.
 
-Available only on in-run deck-view surfaces for now (not Compendium — lifetime aggregation is deferred, see [issue #2](https://github.com/nelsong6/card-utility-stats/issues/2)).
+Available only on in-run deck-view surfaces for now (not Compendium - lifetime aggregation is deferred, see [issue #2](https://github.com/nelsong6/card-utility-stats/issues/2)).
 
 ## Roadmap
 
 | Milestone | Scope | Status |
 |---|---|---|
-| **M1** | Attack damage attribution — the 4 numbers above | ✅ [#5](https://github.com/nelsong6/card-utility-stats/issues/5) |
-| **M2a** | Intended block (how much this card contributed) | ✅ |
-| **M2b** | Block absorption (effective vs wasted) — needs heuristic | [#14](https://github.com/nelsong6/card-utility-stats/issues/14) |
-| **M3** | Utility card closure (energy spent, draw count) | ✅ [#7](https://github.com/nelsong6/card-utility-stats/issues/7) |
-| **M4** | In-game UI: "View Stats" checkbox on deck view | ✅ [#8](https://github.com/nelsong6/card-utility-stats/issues/8) |
-| **M5a** | Removed-card viewing in deck view | ✅ |
-| **M5b** | Run History integration — browse past-run stats | [#9](https://github.com/nelsong6/card-utility-stats/issues/9) |
-| **M6** | Publish v0.1 to Nexus | — |
+| **M1** | Attack damage attribution - the 4 numbers above | OK [#5](https://github.com/nelsong6/card-utility-stats/issues/5) |
+| **M2a** | Intended block (how much this card contributed) | OK |
+| **M2b** | Block absorption (effective vs wasted) - needs heuristic | [#14](https://github.com/nelsong6/card-utility-stats/issues/14) |
+| **M3** | Utility card closure (energy spent, draw count) | OK [#7](https://github.com/nelsong6/card-utility-stats/issues/7) |
+| **M4** | In-game UI: "View Stats" checkbox on deck view | OK [#8](https://github.com/nelsong6/card-utility-stats/issues/8) |
+| **M5a** | Removed-card viewing in deck view | OK |
+| **M5b** | Run History integration - browse past-run stats | [#9](https://github.com/nelsong6/card-utility-stats/issues/9) |
+| **M6** | Publish v0.1 to Nexus | - |
 
-Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, HP-lost from self-damage cards, cards-drawn attribution.
+Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, Regent star-resource tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution.
 
-Open: [#10 Run outcome detection](https://github.com/nelsong6/card-utility-stats/issues/10) — non-blocking for M1–M3, required before M6.
+Open: [#10 Run outcome detection](https://github.com/nelsong6/card-utility-stats/issues/10) - non-blocking for M1-M3, required before M6.
 
 ## Storage
 
-Per-run JSON files at `%APPDATA%/SlayTheSpire2/CardUtilityStats/runs/<run-id>.json` (Godot's `user://` path). Contains both aggregated stats (fast for UI) and a full event log (one entry per card-played / damage-received / card-upgraded / block-gained / card-removed event, for future analysis). Schema versioned — see [issue #4](https://github.com/nelsong6/card-utility-stats/issues/4). Current hot-reload resume expects the per-instance `v3` shape; older pooled `v1` files are history-only, while additive `v2` files remain resumable under the newer loader. Session preferences (checkbox state) at `prefs.json` in the same dir.
+Per-run JSON files at `%APPDATA%/SlayTheSpire2/CardUtilityStats/runs/<run-id>.json` (Godot's `user://` path). Contains both aggregated stats (fast for UI) and a full event log (one entry per card-played / damage-received / card-upgraded / block-gained / card-removed event, for future analysis). Schema versioned - see [issue #4](https://github.com/nelsong6/card-utility-stats/issues/4). The current schema is additive through `v8`; pooled `v1` files remain history-only, while per-instance `v2` through `v8` files are resumable under the current loader. Session preferences (checkbox state) at `prefs.json` in the same dir.
 
 ## Requirements
 
 - Slay the Spire 2 (tested against v0.103.2)
-- [BaseLib](https://www.nexusmods.com/slaythespire2/mods/103) — required dependency
+- [BaseLib](https://www.nexusmods.com/slaythespire2/mods/103) - required dependency
 
 ## Install
 
-Drop `CardUtilityStats.dll` and `CardUtilityStats.json` (and `CardUtilityStats.pck` once UI lands) into `<game install>/mods/`. Requires BaseLib.
+Drop the mod output into `<game install>/mods/` (including `CardUtilityStats.dll`, `CardUtilityStats.json`, and the `.pck` when present). Requires BaseLib.
 
 ## Build from source
 

--- a/Tests/CardUtilityStats.Core.Tests/BlockTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/BlockTooltipTests.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using CardUtilityStats.Core;
+using CardUtilityStats.Core.Patches;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class BlockTooltipTests
+{
+    private static readonly MethodInfo GetBlockStatLabelMethod =
+        typeof(CardHoverShowPatch).GetMethod("GetBlockStatLabel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("GetBlockStatLabel not found.");
+
+    private static readonly MethodInfo GetDrawStatLabelMethod =
+        typeof(CardHoverShowPatch).GetMethod("GetDrawStatLabel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("GetDrawStatLabel not found.");
+
+    private static readonly MethodInfo GetEnergyStatLabelMethod =
+        typeof(CardHoverShowPatch).GetMethod("GetEnergyStatLabel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("GetEnergyStatLabel not found.");
+
+    private static readonly MethodInfo GetStarStatLabelMethod =
+        typeof(CardHoverShowPatch).GetMethod("GetStarStatLabel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("GetStarStatLabel not found.");
+
+    private static readonly MethodInfo AppendCompactBodyMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendCompactBody", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendCompactBody not found.");
+
+    [Fact]
+    public void GetBlockStatLabel_UsesShieldIcon()
+    {
+        var label = (string)(GetBlockStatLabelMethod.Invoke(null, new object?[] { "gained" })
+            ?? throw new InvalidOperationException("GetBlockStatLabel returned null."));
+
+        Assert.Equal("[img=16x16]res://images/ui/combat/block.png[/img] gained", label);
+    }
+
+    [Fact]
+    public void AppendCompactBody_UsesShieldIconForBlockRows()
+    {
+        var cardModel = CreateCardModel(CardType.Skill);
+        var agg = new CardAggregate
+        {
+            Plays = 2,
+            TimesDrawn = 3,
+            TotalBlockGained = 9,
+        };
+
+        var sb = new StringBuilder();
+        _ = AppendCompactBodyMethod.Invoke(null, new object?[] { sb, cardModel, agg });
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] gained", text);
+        Assert.Contains("[b]9[/b]", text);
+    }
+
+    [Fact]
+    public void GetDrawStatLabel_UsesDrawCardsNextTurnPowerIcon()
+    {
+        var label = (string)(GetDrawStatLabelMethod.Invoke(null, new object?[] { "cards drawn" })
+            ?? throw new InvalidOperationException("GetDrawStatLabel returned null."));
+
+        Assert.Equal("[img=16x16]res://images/atlases/power_atlas.sprites/draw_cards_next_turn_power.tres[/img] cards drawn", label);
+    }
+
+    [Fact]
+    public void GetEnergyStatLabel_UsesEnergyPotionIcon()
+    {
+        var label = (string)(GetEnergyStatLabelMethod.Invoke(null, new object?[] { "gained" })
+            ?? throw new InvalidOperationException("GetEnergyStatLabel returned null."));
+
+        Assert.Equal("[img=16x16]res://images/atlases/potion_atlas.sprites/energy_potion.tres[/img] gained", label);
+    }
+
+    [Fact]
+    public void GetStarStatLabel_UsesStarIcon()
+    {
+        var label = (string)(GetStarStatLabelMethod.Invoke(null, new object?[] { "gained" })
+            ?? throw new InvalidOperationException("GetStarStatLabel returned null."));
+
+        Assert.Equal("[img=16x16]res://images/packed/sprite_fonts/star_icon.png[/img] gained", label);
+    }
+
+    [Fact]
+    public void AppendCompactBody_UsesDrawPowerIconForUnplayableDrawRows()
+    {
+        var cardModel = CreateCardModel(CardType.Curse);
+        var agg = new CardAggregate
+        {
+            TimesDrawn = 4,
+        };
+
+        var sb = new StringBuilder();
+        _ = AppendCompactBodyMethod.Invoke(null, new object?[] { sb, cardModel, agg });
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/atlases/power_atlas.sprites/draw_cards_next_turn_power.tres[/img] drawn", text);
+        Assert.Contains("[b]4[/b]", text);
+    }
+
+    [Fact]
+    public void AppendCompactBody_UsesEnergyPotionIconForEnergyRows()
+    {
+        var cardModel = CreateCardModel(CardType.Skill);
+        var agg = new CardAggregate
+        {
+            Plays = 2,
+            TimesDrawn = 3,
+            TotalEnergyGenerated = 2,
+        };
+
+        var sb = new StringBuilder();
+        _ = AppendCompactBodyMethod.Invoke(null, new object?[] { sb, cardModel, agg });
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/atlases/potion_atlas.sprites/energy_potion.tres[/img] gained", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendCompactBody_UsesStarIconForStarRows()
+    {
+        var cardModel = CreateCardModel(CardType.Skill);
+        var agg = new CardAggregate
+        {
+            Plays = 2,
+            TimesDrawn = 3,
+            TotalStarsGenerated = 2,
+        };
+
+        var sb = new StringBuilder();
+        _ = AppendCompactBodyMethod.Invoke(null, new object?[] { sb, cardModel, agg });
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/packed/sprite_fonts/star_icon.png[/img] gained", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    private static CardModel CreateCardModel(CardType type)
+    {
+        var concreteCardType = typeof(CardModel).Assembly.GetTypes()
+            .FirstOrDefault(t => typeof(CardModel).IsAssignableFrom(t) && !t.IsAbstract)
+            ?? throw new InvalidOperationException("No concrete CardModel subtype found.");
+        var card = (CardModel)RuntimeHelpers.GetUninitializedObject(concreteCardType);
+
+        var typeField = typeof(CardModel).GetField("<Type>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("CardModel.Type backing field not found.");
+        typeField.SetValue(card, type);
+
+        var keywordsField = typeof(CardModel).GetField("_keywords", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (keywordsField != null && keywordsField.GetValue(card) == null)
+        {
+            object? emptyKeywords = keywordsField.FieldType.IsArray
+                ? Array.CreateInstance(keywordsField.FieldType.GetElementType()
+                    ?? throw new InvalidOperationException("Keywords element type not found."), 0)
+                : Activator.CreateInstance(keywordsField.FieldType);
+
+            if (emptyKeywords != null)
+                keywordsField.SetValue(card, emptyKeywords);
+        }
+
+        return card;
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using System.Text;
+using CardUtilityStats.Core;
+using CardUtilityStats.Core.Patches;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class PoisonTooltipTests
+{
+    private static readonly MethodInfo AppendDedicatedPoisonStatsMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendDedicatedPoisonStats", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendDedicatedPoisonStats not found.");
+
+    private static readonly MethodInfo AppendAppliedEffectsMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendAppliedEffects", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendAppliedEffects not found.");
+
+    private static readonly MethodInfo AppendArtifactBlockedSummaryMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendArtifactBlockedSummary", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendArtifactBlockedSummary not found.");
+
+    [Fact]
+    public void AppendDedicatedPoisonStats_FullViewCombinesPoisonTotals()
+    {
+        var agg = new CardAggregate
+        {
+            Plays = 4,
+            AppliedEffects =
+            {
+                ["POWER.POISON"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.POISON",
+                    DisplayName = "Poison",
+                    TimesApplied = 3,
+                    TotalAmountApplied = 9m,
+                    TimesBlockedByArtifact = 1,
+                    TotalAmountBlockedByArtifact = 2m,
+                },
+                ["POWER.POISON_SPLASH"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.POISON_SPLASH",
+                    DisplayName = "Poison",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 3m,
+                },
+                ["POWER.WEAK"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.WEAK",
+                    DisplayName = "Weak",
+                    TimesApplied = 2,
+                    TotalAmountApplied = 4m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        var rendered = AppendDedicatedPoisonStats(sb, agg, compact: false);
+        var text = sb.ToString();
+
+        Assert.True(rendered);
+        Assert.Contains("Poison applied", text);
+        Assert.Contains("Total poison", text);
+        Assert.Contains("[b]12[/b]", text);
+        Assert.Contains("Avg poison", text);
+        Assert.Contains("[b]3[/b]", text);
+        Assert.Contains("Applications", text);
+        Assert.Contains("[b]4[/b]", text);
+        Assert.Contains("Blocked by Artifact", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendAppliedEffects_ExcludesPoisonWhenDedicatedSectionIsShown()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.POISON"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.POISON",
+                    DisplayName = "Poison",
+                    TimesApplied = 2,
+                    TotalAmountApplied = 5m,
+                },
+                ["POWER.WEAK"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.WEAK",
+                    DisplayName = "Weak",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 2m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: true);
+        var text = sb.ToString();
+
+        Assert.Contains("Effects applied", text);
+        Assert.Contains("Weak", text);
+        Assert.DoesNotContain("Poison", text);
+    }
+
+    [Fact]
+    public void AppendArtifactBlockedSummary_ExcludesPoisonWhenDedicatedSectionIsShown()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.POISON"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.POISON",
+                    DisplayName = "Poison",
+                    TimesBlockedByArtifact = 1,
+                    TotalAmountBlockedByArtifact = 2m,
+                },
+                ["POWER.WEAK"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.WEAK",
+                    DisplayName = "Weak",
+                    TimesBlockedByArtifact = 1,
+                    TotalAmountBlockedByArtifact = 1m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendArtifactBlockedSummary(sb, agg, excludePoison: true);
+        var text = sb.ToString();
+
+        Assert.Contains("[b]1[/b]", text);
+        Assert.DoesNotContain("amt", text);
+    }
+
+    private static bool AppendDedicatedPoisonStats(StringBuilder sb, CardAggregate agg, bool compact)
+    {
+        return (bool)(AppendDedicatedPoisonStatsMethod.Invoke(null, new object?[] { sb, agg, compact })
+            ?? throw new InvalidOperationException("AppendDedicatedPoisonStats returned null."));
+    }
+
+    private static void AppendAppliedEffects(StringBuilder sb, CardAggregate agg, bool compact, bool excludePoison)
+    {
+        _ = AppendAppliedEffectsMethod.Invoke(null, new object?[] { sb, agg, compact, excludePoison });
+    }
+
+    private static void AppendArtifactBlockedSummary(StringBuilder sb, CardAggregate agg, bool excludePoison)
+    {
+        _ = AppendArtifactBlockedSummaryMethod.Invoke(null, new object?[] { sb, agg, excludePoison });
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
@@ -32,17 +32,23 @@ public class PoisonTooltipTests
                 {
                     EffectId = "POWER.POISON",
                     DisplayName = "Poison",
+                    IconPath = "res://art/powers/poison.png",
                     TimesApplied = 3,
                     TotalAmountApplied = 9m,
                     TimesBlockedByArtifact = 1,
                     TotalAmountBlockedByArtifact = 2m,
+                    TotalTriggeredEffectiveDamage = 8m,
+                    TotalTriggeredOverkill = 1m,
                 },
                 ["POWER.POISON_SPLASH"] = new AppliedEffectAggregate
                 {
                     EffectId = "POWER.POISON_SPLASH",
                     DisplayName = "Poison",
+                    IconPath = "res://art/powers/poison.png",
                     TimesApplied = 1,
                     TotalAmountApplied = 3m,
+                    TotalTriggeredEffectiveDamage = 4m,
+                    TotalTriggeredOverkill = 1m,
                 },
                 ["POWER.WEAK"] = new AppliedEffectAggregate
                 {
@@ -59,14 +65,19 @@ public class PoisonTooltipTests
         var text = sb.ToString();
 
         Assert.True(rendered);
-        Assert.Contains("Poison applied", text);
-        Assert.Contains("Total poison", text);
+        Assert.DoesNotContain("[color=#b5b5b5]Poison applied[/color]", text);
+        Assert.Contains("[img=16x16]res://art/powers/poison.png[/img] total", text);
         Assert.Contains("[b]12[/b]", text);
-        Assert.Contains("Avg poison", text);
+        Assert.Contains("avg", text);
         Assert.Contains("[b]3[/b]", text);
-        Assert.Contains("Applications", text);
+        Assert.Contains("applications", text);
         Assert.Contains("[b]4[/b]", text);
-        Assert.Contains("Blocked by Artifact", text);
+        Assert.Contains("damage", text);
+        Assert.Contains("[b]12[/b]", text);
+        Assert.Contains("avg dmg", text);
+        Assert.Contains("overkill", text);
+        Assert.Contains("[b]2[/b]", text);
+        Assert.Contains("blocked by Artifact", text);
         Assert.Contains("[b]2[/b]", text);
     }
 
@@ -133,6 +144,83 @@ public class PoisonTooltipTests
 
         Assert.Contains("[b]1[/b]", text);
         Assert.DoesNotContain("amt", text);
+    }
+
+    [Fact]
+    public void AppendAppliedEffects_UsesEnergyPotionIconForEnergyEffects()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.ENERGY_NEXT_TURN"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.ENERGY_NEXT_TURN",
+                    DisplayName = "Energy Next Turn",
+                    IconPath = "res://images/atlases/power_atlas.sprites/energy_next_turn_power.tres",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 2m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: false);
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/atlases/potion_atlas.sprites/energy_potion.tres[/img] Next Turn", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendAppliedEffects_UsesStarIconForStarEffects()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.STAR_NEXT_TURN"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.STAR_NEXT_TURN",
+                    DisplayName = "Star Next Turn",
+                    IconPath = "res://images/atlases/power_atlas.sprites/star_next_turn_power.tres",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 2m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: false);
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/packed/sprite_fonts/star_icon.png[/img] Next Turn", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendDedicatedPoisonStats_CompactViewDoesNotHidePoisonOnlyArtifactBlocks()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.POISON"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.POISON",
+                    DisplayName = "Poison",
+                    TimesBlockedByArtifact = 1,
+                    TotalAmountBlockedByArtifact = 2m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        var rendered = AppendDedicatedPoisonStats(sb, agg, compact: true);
+        var text = sb.ToString();
+
+        Assert.False(rendered);
+        Assert.DoesNotContain("Poison applied", text);
     }
 
     private static bool AppendDedicatedPoisonStats(StringBuilder sb, CardAggregate agg, bool compact)

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -119,6 +119,22 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsCurrentV8Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v8-per-instance-regent-stars-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(8, loaded!.SourceSchemaVersion);
+        Assert.False(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Null(loaded.CompatibilityNote);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
+        Assert.Equal(2, loaded.Data.Events[1].StarsSpent);
+    }
+
+    [Fact]
     public void HistoricalLoad_RejectsUnknownSchemaFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v999-unknown-run.json"));
@@ -199,6 +215,18 @@ public class SchemaLoadingTests
         var effect = resumed.Aggregates["CARD.DEADLY_POISON#1"].AppliedEffects["POWER.POISON"];
         Assert.Equal(9m, effect.TotalTriggeredEffectiveDamage);
         Assert.Equal(3m, effect.TotalTriggeredOverkill);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV8Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v8-per-instance-regent-stars-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(8, resumed!.SchemaVersion);
+        Assert.Equal(2, resumed.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
+        Assert.Equal(2, resumed.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
+        Assert.Equal(1, resumed.Aggregates["CARD.VENERATE#1"].TimesDrawn);
     }
 
     [Fact]

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -88,19 +88,34 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV6Fixture()
+    public void HistoricalLoad_AcceptsLegacyResumableV6Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v6-per-instance-artifact-block-run.json"));
 
         Assert.NotNull(loaded);
-        Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
-        Assert.False(loaded.IsLegacy);
+        Assert.Equal(6, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
         Assert.True(loaded.SupportsResume);
         Assert.True(loaded.HasPerInstanceIdentity);
         Assert.Equal(6, loaded.Data.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         var effect = loaded.Data.Aggregates["CARD.BASH_KIN#1"].AppliedEffects["POWER.WEAK"];
         Assert.Equal(1, effect.TimesBlockedByArtifact);
         Assert.Equal(2m, effect.TotalAmountBlockedByArtifact);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsLegacyResumableV7Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v7-per-instance-poison-damage-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(7, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        var effect = loaded.Data.Aggregates["CARD.DEADLY_POISON#1"].AppliedEffects["POWER.POISON"];
+        Assert.Equal(9m, effect.TotalTriggeredEffectiveDamage);
+        Assert.Equal(3m, effect.TotalTriggeredOverkill);
     }
 
     [Fact]
@@ -162,16 +177,28 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV6Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV6Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v6-per-instance-artifact-block-run.json"));
 
         Assert.NotNull(resumed);
-        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(6, resumed!.SchemaVersion);
         Assert.Equal(6, resumed.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         var effect = resumed.Aggregates["CARD.BASH_KIN#1"].AppliedEffects["POWER.WEAK"];
         Assert.Equal(1, effect.TimesBlockedByArtifact);
         Assert.Equal(2m, effect.TotalAmountBlockedByArtifact);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsLegacyResumableV7Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v7-per-instance-poison-damage-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(7, resumed!.SchemaVersion);
+        var effect = resumed.Aggregates["CARD.DEADLY_POISON#1"].AppliedEffects["POWER.POISON"];
+        Assert.Equal(9m, effect.TotalTriggeredEffectiveDamage);
+        Assert.Equal(3m, effect.TotalTriggeredOverkill);
     }
 
     [Fact]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,107 @@
+# Architecture
+
+This codebase has two big goals:
+
+1. stay hot-reload friendly during development
+2. attribute run outcomes back to the card that actually caused them
+
+## Runtime Topology
+
+### Loader
+
+- [Loader/LoaderMain.cs](D:/repos/CardUtilityStats/Loader/LoaderMain.cs:14) is the stable bootstrap loaded once by BaseLib.
+- It owns the `F5` workflow:
+  - copy the Core DLL to a fresh temp path
+  - load that copy
+  - call `CoreMain.Initialize()`
+  - on reload, call the previous `CoreMain.Shutdown()` first
+- The loader does not try to truly unload old contexts; it relies on explicit cleanup plus process-lifetime tolerance.
+
+### Core
+
+- [Core/CoreMain.cs](D:/repos/CardUtilityStats/Core/CoreMain.cs:8) is the hot-reloaded entry point.
+- It applies Harmony patches, wires tracker hooks, resumes active run state after reload, and tears all of that back down on `Shutdown()`.
+
+## Data Flow
+
+### Live Tracking
+
+- [Core/RunTracker.cs](D:/repos/CardUtilityStats/Core/RunTracker.cs:18) is the heart of the mod.
+- Combat history entries and selected hook patches feed into the tracker.
+- During combat, observations accumulate in `_pendingCombat`.
+- On combat end, `_pendingCombat` is promoted into the committed run aggregates and saved.
+
+This combat-boundary rule is important:
+
+- between-combat reload is supported
+- between-floor reload is supported
+- mid-combat restore is intentionally unsupported
+
+### Persistence
+
+- [Core/RunData.cs](D:/repos/CardUtilityStats/Core/RunData.cs:6) defines the serialized run shape.
+- [Core/RunStorage.cs](D:/repos/CardUtilityStats/Core/RunStorage.cs:9) handles load/save and resumability rules.
+- Schema changes are additive when possible. The current schema is `v8`.
+
+Historical compatibility is pinned by:
+
+- [Fixtures/RunSchema](D:/repos/CardUtilityStats/Fixtures/RunSchema/README.md:1)
+- [Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs](D:/repos/CardUtilityStats/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs:1)
+
+## Attribution Model
+
+The project tries to answer "what actually happened because of this card?" rather than "what did the card text claim?"
+
+Examples already implemented:
+
+- direct attack damage, blocked damage, overkill, kills
+- block gained / effective / wasted
+- actual energy generated
+- Regent stars spent / generated
+- observed cards drawn from draw effects
+- effect applications credited back to the source card
+- Artifact-blocked debuffs
+- downstream poison damage and poison overkill
+
+When attribution is not naturally one-card-to-one-outcome, the code prefers:
+
+- observed outcomes over listed intent
+- pooled summaries for combat-generated cards when they do not have stable deck identity
+- explicitly heuristic handling instead of pretending certainty
+
+## UI Surface
+
+- [Core/Patches/ViewStatsInjectorPatch.cs](D:/repos/CardUtilityStats/Core/Patches/ViewStatsInjectorPatch.cs:11) injects the `View Stats` toggle into the deck view.
+- [Core/Patches/CardHoverTooltipPatch.cs](D:/repos/CardUtilityStats/Core/Patches/CardHoverTooltipPatch.cs:11) builds compact and full tooltip bodies.
+- [Core/StatsTooltip.cs](D:/repos/CardUtilityStats/Core/StatsTooltip.cs:1) renders the side tooltip panel.
+
+Current UI conventions:
+
+- hand tooltips stay compact
+- deck-view tooltips can be fuller and include lineage/context
+- rows should be self-describing
+- loud section headers are discouraged unless they add real clarity
+- inline icons are preferred for keyword-like effects when they improve scanning
+- when the game already exposes a recognizable asset, prefer the in-game block/draw/energy/star iconography over generic text-only rows
+
+## Generated And Non-Deck Cards
+
+Not every card the player sees should be treated as a stable deck resident.
+
+- stable deck cards use per-instance numbering
+- removed cards remain viewable with their accumulated stats
+- some combat-generated cards are better represented as pooled summaries than as fake permanent instances
+
+That distinction matters for both tooltip wording and data integrity.
+
+## If You Add A New Stat
+
+Use this checklist:
+
+1. decide whether the stat should be per-instance, pooled, or effect-oriented
+2. record the observed game outcome, not just the requested amount, if those can diverge
+3. update [RunData.cs](D:/repos/CardUtilityStats/Core/RunData.cs:6) if persistence changes
+4. update fixtures under [Fixtures/RunSchema](D:/repos/CardUtilityStats/Fixtures/RunSchema/README.md:1)
+5. update [SchemaLoadingTests.cs](D:/repos/CardUtilityStats/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs:1)
+6. update tooltip rendering in [CardHoverTooltipPatch.cs](D:/repos/CardUtilityStats/Core/Patches/CardHoverTooltipPatch.cs:11) if the stat is user-facing
+7. keep compact tooltip noise low


### PR DESCRIPTION
## Summary
- add a dedicated poison stats block to card hover tooltips using the existing applied-effect tracking
- hide poison from the generic effect/artifact summaries when that dedicated poison block is shown
- add focused tests for poison totals and the poison-filtered effect/artifact rows

## Notes
- This intentionally does not claim downstream poison tick damage or poison-kill attribution yet.
- The game history records poison tick damage without a card source, so surfacing exact per-card tick attribution here would be misleading.

Closes #26