### PR TITLE
Track blocked draw attempts in card stats

### DIFF
--- a/Core/CardAggregatePooler.cs
+++ b/Core/CardAggregatePooler.cs
@@ -49,6 +49,7 @@ internal static class CardAggregatePooler
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
+        target.TimesCardsDrawBlocked += source.TimesCardsDrawBlocked;
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -361,6 +361,8 @@ public static class CardHoverShowPatch
         // Counts only card-effect draws (not turn-start auto-draw).
         if (agg.TimesCardsDrawn > 0)
             Row3(sb, GetDrawStatLabel("cards drawn"), agg.TimesCardsDrawn.ToString(), "");
+        if (agg.TimesCardsDrawBlocked > 0)
+            Row3(sb, GetDrawStatLabel("draws blocked"), agg.TimesCardsDrawBlocked.ToString(), "");
 
         // HP lost from playing this card — Ironclad self-damage cards.
         // POST-reduction value, so Tungsten Rod / buffer interactions

--- a/Core/Patches/HookShouldDrawPatch.cs
+++ b/Core/Patches/HookShouldDrawPatch.cs
@@ -1,6 +1,7 @@
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
 
 namespace CardUtilityStats.Core.Patches;
 
@@ -25,6 +26,20 @@ public static class HookShouldDrawPatch
         catch (System.Exception e)
         {
             CoreMain.Logger.Error($"HookShouldDrawPatch failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(Player player, bool fromHandDraw, ref AbstractModel? modifier, bool __result)
+    {
+        try
+        {
+            if (__result) return;
+            RunTracker.RecordBlockedDrawAttempt(player, fromHandDraw, modifier);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"HookShouldDrawPatch failed during postfix: {e.Message}");
         }
     }
 }

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 8;
+    public const int CurrentSchemaVersion = 9;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -33,6 +33,8 @@ public class RunData
     // v8: add Regent star-resource spend / gain tracking alongside the
     //     existing energy fields. Also additive; older v7 files remain
     //     resumable with the new fields defaulting to 0.
+    // v9: add per-card blocked-draw attribution counts. Also additive;
+    //     older v8 files remain resumable with the new field defaulting to 0.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -184,6 +186,13 @@ public class CardAggregate
     // Acrobatics etc. depending on the character). Excludes turn-start
     // auto-draw via the game's FromHandDraw flag.
     public int TimesCardsDrawn { get; set; }
+
+    // M3i2: Blocked draw attribution. When THIS card's play ATTEMPTS to draw
+    // cards but a draw-prevention hook vetoes the attempt (Battle Trance,
+    // future "can't draw" effects, etc.). Counts blocked cards separately
+    // from successful draws so draw cards don't silently look like they drew
+    // zero when the game explicitly prevented them.
+    public int TimesCardsDrawBlocked { get; set; }
 
     // M4a: Effect / power application summary for this specific card
     // instance. First pass tracks ONLY that the card caused a power/effect

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -109,6 +109,7 @@ public static class RunStorage
             case 5:
             case 6:
             case 7:
+            case 8:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1667,6 +1667,35 @@ public static class RunTracker
         }
     }
 
