### PR TITLE
Track direct hand-add attribution

### DIFF
--- a/Core/CardAggregatePooler.cs
+++ b/Core/CardAggregatePooler.cs
@@ -49,6 +49,7 @@ internal static class CardAggregatePooler
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
+        target.TimesCardsAddedToHand += source.TimesCardsAddedToHand;
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -342,6 +342,8 @@ public static class CardHoverShowPatch
         // Counts only card-effect draws (not turn-start auto-draw).
         if (agg.TimesCardsDrawn > 0)
             Row3(sb, "Cards drawn", agg.TimesCardsDrawn.ToString(), "");
+        if (agg.TimesCardsAddedToHand > 0)
+            Row3(sb, "Added to hand", agg.TimesCardsAddedToHand.ToString(), "");
 
         // HP lost from playing this card — Ironclad self-damage cards.
         // POST-reduction value, so Tungsten Rod / buffer interactions
@@ -395,6 +397,8 @@ public static class CardHoverShowPatch
 
         if (agg.TotalBlockGained > 0)
             Row3(sb, "Block gained", agg.TotalBlockGained.ToString(), "");
+        if (agg.TimesCardsAddedToHand > 0)
+            Row3(sb, "Added to hand", agg.TimesCardsAddedToHand.ToString(), "");
 
         AppendAppliedEffects(sb, agg, compact: true);
         AppendArtifactBlockedSummary(sb, agg);

--- a/Core/Patches/HookAfterCardChangedPilesPatch.cs
+++ b/Core/Patches/HookAfterCardChangedPilesPatch.cs
@@ -1,0 +1,32 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Tracks cards that are inserted directly into hand rather than drawn.
+/// We hook <c>Hook.AfterCardChangedPiles</c> because it runs after the game
+/// has already resolved full-hand fallback, so the card's current pile is
+/// the truth of where it really ended up. Filtering to
+/// <c>oldPile == None</c> keeps normal draw / discard-to-hand / pile-shift
+/// movement out of this stat and leaves us with direct generation into hand.
+/// </summary>
+[HarmonyPatch(typeof(Hook), nameof(Hook.AfterCardChangedPiles))]
+public static class HookAfterCardChangedPilesPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(CardModel card, PileType oldPile, AbstractModel? source)
+    {
+        try
+        {
+            if (card == null) return;
+            RunTracker.RecordCardAddedToHand(card, oldPile, source);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"HookAfterCardChangedPilesPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 6;
+    public const int CurrentSchemaVersion = 7;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -26,6 +26,9 @@ public class RunData
     //     files remain resumable with the new fields defaulting to 0.
     // v6: add per-effect Artifact-blocked debuff counters. Also additive;
     //     older v5 files remain resumable with the new fields defaulting to 0.
+    // v7: add per-card "times cards added directly to hand" attribution.
+    //     Also additive; older v6 files remain resumable with the new field
+    //     defaulting to 0.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -172,6 +175,15 @@ public class CardAggregate
     // Acrobatics etc. depending on the character). Excludes turn-start
     // auto-draw via the game's FromHandDraw flag.
     public int TimesCardsDrawn { get; set; }
+
+    // M3i2: Direct hand-add attribution. When THIS card's play causes
+    // OTHER cards to be created/inserted directly into the player's hand
+    // without going through the draw pipeline. Covers Crash Landing-style
+    // "fill the hand with statuses" effects and any future direct-to-hand
+    // generation where actual hand capacity should determine the observed
+    // count. Cards redirected elsewhere (for example, to discard because
+    // the hand is full) do NOT count here.
+    public int TimesCardsAddedToHand { get; set; }
 
     // M4a: Effect / power application summary for this specific card
     // instance. First pass tracks ONLY that the card caused a power/effect

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -107,6 +107,7 @@ public static class RunStorage
             case 3:
             case 4:
             case 5:
+            case 6:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1545,6 +1545,32 @@ public static class RunTracker
         return null;
     }
 
+    private static CardModel? FindLikelyHandAddSourceCard(Player targetPlayer, AbstractModel? source)
+    {
+        if (source is CardModel sourceCard && IsOwnedBy(sourceCard, targetPlayer))
+            return Canonical(sourceCard);
+
+        if (_pendingEffectSourceCard != null && IsOwnedBy(_pendingEffectSourceCard, targetPlayer))
+        {
+            int historyCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
+            if (historyCount <= _pendingEffectSourceHistoryCount + 1)
+                return _pendingEffectSourceCard;
+        }
+
+        var causingPlay = FindCurrentlyResolvingCardPlay();
+        if (causingPlay?.Card != null && IsOwnedBy(causingPlay.Card, targetPlayer))
+            return Canonical(causingPlay.Card);
+
+        if (_recentCompletedPlayerCardPlay?.Card != null && IsOwnedBy(_recentCompletedPlayerCardPlay.Card, targetPlayer))
+        {
+            int historyCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
+            if (historyCount <= _recentCompletedPlayerCardPlayHistoryCount + 1)
+                return Canonical(_recentCompletedPlayerCardPlay.Card);
+        }
+
+        return null;
+    }
+
     private static bool IsOwnedBy(CardModel card, Player targetPlayer)
     {
         if (targetPlayer == null) return true;
@@ -1590,6 +1616,38 @@ public static class RunTracker
                 {
                     CoreMain.LogDebug($"RecordDrawFromCard attribution failed: {e.Message}");
                 }
+            }
+        }
+    }
+
+    public static void RecordCardAddedToHand(CardModel card, MegaCrit.Sts2.Core.Entities.Cards.PileType oldPile, AbstractModel? source)
+    {
+        lock (_lock)
+        {
+            if (card == null) return;
+            if (oldPile != MegaCrit.Sts2.Core.Entities.Cards.PileType.None) return;
+            if (card.Pile?.Type != MegaCrit.Sts2.Core.Entities.Cards.PileType.Hand) return;
+
+            _pendingCombat ??= new PendingCombat();
+
+            try
+            {
+                var sourceCard = FindLikelyHandAddSourceCard(card.Owner, source);
+                if (sourceCard == null)
+                {
+                    CoreMain.LogDebug($"CardAddedToHand unattributed card={card.Id} title='{card.Title}'");
+                    return;
+                }
+
+                if (ReferenceEquals(Canonical(sourceCard), Canonical(card))) return;
+
+                var causerId = GetOrAssignInstanceId(sourceCard);
+                var causerAgg = GetOrCreateAggregate(_pendingCombat, causerId);
+                causerAgg.TimesCardsAddedToHand++;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordCardAddedToHand attribution failed: {e.Message}");
             }
         }
     }
@@ -1906,6 +1964,7 @@ public static class RunTracker
             TimesExhausted = source.TimesExhausted,
             TotalHpLost = source.TotalHpLost,
             TimesCardsDrawn = source.TimesCardsDrawn,
+            TimesCardsAddedToHand = source.TimesCardsAddedToHand,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
@@ -1937,6 +1996,7 @@ public static class RunTracker
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
+        target.TimesCardsAddedToHand += source.TimesCardsAddedToHand;
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -17,15 +17,18 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds absorbed/wasted block aggregates
   on top of the v4 effect and exhaust fields.
 - `v6-per-instance-artifact-block-run.json`
-  Current schema. Adds per-effect Artifact-blocked debuff counters on top of
-  the v5 block ledger fields.
+  Legacy-but-resumable additive schema. Adds per-effect Artifact-blocked
+  debuff counters on top of the v5 block ledger fields.
+- `v7-per-instance-hand-add-run.json`
+  Current schema. Adds per-card direct-to-hand card generation counts on top
+  of the v6 Artifact-blocked effect fields.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, and `v5 -> v6`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, and `v6 -> v7`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v7-per-instance-hand-add-run.json
+++ b/Fixtures/RunSchema/v7-per-instance-hand-add-run.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": 7,
+  "run_id": "fixture-v7-per-instance-hand-add",
+  "started_at": "2026-04-20T12:20:00Z",
+  "updated_at": "2026-04-20T12:34:00Z",
+  "ended_at": "2026-04-20T12:36:30Z",
+  "character": "KIN",
+  "ascension": 4,
+  "floor_reached": 24,
+  "outcome": "win",
+  "game_start_time": 1713615600,
+  "aggregates": {
+    "CARD.DEFEND_KIN#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_block_gained": 10,
+      "total_block_effective": 6,
+      "total_block_wasted": 4,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_added_to_hand": 0,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.BASH_KIN#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_added_to_hand": 0,
+      "applied_effects": {
+        "POWER.WEAK": {
+          "effect_id": "POWER.WEAK",
+          "display_name": "Weak",
+          "icon_path": "res://art/powers/weak.png",
+          "times_applied": 1,
+          "total_amount_applied": 2,
+          "times_blocked_by_artifact": 1,
+          "total_amount_blocked_by_artifact": 2
+        }
+      },
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.CRASH_LANDING#1": {
+      "plays": 2,
+      "total_intended": 42,
+      "total_blocked": 6,
+      "total_overkill": 4,
+      "total_effective": 32,
+      "kills": 1,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_added_to_hand": 7,
+      "applied_effects": {},
+      "floor_added": 12,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-20T12:26:00Z",
+      "type": "card_played",
+      "card_id": "CARD.DEFEND_KIN#1",
+      "energy_spent": 1,
+      "floor": 9
+    },
+    {
+      "t": "2026-04-20T12:27:00Z",
+      "type": "card_played",
+      "card_id": "CARD.BASH_KIN#1",
+      "energy_spent": 1,
+      "floor": 9
+    },
+    {
+      "t": "2026-04-20T12:28:00Z",
+      "type": "card_played",
+      "card_id": "CARD.CRASH_LANDING#1",
+      "energy_spent": 1,
+      "floor": 12
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.DEFEND_KIN": [
+      1
+    ],
+    "CARD.BASH_KIN": [
+      1
+    ],
+    "CARD.CRASH_LANDING": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.DEFEND_KIN": 1,
+    "CARD.BASH_KIN": 1,
+    "CARD.CRASH_LANDING": 1
+  }
+}