+    public static void RecordBlockedDrawAttempt(Player player, bool fromHandDraw, AbstractModel? modifier)
+    {
+        lock (_lock)
+        {
+            if (fromHandDraw) return;
+
+            _pendingCombat ??= new PendingCombat();
+
+            try
+            {
+                var sourceCard = _pendingDrawSourceCard ?? FindLikelyDrawSourceCard(player);
+                if (sourceCard == null)
+                {
+                    CoreMain.LogDebug(
+                        $"Blocked draw unattributed modifier={modifier?.GetType().Name ?? "null"}");
+                    return;
+                }
+
+                var sourceId = GetOrAssignInstanceId(sourceCard);
+                var sourceAgg = GetOrCreateAggregate(_pendingCombat, sourceId);
+                sourceAgg.TimesCardsDrawBlocked++;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordBlockedDrawAttempt failed: {e.Message}");
+            }
+        }
+    }
+
     private static void RecordPowerReceived(PowerReceivedEntry entry)
     {
         lock (_lock)
@@ -2093,6 +2122,7 @@ public static class RunTracker
             TimesExhausted = source.TimesExhausted,
             TotalHpLost = source.TotalHpLost,
             TimesCardsDrawn = source.TimesCardsDrawn,
+            TimesCardsDrawBlocked = source.TimesCardsDrawBlocked,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
@@ -2126,6 +2156,7 @@ public static class RunTracker
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
+        target.TimesCardsDrawBlocked += source.TimesCardsDrawBlocked;
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -23,15 +23,18 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds per-effect downstream damage and overkill counters so
   dedicated poison rows can report observed poison outcomes, not just poison applied.
 - `v8-per-instance-regent-stars-run.json`
-  Current schema. Adds Regent star-resource spend/gain fields alongside the
+  Legacy-but-resumable additive schema. Adds Regent star-resource spend/gain fields alongside the
   existing energy and per-instance attribution data.
+- `v9-per-instance-blocked-draw-run.json`
+  Current schema. Adds per-card blocked-draw attribution counts on top of
+  the v8 Regent-star fields.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, and `v7 -> v8`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, `v7 -> v8`, and `v8 -> v9`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v9-per-instance-blocked-draw-run.json
+++ b/Fixtures/RunSchema/v9-per-instance-blocked-draw-run.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 9,
+  "run_id": "fixture-v9-per-instance-blocked-draw",
+  "started_at": "2026-04-20T12:20:00Z",
+  "updated_at": "2026-04-20T12:28:00Z",
+  "ended_at": "2026-04-20T12:31:00Z",
+  "character": "IRONCLAD",
+  "ascension": 9,
+  "floor_reached": 18,
+  "outcome": "win",
+  "game_start_time": 1713615600,
+  "aggregates": {
+    "CARD.BATTLE_TRANCE#1": {
+      "plays": 1,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 0,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 1,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 3,
+      "times_cards_draw_blocked": 0,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.POMMEL_STRIKE#1": {
+      "plays": 2,
+      "total_intended": 16,
+      "total_blocked": 2,
+      "total_overkill": 0,
+      "total_effective": 14,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 1,
+      "times_cards_draw_blocked": 2,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-20T12:23:00Z",
+      "type": "card_played",
+      "card_id": "CARD.BATTLE_TRANCE#1",
+      "energy_spent": 0,
+      "stars_spent": 0,
+      "stars_gained": 0,
+      "floor": 8
+    },
+    {
+      "t": "2026-04-20T12:24:00Z",
+      "type": "card_played",
+      "card_id": "CARD.POMMEL_STRIKE#1",
+      "energy_spent": 1,
+      "stars_spent": 0,
+      "stars_gained": 0,
+      "floor": 8
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.BATTLE_TRANCE": [
+      1
+    ],
+    "CARD.POMMEL_STRIKE": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.BATTLE_TRANCE": 1,
+    "CARD.POMMEL_STRIKE": 1
+  }
+}

--- a/Tests/CardUtilityStats.Core.Tests/BlockTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/BlockTooltipTests.cs
@@ -69,6 +69,15 @@ public class BlockTooltipTests
     }
 
     [Fact]
+    public void GetDrawStatLabel_UsesDrawCardsNextTurnPowerIconForBlockedRows()
+    {
+        var label = (string)(GetDrawStatLabelMethod.Invoke(null, new object?[] { "draws blocked" })
+            ?? throw new InvalidOperationException("GetDrawStatLabel returned null."));
+
+        Assert.Equal("[img=16x16]res://images/atlases/power_atlas.sprites/draw_cards_next_turn_power.tres[/img] draws blocked", label);
+    }
+
+    [Fact]
     public void GetEnergyStatLabel_UsesEnergyPotionIcon()
     {
         var label = (string)(GetEnergyStatLabelMethod.Invoke(null, new object?[] { "gained" })

--- a/Tests/CardUtilityStats.Core.Tests/CardAggregatePoolerTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/CardAggregatePoolerTests.cs
@@ -14,6 +14,7 @@ public class CardAggregatePoolerTests
             TotalEffective = 4,
             TotalBlocked = 1,
             TimesExhausted = 1,
+            TimesCardsDrawBlocked = 2,
         };
         first.AppliedEffects["POWER.ARTIFACT"] = new AppliedEffectAggregate
         {
@@ -29,6 +30,7 @@ public class CardAggregatePoolerTests
             TotalEffective = 11,
             TotalBlocked = 2,
             TimesExhausted = 2,
+            TimesCardsDrawBlocked = 1,
         };
         second.AppliedEffects["POWER.VULNERABLE"] = new AppliedEffectAggregate
         {
@@ -59,6 +61,7 @@ public class CardAggregatePoolerTests
         Assert.Equal(15, pooled.TotalEffective);
         Assert.Equal(3, pooled.TotalBlocked);
         Assert.Equal(3, pooled.TimesExhausted);
+        Assert.Equal(3, pooled.TimesCardsDrawBlocked);
 
         var artifact = pooled.AppliedEffects["POWER.ARTIFACT"];
         Assert.Equal(1, artifact.TimesBlockedByArtifact);

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -119,19 +119,34 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV8Fixture()
+    public void HistoricalLoad_AcceptsLegacyResumableV8Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v8-per-instance-regent-stars-run.json"));
 
         Assert.NotNull(loaded);
         Assert.Equal(8, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
+        Assert.Equal(2, loaded.Data.Events[1].StarsSpent);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsCurrentV9Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v9-per-instance-blocked-draw-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
         Assert.False(loaded.IsLegacy);
         Assert.True(loaded.SupportsResume);
         Assert.True(loaded.HasPerInstanceIdentity);
         Assert.Null(loaded.CompatibilityNote);
-        Assert.Equal(2, loaded.Data.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
-        Assert.Equal(2, loaded.Data.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
-        Assert.Equal(2, loaded.Data.Events[1].StarsSpent);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.POMMEL_STRIKE#1"].TimesCardsDrawBlocked);
+        Assert.Equal(1, loaded.Data.Aggregates["CARD.POMMEL_STRIKE#1"].TimesCardsDrawn);
+        Assert.Equal(0, loaded.Data.Aggregates["CARD.POMMEL_STRIKE#1"].TotalStarsGenerated);
     }
 
     [Fact]
@@ -218,7 +233,7 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV8Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV8Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v8-per-instance-regent-stars-run.json"));
 
@@ -227,6 +242,18 @@ public class SchemaLoadingTests
         Assert.Equal(2, resumed.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
         Assert.Equal(2, resumed.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
         Assert.Equal(1, resumed.Aggregates["CARD.VENERATE#1"].TimesDrawn);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV9Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v9-per-instance-blocked-draw-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(2, resumed.Aggregates["CARD.POMMEL_STRIKE#1"].TimesCardsDrawBlocked);
+        Assert.Equal(1, resumed.Aggregates["CARD.POMMEL_STRIKE#1"].TimesCardsDrawn);
+        Assert.Equal(0, resumed.Aggregates["CARD.POMMEL_STRIKE#1"].TotalStarsSpent);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- track card-effect draw attempts that are vetoed by `Hook.ShouldDraw`, which covers Battle Trance and similar draw-prevention effects
- surface blocked draws as a separate per-card stat so draw cards do not look like ordinary zero-draw outcomes
- bump the run schema additively to v7 and add fixture/test coverage for the new field

## Testing
- `dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj`

Closes #32.