--- a/Tests/CardUtilityStats.Core.Tests/CardAggregatePoolerTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/CardAggregatePoolerTests.cs
@@ -14,6 +14,7 @@ public class CardAggregatePoolerTests
             TotalEffective = 4,
             TotalBlocked = 1,
             TimesExhausted = 1,
+            TimesCardsAddedToHand = 3,
         };
         first.AppliedEffects["POWER.ARTIFACT"] = new AppliedEffectAggregate
         {
@@ -29,6 +30,7 @@ public class CardAggregatePoolerTests
             TotalEffective = 11,
             TotalBlocked = 2,
             TimesExhausted = 2,
+            TimesCardsAddedToHand = 4,
         };
         second.AppliedEffects["POWER.VULNERABLE"] = new AppliedEffectAggregate
         {
@@ -59,6 +61,7 @@ public class CardAggregatePoolerTests
         Assert.Equal(15, pooled.TotalEffective);
         Assert.Equal(3, pooled.TotalBlocked);
         Assert.Equal(3, pooled.TimesExhausted);
+        Assert.Equal(7, pooled.TimesCardsAddedToHand);
 
         var artifact = pooled.AppliedEffects["POWER.ARTIFACT"];
         Assert.Equal(1, artifact.TimesBlockedByArtifact);

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -88,19 +88,33 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV6Fixture()
+    public void HistoricalLoad_AcceptsLegacyResumableV6Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v6-per-instance-artifact-block-run.json"));
 
         Assert.NotNull(loaded);
-        Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
-        Assert.False(loaded.IsLegacy);
+        Assert.Equal(6, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
         Assert.True(loaded.SupportsResume);
         Assert.True(loaded.HasPerInstanceIdentity);
         Assert.Equal(6, loaded.Data.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         var effect = loaded.Data.Aggregates["CARD.BASH_KIN#1"].AppliedEffects["POWER.WEAK"];
         Assert.Equal(1, effect.TimesBlockedByArtifact);
         Assert.Equal(2m, effect.TotalAmountBlockedByArtifact);
+        Assert.Equal(0, loaded.Data.Aggregates["CARD.BASH_KIN#1"].TimesCardsAddedToHand);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsCurrentV7Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v7-per-instance-hand-add-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
+        Assert.False(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Equal(7, loaded.Data.Aggregates["CARD.CRASH_LANDING#1"].TimesCardsAddedToHand);
     }
 
     [Fact]
@@ -162,16 +176,27 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV6Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV6Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v6-per-instance-artifact-block-run.json"));
 
         Assert.NotNull(resumed);
-        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(6, resumed!.SchemaVersion);
         Assert.Equal(6, resumed.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         var effect = resumed.Aggregates["CARD.BASH_KIN#1"].AppliedEffects["POWER.WEAK"];
         Assert.Equal(1, effect.TimesBlockedByArtifact);
         Assert.Equal(2m, effect.TotalAmountBlockedByArtifact);
+        Assert.Equal(0, resumed.Aggregates["CARD.BASH_KIN#1"].TimesCardsAddedToHand);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV7Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v7-per-instance-hand-add-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(7, resumed.Aggregates["CARD.CRASH_LANDING#1"].TimesCardsAddedToHand);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- track cards/statuses that are generated directly into hand, separate from normal draw attribution
- attribute those hand-adds back to the source card and surface them in the tooltip as Added to hand
- count only cards that actually land in hand after the game's hand-cap fallback, which fixes Crash Landing-style status fill effects
- bump the additive run schema to v7 and add fixture/pooler coverage for the new counter

## Notes
- This is aimed at issue #24, with Crash Landing as the concrete target case.
- The hook is on Hook.AfterCardChangedPiles, filtered to oldPile == None and final pile Hand, so normal draws and discard-to-hand movement are not mixed into this stat.

## Testing
- dotnet build Core/CardUtilityStats.Core.csproj -p:SkipModsDeploy=true
- dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -p:SkipModsDeploy=true

Closes #24