### PR TITLE
Track Noxious Fumes poison attribution

### DIFF
--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -480,15 +480,23 @@ public static class CardHoverShowPatch
                 ? poison.Value.TimesApplied > 1 ? $"{poison.Value.TimesApplied}x" : "1x"
                 : "";
             Row3(sb, "Poison applied", FormatDecimal(poison.Value.TotalAmountApplied), extra);
+            if (poison.Value.TotalDamageDealt > 0m)
+                Row3(sb, "Poison damage", FormatDecimal(poison.Value.TotalDamageDealt), "");
             return true;
         }
 
         decimal avgPoison = agg.Plays > 0 ? poison.Value.TotalAmountApplied / agg.Plays : 0m;
+        decimal avgPoisonDamage = agg.Plays > 0 ? poison.Value.TotalDamageDealt / agg.Plays : 0m;
 
         sb.Append("[color=#b5b5b5]Poison applied[/color]\n");
         Row3(sb, "Total poison", FormatDecimal(poison.Value.TotalAmountApplied), "");
         Row3(sb, "Avg poison", FormatDecimal(avgPoison), "");
         Row3(sb, "Applications", poison.Value.TimesApplied.ToString(), "");
+        if (poison.Value.TotalDamageDealt > 0m)
+        {
+            Row3(sb, "Poison damage", FormatDecimal(poison.Value.TotalDamageDealt), "");
+            Row3(sb, "Avg poison dmg", FormatDecimal(avgPoisonDamage), "");
+        }
 
         if (poison.Value.TimesBlockedByArtifact > 0)
         {
@@ -503,34 +511,38 @@ public static class CardHoverShowPatch
 
     private static PoisonEffectSummary? GetPoisonSummary(CardAggregate agg)
     {
-        if (agg.AppliedEffects == null || agg.AppliedEffects.Count == 0) return null;
-
         int timesApplied = 0;
         decimal totalAmountApplied = 0m;
         int timesBlockedByArtifact = 0;
         decimal totalAmountBlockedByArtifact = 0m;
+        decimal totalDamageDealt = agg.TotalPoisonDamageDealt;
 
-        foreach (var effect in agg.AppliedEffects.Values)
+        if (agg.AppliedEffects != null)
         {
-            if (!IsPoisonEffect(effect)) continue;
+            foreach (var effect in agg.AppliedEffects.Values)
+            {
+                if (!IsPoisonEffect(effect)) continue;
 
-            timesApplied += effect.TimesApplied;
-            totalAmountApplied += effect.TotalAmountApplied;
-            timesBlockedByArtifact += effect.TimesBlockedByArtifact;
-            totalAmountBlockedByArtifact += effect.TotalAmountBlockedByArtifact;
+                timesApplied += effect.TimesApplied;
+                totalAmountApplied += effect.TotalAmountApplied;
+                timesBlockedByArtifact += effect.TimesBlockedByArtifact;
+                totalAmountBlockedByArtifact += effect.TotalAmountBlockedByArtifact;
+            }
         }
 
         if (timesApplied <= 0 &&
             totalAmountApplied == 0m &&
             timesBlockedByArtifact <= 0 &&
-            totalAmountBlockedByArtifact == 0m)
+            totalAmountBlockedByArtifact == 0m &&
+            totalDamageDealt == 0m)
             return null;
 
         return new PoisonEffectSummary(
             timesApplied,
             totalAmountApplied,
             timesBlockedByArtifact,
-            totalAmountBlockedByArtifact);
+            totalAmountBlockedByArtifact,
+            totalDamageDealt);
     }
 
     private static void AppendAppliedEffects(StringBuilder sb, CardAggregate agg, bool compact, bool excludePoison)
@@ -684,7 +696,8 @@ internal readonly record struct PoisonEffectSummary(
     int TimesApplied,
     decimal TotalAmountApplied,
     int TimesBlockedByArtifact,
-    decimal TotalAmountBlockedByArtifact);
+    decimal TotalAmountBlockedByArtifact,
+    decimal TotalDamageDealt);
 
 [HarmonyPatch(typeof(NCardHolder), "ClearHoverTips")]
 public static class CardHoverHidePatch

--- a/Core/Patches/NoxiousFumesAfterSideTurnStartPatch.cs
+++ b/Core/Patches/NoxiousFumesAfterSideTurnStartPatch.cs
@@ -1,0 +1,27 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models.Powers;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Arms a short-lived attribution window for the passive poison applications
+/// emitted by Noxious Fumes at turn start. The ensuing Poison power receives
+/// do not carry a card source, so we map them back to the stacked Noxious
+/// Fumes source ledger while this window is active.
+/// </summary>
+[HarmonyPatch(typeof(NoxiousFumesPower), nameof(NoxiousFumesPower.AfterSideTurnStart))]
+public static class NoxiousFumesAfterSideTurnStartPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(NoxiousFumesPower __instance)
+    {
+        try
+        {
+            RunTracker.NoteNoxiousFumesTick(__instance);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"NoxiousFumesAfterSideTurnStartPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/PoisonAfterSideTurnStartPatch.cs
+++ b/Core/Patches/PoisonAfterSideTurnStartPatch.cs
@@ -1,0 +1,26 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models.Powers;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Arms the next unattributed damage event for this creature as a poison tick
+/// so downstream poison damage can be charged back through the target's poison
+/// source ledger instead of falling on the floor as CardSource=null damage.
+/// </summary>
+[HarmonyPatch(typeof(PoisonPower), nameof(PoisonPower.AfterSideTurnStart))]
+public static class PoisonAfterSideTurnStartPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(PoisonPower __instance)
+    {
+        try
+        {
+            RunTracker.NotePoisonTick(__instance);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"PoisonAfterSideTurnStartPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/PoisonLedgerMath.cs
+++ b/Core/PoisonLedgerMath.cs
@@ -9,42 +9,8 @@ internal sealed class PoisonChunk
     public int Sequence { get; init; }
 }
 
-internal sealed class PersistentContributionChunk
-{
-    public string CardInstanceId { get; init; } = "";
-    public decimal Amount { get; set; }
-    public int Sequence { get; init; }
-}
-
 internal static class PoisonLedgerMath
 {
-    public static (Dictionary<string, decimal> Amounts, decimal UnattributedAmount) AllocateContributions(
-        IReadOnlyList<PersistentContributionChunk> chunks,
-        decimal amount)
-    {
-        var allocations = new Dictionary<string, decimal>();
-        if (chunks.Count == 0 || amount <= 0m) return (allocations, amount);
-
-        decimal remaining = amount;
-        foreach (var chunk in chunks.OrderBy(c => c.Sequence))
-        {
-            if (remaining <= 0m) break;
-            if (chunk.Amount <= 0m) continue;
-
-            decimal portion = Math.Min(chunk.Amount, remaining);
-            if (portion <= 0m) continue;
-
-            if (allocations.TryGetValue(chunk.CardInstanceId, out var existing))
-                allocations[chunk.CardInstanceId] = existing + portion;
-            else
-                allocations[chunk.CardInstanceId] = portion;
-
-            remaining -= portion;
-        }
-
-        return (allocations, remaining);
-    }
-
     public static (Dictionary<string, decimal> Amounts, decimal UnattributedAmount) AttributeDamage(
         IReadOnlyList<PoisonChunk> chunks,
         decimal damage)

--- a/Core/PoisonLedgerMath.cs
+++ b/Core/PoisonLedgerMath.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+
+namespace CardUtilityStats.Core;
+
+internal sealed class PoisonChunk
+{
+    public string CardInstanceId { get; init; } = "";
+    public decimal Remaining { get; set; }
+    public int Sequence { get; init; }
+}
+
+internal sealed class PersistentContributionChunk
+{
+    public string CardInstanceId { get; init; } = "";
+    public decimal Amount { get; set; }
+    public int Sequence { get; init; }
+}
+
+internal static class PoisonLedgerMath
+{
+    public static (Dictionary<string, decimal> Amounts, decimal UnattributedAmount) AllocateContributions(
+        IReadOnlyList<PersistentContributionChunk> chunks,
+        decimal amount)
+    {
+        var allocations = new Dictionary<string, decimal>();
+        if (chunks.Count == 0 || amount <= 0m) return (allocations, amount);
+
+        decimal remaining = amount;
+        foreach (var chunk in chunks.OrderBy(c => c.Sequence))
+        {
+            if (remaining <= 0m) break;
+            if (chunk.Amount <= 0m) continue;
+
+            decimal portion = Math.Min(chunk.Amount, remaining);
+            if (portion <= 0m) continue;
+
+            if (allocations.TryGetValue(chunk.CardInstanceId, out var existing))
+                allocations[chunk.CardInstanceId] = existing + portion;
+            else
+                allocations[chunk.CardInstanceId] = portion;
+
+            remaining -= portion;
+        }
+
+        return (allocations, remaining);
+    }
+
+    public static (Dictionary<string, decimal> Amounts, decimal UnattributedAmount) AttributeDamage(
+        IReadOnlyList<PoisonChunk> chunks,
+        decimal damage)
+    {
+        var allocations = new Dictionary<string, decimal>();
+        if (chunks.Count == 0 || damage <= 0m) return (allocations, damage);
+
+        decimal remaining = damage;
+        foreach (var chunk in chunks.OrderBy(c => c.Sequence))
+        {
+            if (remaining <= 0m) break;
+            if (chunk.Remaining <= 0m) continue;
+
+            decimal portion = Math.Min(chunk.Remaining, remaining);
+            if (portion <= 0m) continue;
+
+            if (allocations.TryGetValue(chunk.CardInstanceId, out var existing))
+                allocations[chunk.CardInstanceId] = existing + portion;
+            else
+                allocations[chunk.CardInstanceId] = portion;
+
+            remaining -= portion;
+        }
+
+        return (allocations, remaining);
+    }
+
+    public static decimal ApplyDecay(List<PoisonChunk> chunks, decimal decayAmount)
+    {
+        if (chunks.Count == 0 || decayAmount <= 0m) return decayAmount;
+
+        decimal remainingToDecay = decayAmount;
+        foreach (var chunk in chunks.OrderBy(c => c.Sequence))
+        {
+            if (remainingToDecay <= 0m) break;
+            if (chunk.Remaining <= 0m) continue;
+
+            decimal consumed = Math.Min(chunk.Remaining, remainingToDecay);
+            chunk.Remaining -= consumed;
+            remainingToDecay -= consumed;
+        }
+
+        chunks.RemoveAll(chunk => chunk.Remaining <= 0m);
+        return remainingToDecay;
+    }
+
+    public static decimal TotalRemaining(IReadOnlyList<PoisonChunk> chunks)
+    {
+        decimal total = 0m;
+        foreach (var chunk in chunks)
+        {
+            if (chunk.Remaining > 0m)
+                total += chunk.Remaining;
+        }
+
+        return total;
+    }
+}

--- a/Core/Properties/AssemblyInfo.cs
+++ b/Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CardUtilityStats.Core.Tests")]

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 6;
+    public const int CurrentSchemaVersion = 7;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -26,6 +26,8 @@ public class RunData
     //     files remain resumable with the new fields defaulting to 0.
     // v6: add per-effect Artifact-blocked debuff counters. Also additive;
     //     older v5 files remain resumable with the new fields defaulting to 0.
+    // v7: add per-card downstream poison damage attribution. Also additive;
+    //     older v6 files remain resumable with the new field defaulting to 0.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -179,6 +181,12 @@ public class CardAggregate
     // game's power id (e.g. "POWER.NECROBINDER_TRIGGER"), with localized
     // display text cached for tooltip rendering.
     public Dictionary<string, AppliedEffectAggregate> AppliedEffects { get; set; } = new();
+
+    // M4b: Downstream poison damage dealt by poison this card applied.
+    // Unlike TotalAmountApplied above, this tracks the poison ticks that
+    // later resolved off the target's poison stack, attributed via an
+    // ordered per-target poison source ledger during combat.
+    public decimal TotalPoisonDamageDealt { get; set; }
 
     // M3d: Per-instance lineage (when the card entered the deck and at
     // what upgrade level). Lets us distinguish between "card arrived

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -107,6 +107,7 @@ public static class RunStorage
             case 3:
             case 4:
             case 5:
+            case 6:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1242,15 +1242,23 @@ public static class RunTracker
             var owner = GetPowerReceiverCreature(power);
             if (owner == null) return;
 
+            var sourceCardInstanceId = FindNoxiousFumesEffectSourceLocked(power);
+            if (sourceCardInstanceId == null)
+            {
+                CoreMain.LogDebug(
+                    $"Noxious Fumes tick missing effect source owner={DescribeCreature(owner)} amount={power.Amount}");
+                return;
+            }
+
             int recipients = CountLikelyNoxiousFumesRecipients(power, owner);
             if (recipients <= 0) return;
 
-            _pendingNoxiousFumesApplications.RemoveAll(window => ReferenceEquals(window.Owner, owner));
+            _pendingNoxiousFumesApplications.RemoveAll(window => ReferenceEquals(window.Applier, owner));
             _pendingNoxiousFumesApplications.Add(new PendingNoxiousFumesApplicationWindow
             {
-                Owner = owner,
+                Applier = owner,
+                SourceCardInstanceId = sourceCardInstanceId,
                 RemainingApplications = recipients,
-                AmountPerApplication = power.Amount,
             });
         }
     }
@@ -1479,20 +1487,6 @@ public static class RunTracker
         });
     }
 
-    private static void RecordNoxiousFumesContributionLocked(Creature owner, string instanceId, decimal amount)
-    {
-        if (amount <= 0m) return;
-
-        _pendingCombat ??= new PendingCombat();
-        var ledger = GetOrCreateNoxiousFumesLedgerLocked(owner);
-        ledger.Chunks.Add(new PersistentContributionChunk
-        {
-            CardInstanceId = instanceId,
-            Amount = amount,
-            Sequence = ledger.NextSequence++,
-        });
-    }
-
     private static bool TryRecordNoxiousFumesPoisonApplicationLocked(
         PowerModel poisonPower,
         Creature target,
@@ -1503,30 +1497,8 @@ public static class RunTracker
 
         var window = TakePendingNoxiousFumesApplicationLocked(applier);
         if (window == null) return false;
-
-        var ledger = FindNoxiousFumesLedgerLocked(window.Owner);
-        if (ledger == null || ledger.Chunks.Count == 0)
-        {
-            CoreMain.LogDebug(
-                $"Noxious Fumes poison application missing source ledger target={DescribeCreature(target)} " +
-                $"applier={DescribeCreature(applier)} amount={amount}");
-            return false;
-        }
-
-        var (allocations, unattributed) = PoisonLedgerMath.AllocateContributions(ledger.Chunks, amount);
-        foreach (var kv in allocations)
-        {
-            RecordPoisonApplicationLocked(kv.Key, poisonPower, target, kv.Value);
-        }
-
-        if (unattributed > 0m)
-        {
-            CoreMain.LogDebug(
-                $"Noxious Fumes poison application under-attributed target={DescribeCreature(target)} " +
-                $"applier={DescribeCreature(applier)} amount={amount} remainder={unattributed}");
-        }
-
-        return allocations.Count > 0;
+        RecordPoisonApplicationLocked(window.SourceCardInstanceId, poisonPower, target, amount);
+        return true;
     }
 
     private static bool TryRecordNoxiousFumesPoisonArtifactBlockLocked(
@@ -1539,31 +1511,9 @@ public static class RunTracker
 
         var window = TakePendingNoxiousFumesApplicationLocked(applier);
         if (window == null) return false;
-
-        var ledger = FindNoxiousFumesLedgerLocked(window.Owner);
-        if (ledger == null || ledger.Chunks.Count == 0)
-        {
-            CoreMain.LogDebug(
-                $"Noxious Fumes poison Artifact block missing source ledger target={DescribeCreature(target)} " +
-                $"applier={DescribeCreature(applier)} amount={requestedAmount}");
-            return false;
-        }
-
-        var (allocations, unattributed) = PoisonLedgerMath.AllocateContributions(ledger.Chunks, requestedAmount);
         _pendingCombat ??= new PendingCombat();
-        foreach (var kv in allocations)
-        {
-            RecordArtifactBlockedEffectLocked(kv.Key, poisonPower, kv.Value);
-        }
-
-        if (unattributed > 0m)
-        {
-            CoreMain.LogDebug(
-                $"Noxious Fumes poison Artifact block under-attributed target={DescribeCreature(target)} " +
-                $"applier={DescribeCreature(applier)} amount={requestedAmount} remainder={unattributed}");
-        }
-
-        return allocations.Count > 0;
+        RecordArtifactBlockedEffectLocked(window.SourceCardInstanceId, poisonPower, requestedAmount);
+        return true;
     }
 
     private static PendingNoxiousFumesApplicationWindow? TakePendingNoxiousFumesApplicationLocked(Creature? applier)
@@ -1573,7 +1523,7 @@ public static class RunTracker
         for (int i = _pendingNoxiousFumesApplications.Count - 1; i >= 0; i--)
         {
             var window = _pendingNoxiousFumesApplications[i];
-            if (!ReferenceEquals(window.Owner, applier)) continue;
+            if (!ReferenceEquals(window.Applier, applier)) continue;
 
             window.RemainingApplications--;
             if (window.RemainingApplications <= 0)
@@ -1681,29 +1631,32 @@ public static class RunTracker
         _pendingCombat?.PoisonLedgers.RemoveAll(ledger => ReferenceEquals(ledger.Target, target));
     }
 
-    private static NoxiousFumesSourceLedger GetOrCreateNoxiousFumesLedgerLocked(Creature owner)
+    private static void TrackNoxiousFumesEffectSourceLocked(NoxiousFumesPower power, string sourceCardInstanceId)
     {
         _pendingCombat ??= new PendingCombat();
 
-        foreach (var ledger in _pendingCombat.NoxiousFumesLedgers)
+        foreach (var source in _pendingCombat.NoxiousFumesEffectSources)
         {
-            if (ReferenceEquals(ledger.Owner, owner))
-                return ledger;
+            if (!ReferenceEquals(source.Power, power)) continue;
+            source.SourceCardInstanceId = sourceCardInstanceId;
+            return;
         }
 
-        var created = new NoxiousFumesSourceLedger { Owner = owner };
-        _pendingCombat.NoxiousFumesLedgers.Add(created);
-        return created;
+        _pendingCombat.NoxiousFumesEffectSources.Add(new NoxiousFumesEffectSource
+        {
+            Power = power,
+            SourceCardInstanceId = sourceCardInstanceId,
+        });
     }
 
-    private static NoxiousFumesSourceLedger? FindNoxiousFumesLedgerLocked(Creature owner)
+    private static string? FindNoxiousFumesEffectSourceLocked(NoxiousFumesPower power)
     {
         if (_pendingCombat == null) return null;
 
-        foreach (var ledger in _pendingCombat.NoxiousFumesLedgers)
+        foreach (var source in _pendingCombat.NoxiousFumesEffectSources)
         {
-            if (ReferenceEquals(ledger.Owner, owner))
-                return ledger;
+            if (ReferenceEquals(source.Power, power))
+                return source.SourceCardInstanceId;
         }
 
         return null;
@@ -1826,8 +1779,8 @@ public static class RunTracker
                         RecordAppliedEffectLocked(instanceId, entry.Power, entry.Amount);
                     }
 
-                    if (IsNoxiousFumesPower(entry.Power) && target != null && target.IsPlayer)
-                        RecordNoxiousFumesContributionLocked(target, instanceId, entry.Amount);
+                    if (entry.Power is NoxiousFumesPower noxiousFumesPower && target != null && target.IsPlayer)
+                        TrackNoxiousFumesEffectSourceLocked(noxiousFumesPower, instanceId);
 
                     return;
                 }
@@ -2259,7 +2212,7 @@ internal class PendingCombat
     public List<CardEvent> CombatEvents { get; } = new();
     public List<BlockChunk> PlayerBlockLedger { get; } = new();
     public List<PoisonTargetLedger> PoisonLedgers { get; } = new();
-    public List<NoxiousFumesSourceLedger> NoxiousFumesLedgers { get; } = new();
+    public List<NoxiousFumesEffectSource> NoxiousFumesEffectSources { get; } = new();
     public int NextBlockSequence { get; set; }
 }
 
@@ -2287,11 +2240,10 @@ internal sealed class PoisonTargetLedger
     public int NextSequence { get; set; }
 }
 
-internal sealed class NoxiousFumesSourceLedger
+internal sealed class NoxiousFumesEffectSource
 {
-    public required Creature Owner { get; init; }
-    public List<PersistentContributionChunk> Chunks { get; } = new();
-    public int NextSequence { get; set; }
+    public required NoxiousFumesPower Power { get; init; }
+    public string SourceCardInstanceId { get; set; } = "";
 }
 
 internal sealed class PendingPoisonTick
@@ -2302,7 +2254,7 @@ internal sealed class PendingPoisonTick
 
 internal sealed class PendingNoxiousFumesApplicationWindow
 {
-    public required Creature Owner { get; init; }
+    public required Creature Applier { get; init; }
+    public string SourceCardInstanceId { get; init; } = "";
     public int RemainingApplications { get; set; }
-    public decimal AmountPerApplication { get; init; }
 }

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -44,6 +44,8 @@ public static class RunTracker
     private static CardModel? _pendingEffectSourceCard;
     private static int _pendingEffectSourceHistoryCount;
     private static readonly List<PendingPowerChangeAttempt> _pendingPowerChangeAttempts = new();
+    private static readonly List<PendingPoisonTick> _pendingPoisonTicks = new();
+    private static readonly List<PendingNoxiousFumesApplicationWindow> _pendingNoxiousFumesApplications = new();
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
 
@@ -353,6 +355,8 @@ public static class RunTracker
         _pendingEffectSourceCard = null;
         _pendingEffectSourceHistoryCount = 0;
         _pendingPowerChangeAttempts.Clear();
+        _pendingPoisonTicks.Clear();
+        _pendingNoxiousFumesApplications.Clear();
         _pendingPlayerBlockClearAmount = 0;
         _pendingPlayerBlockClearArmed = false;
     }
@@ -736,6 +740,9 @@ public static class RunTracker
                     }
                     else
                     {
+                        if (TryRecordPoisonDamage(dre))
+                            break;
+
                         if (!dre.Receiver.IsPlayer)
                         {
                             // Diagnostic: the game emitted a DamageReceivedEntry
@@ -1212,6 +1219,42 @@ public static class RunTracker
         }
     }
 
+    public static void NotePoisonTick(PoisonPower power)
+    {
+        lock (_lock)
+        {
+            var target = GetPowerReceiverCreature(power);
+            if (target == null) return;
+
+            _pendingPoisonTicks.RemoveAll(tick => ReferenceEquals(tick.Target, target));
+            _pendingPoisonTicks.Add(new PendingPoisonTick
+            {
+                Target = target,
+                ExpectedAmount = power.Amount,
+            });
+        }
+    }
+
+    public static void NoteNoxiousFumesTick(NoxiousFumesPower power)
+    {
+        lock (_lock)
+        {
+            var owner = GetPowerReceiverCreature(power);
+            if (owner == null) return;
+
+            int recipients = CountLikelyNoxiousFumesRecipients(power, owner);
+            if (recipients <= 0) return;
+
+            _pendingNoxiousFumesApplications.RemoveAll(window => ReferenceEquals(window.Owner, owner));
+            _pendingNoxiousFumesApplications.Add(new PendingNoxiousFumesApplicationWindow
+            {
+                Owner = owner,
+                RemainingApplications = recipients,
+                AmountPerApplication = power.Amount,
+            });
+        }
+    }
+
     public static void NotePowerAmountChangeAttempt(
         PowerModel power,
         decimal amount,
@@ -1242,15 +1285,18 @@ public static class RunTracker
     {
         lock (_lock)
         {
-            var attempt = TakePendingPowerChangeAttemptLocked(canonicalPower, target, applier, requestedAmount);
-
             if (modifiedAmount != 0m) return;
             if (canonicalPower.GetTypeForAmount(requestedAmount) != PowerType.Debuff) return;
             if (!WasArtifactBlock(target, modifiers)) return;
 
+            var attempt = TakePendingPowerChangeAttemptLocked(canonicalPower, target, applier, requestedAmount);
             var sourceCard = ResolvePowerChangeSourceCardLocked(attempt, applier);
             if (sourceCard == null)
             {
+                if (IsPoisonPower(canonicalPower) &&
+                    TryRecordNoxiousFumesPoisonArtifactBlockLocked(canonicalPower, target, applier, requestedAmount))
+                    return;
+
                 CoreMain.LogDebug(
                     $"Artifact-blocked debuff unattributed power={canonicalPower.Id} amount={requestedAmount} " +
                     $"target={DescribeCreature(target)} applier={DescribeCreature(applier)}");
@@ -1259,10 +1305,7 @@ public static class RunTracker
 
             _pendingCombat ??= new PendingCombat();
             var instanceId = GetOrAssignInstanceId(sourceCard);
-            var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
-            var effect = GetOrCreateAppliedEffect(agg, canonicalPower);
-            effect.TimesBlockedByArtifact++;
-            effect.TotalAmountBlockedByArtifact += requestedAmount;
+            RecordArtifactBlockedEffectLocked(instanceId, canonicalPower, requestedAmount);
         }
     }
 
@@ -1346,6 +1389,324 @@ public static class RunTracker
         {
             return false;
         }
+    }
+
+    private static Creature? GetPowerReceiverCreature(PowerModel power)
+    {
+        try
+        {
+            return power.Owner ?? power.Target;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsPoisonPower(PowerModel power)
+    {
+        try
+        {
+            if (power is PoisonPower) return true;
+            return power.Id.ToString().Contains("POISON", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsNoxiousFumesPower(PowerModel power)
+    {
+        try
+        {
+            if (power is NoxiousFumesPower) return true;
+            return power.Id.ToString().Contains("NOXIOUS_FUMES", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int CountLikelyNoxiousFumesRecipients(PowerModel power, Creature owner)
+    {
+        try
+        {
+            return power.CombatState
+                .GetOpponentsOf(owner)
+                .Count(creature => creature.IsAlive && creature.CanReceivePowers);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static void RecordAppliedEffectLocked(string instanceId, PowerModel power, decimal amount)
+    {
+        if (_pendingCombat == null || amount <= 0m) return;
+
+        var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+        var effect = GetOrCreateAppliedEffect(agg, power);
+        effect.TimesApplied++;
+        effect.TotalAmountApplied += amount;
+    }
+
+    private static void RecordArtifactBlockedEffectLocked(string instanceId, PowerModel power, decimal amount)
+    {
+        if (_pendingCombat == null || amount <= 0m) return;
+
+        var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+        var effect = GetOrCreateAppliedEffect(agg, power);
+        effect.TimesBlockedByArtifact++;
+        effect.TotalAmountBlockedByArtifact += amount;
+    }
+
+    private static void RecordPoisonApplicationLocked(string instanceId, PowerModel poisonPower, Creature target, decimal amount)
+    {
+        if (amount <= 0m) return;
+
+        _pendingCombat ??= new PendingCombat();
+        RecordAppliedEffectLocked(instanceId, poisonPower, amount);
+
+        var ledger = GetOrCreatePoisonLedgerLocked(target);
+        ledger.Chunks.Add(new PoisonChunk
+        {
+            CardInstanceId = instanceId,
+            Remaining = amount,
+            Sequence = ledger.NextSequence++,
+        });
+    }
+
+    private static void RecordNoxiousFumesContributionLocked(Creature owner, string instanceId, decimal amount)
+    {
+        if (amount <= 0m) return;
+
+        _pendingCombat ??= new PendingCombat();
+        var ledger = GetOrCreateNoxiousFumesLedgerLocked(owner);
+        ledger.Chunks.Add(new PersistentContributionChunk
+        {
+            CardInstanceId = instanceId,
+            Amount = amount,
+            Sequence = ledger.NextSequence++,
+        });
+    }
+
+    private static bool TryRecordNoxiousFumesPoisonApplicationLocked(
+        PowerModel poisonPower,
+        Creature target,
+        Creature? applier,
+        decimal amount)
+    {
+        if (amount <= 0m) return false;
+
+        var window = TakePendingNoxiousFumesApplicationLocked(applier);
+        if (window == null) return false;
+
+        var ledger = FindNoxiousFumesLedgerLocked(window.Owner);
+        if (ledger == null || ledger.Chunks.Count == 0)
+        {
+            CoreMain.LogDebug(
+                $"Noxious Fumes poison application missing source ledger target={DescribeCreature(target)} " +
+                $"applier={DescribeCreature(applier)} amount={amount}");
+            return false;
+        }
+
+        var (allocations, unattributed) = PoisonLedgerMath.AllocateContributions(ledger.Chunks, amount);
+        foreach (var kv in allocations)
+        {
+            RecordPoisonApplicationLocked(kv.Key, poisonPower, target, kv.Value);
+        }
+
+        if (unattributed > 0m)
+        {
+            CoreMain.LogDebug(
+                $"Noxious Fumes poison application under-attributed target={DescribeCreature(target)} " +
+                $"applier={DescribeCreature(applier)} amount={amount} remainder={unattributed}");
+        }
+
+        return allocations.Count > 0;
+    }
+
+    private static bool TryRecordNoxiousFumesPoisonArtifactBlockLocked(
+        PowerModel poisonPower,
+        Creature target,
+        Creature? applier,
+        decimal requestedAmount)
+    {
+        if (requestedAmount <= 0m) return false;
+
+        var window = TakePendingNoxiousFumesApplicationLocked(applier);
+        if (window == null) return false;
+
+        var ledger = FindNoxiousFumesLedgerLocked(window.Owner);
+        if (ledger == null || ledger.Chunks.Count == 0)
+        {
+            CoreMain.LogDebug(
+                $"Noxious Fumes poison Artifact block missing source ledger target={DescribeCreature(target)} " +
+                $"applier={DescribeCreature(applier)} amount={requestedAmount}");
+            return false;
+        }
+
+        var (allocations, unattributed) = PoisonLedgerMath.AllocateContributions(ledger.Chunks, requestedAmount);
+        _pendingCombat ??= new PendingCombat();
+        foreach (var kv in allocations)
+        {
+            RecordArtifactBlockedEffectLocked(kv.Key, poisonPower, kv.Value);
+        }
+
+        if (unattributed > 0m)
+        {
+            CoreMain.LogDebug(
+                $"Noxious Fumes poison Artifact block under-attributed target={DescribeCreature(target)} " +
+                $"applier={DescribeCreature(applier)} amount={requestedAmount} remainder={unattributed}");
+        }
+
+        return allocations.Count > 0;
+    }
+
+    private static PendingNoxiousFumesApplicationWindow? TakePendingNoxiousFumesApplicationLocked(Creature? applier)
+    {
+        if (applier == null) return null;
+
+        for (int i = _pendingNoxiousFumesApplications.Count - 1; i >= 0; i--)
+        {
+            var window = _pendingNoxiousFumesApplications[i];
+            if (!ReferenceEquals(window.Owner, applier)) continue;
+
+            window.RemainingApplications--;
+            if (window.RemainingApplications <= 0)
+                _pendingNoxiousFumesApplications.RemoveAt(i);
+
+            return window;
+        }
+
+        return null;
+    }
+
+    private static bool TryRecordPoisonDamage(DamageReceivedEntry entry)
+    {
+        lock (_lock)
+        {
+            return TryRecordPoisonDamageLocked(entry);
+        }
+    }
+
+    private static bool TryRecordPoisonDamageLocked(DamageReceivedEntry entry)
+    {
+        PendingPoisonTick? pendingTick = null;
+        for (int i = _pendingPoisonTicks.Count - 1; i >= 0; i--)
+        {
+            var tick = _pendingPoisonTicks[i];
+            if (!ReferenceEquals(tick.Target, entry.Receiver)) continue;
+
+            pendingTick = tick;
+            _pendingPoisonTicks.RemoveAt(i);
+            break;
+        }
+
+        if (pendingTick == null) return false;
+
+        var ledger = FindPoisonLedgerLocked(entry.Receiver);
+        int effectiveDamage = Math.Max(0, entry.Result.UnblockedDamage - entry.Result.OverkillDamage);
+
+        if (ledger == null)
+        {
+            CoreMain.LogDebug(
+                $"Poison tick missing source ledger receiver={DescribeCreature(entry.Receiver)} " +
+                $"expected={pendingTick.ExpectedAmount} actual={effectiveDamage}");
+            return true;
+        }
+
+        var (allocations, unattributed) = PoisonLedgerMath.AttributeDamage(ledger.Chunks, effectiveDamage);
+        _pendingCombat ??= new PendingCombat();
+        foreach (var kv in allocations)
+        {
+            var agg = GetOrCreateAggregate(_pendingCombat, kv.Key);
+            agg.TotalPoisonDamageDealt += kv.Value;
+        }
+
+        decimal undecayed = PoisonLedgerMath.ApplyDecay(ledger.Chunks, 1m);
+        if (entry.Result.WasTargetKilled || PoisonLedgerMath.TotalRemaining(ledger.Chunks) <= 0m)
+            RemovePoisonLedgerLocked(entry.Receiver);
+
+        if (unattributed > 0m)
+        {
+            CoreMain.LogDebug(
+                $"Poison tick under-attributed receiver={DescribeCreature(entry.Receiver)} " +
+                $"damage={effectiveDamage} remainder={unattributed}");
+        }
+
+        if (undecayed > 0m)
+        {
+            CoreMain.LogDebug(
+                $"Poison tick decay underflow receiver={DescribeCreature(entry.Receiver)} " +
+                $"expectedDecay=1 remainder={undecayed}");
+        }
+
+        return true;
+    }
+
+    private static PoisonTargetLedger GetOrCreatePoisonLedgerLocked(Creature target)
+    {
+        _pendingCombat ??= new PendingCombat();
+
+        foreach (var ledger in _pendingCombat.PoisonLedgers)
+        {
+            if (ReferenceEquals(ledger.Target, target))
+                return ledger;
+        }
+
+        var created = new PoisonTargetLedger { Target = target };
+        _pendingCombat.PoisonLedgers.Add(created);
+        return created;
+    }
+
+    private static PoisonTargetLedger? FindPoisonLedgerLocked(Creature target)
+    {
+        if (_pendingCombat == null) return null;
+
+        foreach (var ledger in _pendingCombat.PoisonLedgers)
+        {
+            if (ReferenceEquals(ledger.Target, target))
+                return ledger;
+        }
+
+        return null;
+    }
+
+    private static void RemovePoisonLedgerLocked(Creature target)
+    {
+        _pendingCombat?.PoisonLedgers.RemoveAll(ledger => ReferenceEquals(ledger.Target, target));
+    }
+
+    private static NoxiousFumesSourceLedger GetOrCreateNoxiousFumesLedgerLocked(Creature owner)
+    {
+        _pendingCombat ??= new PendingCombat();
+
+        foreach (var ledger in _pendingCombat.NoxiousFumesLedgers)
+        {
+            if (ReferenceEquals(ledger.Owner, owner))
+                return ledger;
+        }
+
+        var created = new NoxiousFumesSourceLedger { Owner = owner };
+        _pendingCombat.NoxiousFumesLedgers.Add(created);
+        return created;
+    }
+
+    private static NoxiousFumesSourceLedger? FindNoxiousFumesLedgerLocked(Creature owner)
+    {
+        if (_pendingCombat == null) return null;
+
+        foreach (var ledger in _pendingCombat.NoxiousFumesLedgers)
+        {
+            if (ReferenceEquals(ledger.Owner, owner))
+                return ledger;
+        }
+
+        return null;
     }
 
     private static CardModel? FindLikelyBlockSourceCard(Creature receiver)
@@ -1447,20 +1808,38 @@ public static class RunTracker
 
             try
             {
-                var causingPlay = FindCurrentlyResolvingCardPlay();
-                if (causingPlay?.Card == null)
+                var target = GetPowerReceiverCreature(entry.Power);
+                var attempt = target != null
+                    ? TakePendingPowerChangeAttemptLocked(entry.Power, target, entry.Applier, entry.Amount)
+                    : null;
+                var sourceCard = ResolvePowerChangeSourceCardLocked(attempt, entry.Applier);
+
+                if (sourceCard != null)
                 {
-                    CoreMain.LogDebug(
-                        $"PowerReceivedEntry unattributed power={entry.Power.Id} amount={entry.Amount} " +
-                        $"applier={DescribeCreature(entry.Applier)}");
+                    var instanceId = GetOrAssignInstanceId(sourceCard);
+                    if (IsPoisonPower(entry.Power) && target != null)
+                    {
+                        RecordPoisonApplicationLocked(instanceId, entry.Power, target, entry.Amount);
+                    }
+                    else
+                    {
+                        RecordAppliedEffectLocked(instanceId, entry.Power, entry.Amount);
+                    }
+
+                    if (IsNoxiousFumesPower(entry.Power) && target != null && target.IsPlayer)
+                        RecordNoxiousFumesContributionLocked(target, instanceId, entry.Amount);
+
                     return;
                 }
 
-                var instanceId = GetOrAssignInstanceId(causingPlay.Card);
-                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
-                var effect = GetOrCreateAppliedEffect(agg, entry.Power);
-                effect.TimesApplied++;
-                effect.TotalAmountApplied += entry.Amount;
+                if (target != null &&
+                    IsPoisonPower(entry.Power) &&
+                    TryRecordNoxiousFumesPoisonApplicationLocked(entry.Power, target, entry.Applier, entry.Amount))
+                    return;
+
+                CoreMain.LogDebug(
+                    $"PowerReceivedEntry unattributed power={entry.Power.Id} amount={entry.Amount} " +
+                    $"target={DescribeCreature(target)} applier={DescribeCreature(entry.Applier)}");
             }
             catch (Exception e)
             {
@@ -1751,6 +2130,7 @@ public static class RunTracker
             TimesExhausted = source.TimesExhausted,
             TotalHpLost = source.TotalHpLost,
             TimesCardsDrawn = source.TimesCardsDrawn,
+            TotalPoisonDamageDealt = source.TotalPoisonDamageDealt,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
@@ -1782,6 +2162,7 @@ public static class RunTracker
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
+        target.TotalPoisonDamageDealt += source.TotalPoisonDamageDealt;
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 
@@ -1877,6 +2258,8 @@ internal class PendingCombat
     public Dictionary<string, CardAggregate> CombatAggregates { get; } = new();
     public List<CardEvent> CombatEvents { get; } = new();
     public List<BlockChunk> PlayerBlockLedger { get; } = new();
+    public List<PoisonTargetLedger> PoisonLedgers { get; } = new();
+    public List<NoxiousFumesSourceLedger> NoxiousFumesLedgers { get; } = new();
     public int NextBlockSequence { get; set; }
 }
 
@@ -1895,4 +2278,31 @@ internal sealed class PendingPowerChangeAttempt
     public Creature? Applier { get; init; }
     public required decimal RequestedAmount { get; init; }
     public CardModel? CardSource { get; init; }
+}
+
+internal sealed class PoisonTargetLedger
+{
+    public required Creature Target { get; init; }
+    public List<PoisonChunk> Chunks { get; } = new();
+    public int NextSequence { get; set; }
+}
+
+internal sealed class NoxiousFumesSourceLedger
+{
+    public required Creature Owner { get; init; }
+    public List<PersistentContributionChunk> Chunks { get; } = new();
+    public int NextSequence { get; set; }
+}
+
+internal sealed class PendingPoisonTick
+{
+    public required Creature Target { get; init; }
+    public decimal ExpectedAmount { get; init; }
+}
+
+internal sealed class PendingNoxiousFumesApplicationWindow
+{
+    public required Creature Owner { get; init; }
+    public int RemainingApplications { get; set; }
+    public decimal AmountPerApplication { get; init; }
 }

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -17,15 +17,18 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds absorbed/wasted block aggregates
   on top of the v4 effect and exhaust fields.
 - `v6-per-instance-artifact-block-run.json`
-  Current schema. Adds per-effect Artifact-blocked debuff counters on top of
+  Legacy-but-resumable additive schema. Adds per-effect Artifact-blocked debuff counters on top of
   the v5 block ledger fields.
+- `v7-per-instance-poison-ledger-run.json`
+  Current schema. Adds downstream poison damage attribution on top of the v6
+  artifact-block counters.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, and `v5 -> v6`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, and `v6 -> v7`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v7-per-instance-poison-ledger-run.json
+++ b/Fixtures/RunSchema/v7-per-instance-poison-ledger-run.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": 7,
+  "run_id": "fixture-v7-per-instance-poison-ledger",
+  "started_at": "2026-04-20T12:05:00Z",
+  "updated_at": "2026-04-20T12:16:00Z",
+  "ended_at": "2026-04-20T12:18:30Z",
+  "character": "SILENT",
+  "ascension": 4,
+  "floor_reached": 21,
+  "outcome": "win",
+  "game_start_time": 1713614700,
+  "aggregates": {
+    "CARD.DEFEND_KIN#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_block_gained": 10,
+      "total_block_effective": 6,
+      "total_block_wasted": 4,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {},
+      "total_poison_damage_dealt": 0,
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.BASH_KIN#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 2,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {
+        "POWER.WEAK": {
+          "effect_id": "POWER.WEAK",
+          "display_name": "Weak",
+          "icon_path": "res://art/powers/weak.png",
+          "times_applied": 1,
+          "total_amount_applied": 2,
+          "times_blocked_by_artifact": 1,
+          "total_amount_blocked_by_artifact": 2
+        }
+      },
+      "total_poison_damage_dealt": 0,
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.NOXIOUS_FUMES#1": {
+      "plays": 1,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 1,
+      "total_energy_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {
+        "POWER.NOXIOUS_FUMES": {
+          "effect_id": "POWER.NOXIOUS_FUMES",
+          "display_name": "Noxious Fumes",
+          "icon_path": "res://art/powers/noxious_fumes.png",
+          "times_applied": 1,
+          "total_amount_applied": 3,
+          "times_blocked_by_artifact": 0,
+          "total_amount_blocked_by_artifact": 0
+        },
+        "POWER.POISON": {
+          "effect_id": "POWER.POISON",
+          "display_name": "Poison",
+          "icon_path": "res://art/powers/poison.png",
+          "times_applied": 4,
+          "total_amount_applied": 12,
+          "times_blocked_by_artifact": 1,
+          "total_amount_blocked_by_artifact": 3
+        }
+      },
+      "total_poison_damage_dealt": 14,
+      "floor_added": 10,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-20T12:08:00Z",
+      "type": "card_played",
+      "card_id": "CARD.DEFEND_KIN#1",
+      "energy_spent": 1,
+      "floor": 9
+    },
+    {
+      "t": "2026-04-20T12:09:00Z",
+      "type": "card_played",
+      "card_id": "CARD.NOXIOUS_FUMES#1",
+      "energy_spent": 1,
+      "floor": 9
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.DEFEND_KIN": [
+      1
+    ],
+    "CARD.BASH_KIN": [
+      1
+    ],
+    "CARD.NOXIOUS_FUMES": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.DEFEND_KIN": 1,
+    "CARD.BASH_KIN": 1,
+    "CARD.NOXIOUS_FUMES": 1
+  }
+}

--- a/Tests/CardUtilityStats.Core.Tests/PoisonLedgerMathTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonLedgerMathTests.cs
@@ -6,22 +6,6 @@ namespace CardUtilityStats.Core.Tests;
 public class PoisonLedgerMathTests
 {
     [Fact]
-    public void AllocateContributions_SplitsAcrossSourcesInSequenceOrder()
-    {
-        var chunks = new List<PersistentContributionChunk>
-        {
-            new() { CardInstanceId = "CARD.NOXIOUS_FUMES#1", Amount = 2m, Sequence = 0 },
-            new() { CardInstanceId = "CARD.NOXIOUS_FUMES#2", Amount = 3m, Sequence = 1 },
-        };
-
-        var (amounts, remainder) = PoisonLedgerMath.AllocateContributions(chunks, 5m);
-
-        Assert.Equal(0m, remainder);
-        Assert.Equal(2m, amounts["CARD.NOXIOUS_FUMES#1"]);
-        Assert.Equal(3m, amounts["CARD.NOXIOUS_FUMES#2"]);
-    }
-
-    [Fact]
     public void PoisonDamageAndDecay_PreserveSourceLedgerAcrossTicks()
     {
         var chunks = new List<PoisonChunk>

--- a/Tests/CardUtilityStats.Core.Tests/PoisonLedgerMathTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonLedgerMathTests.cs
@@ -1,0 +1,55 @@
+using CardUtilityStats.Core;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class PoisonLedgerMathTests
+{
+    [Fact]
+    public void AllocateContributions_SplitsAcrossSourcesInSequenceOrder()
+    {
+        var chunks = new List<PersistentContributionChunk>
+        {
+            new() { CardInstanceId = "CARD.NOXIOUS_FUMES#1", Amount = 2m, Sequence = 0 },
+            new() { CardInstanceId = "CARD.NOXIOUS_FUMES#2", Amount = 3m, Sequence = 1 },
+        };
+
+        var (amounts, remainder) = PoisonLedgerMath.AllocateContributions(chunks, 5m);
+
+        Assert.Equal(0m, remainder);
+        Assert.Equal(2m, amounts["CARD.NOXIOUS_FUMES#1"]);
+        Assert.Equal(3m, amounts["CARD.NOXIOUS_FUMES#2"]);
+    }
+
+    [Fact]
+    public void PoisonDamageAndDecay_PreserveSourceLedgerAcrossTicks()
+    {
+        var chunks = new List<PoisonChunk>
+        {
+            new() { CardInstanceId = "CARD.DEADLY_POISON#1", Remaining = 3m, Sequence = 0 },
+            new() { CardInstanceId = "CARD.NOXIOUS_FUMES#1", Remaining = 2m, Sequence = 1 },
+        };
+
+        var (firstTick, firstRemainder) = PoisonLedgerMath.AttributeDamage(chunks, 5m);
+        var firstDecayRemainder = PoisonLedgerMath.ApplyDecay(chunks, 1m);
+
+        Assert.Equal(0m, firstRemainder);
+        Assert.Equal(0m, firstDecayRemainder);
+        Assert.Equal(3m, firstTick["CARD.DEADLY_POISON#1"]);
+        Assert.Equal(2m, firstTick["CARD.NOXIOUS_FUMES#1"]);
+        Assert.Equal(4m, PoisonLedgerMath.TotalRemaining(chunks));
+        Assert.Equal(2m, chunks.Single(chunk => chunk.CardInstanceId == "CARD.DEADLY_POISON#1").Remaining);
+        Assert.Equal(2m, chunks.Single(chunk => chunk.CardInstanceId == "CARD.NOXIOUS_FUMES#1").Remaining);
+
+        var (secondTick, secondRemainder) = PoisonLedgerMath.AttributeDamage(chunks, 4m);
+        var secondDecayRemainder = PoisonLedgerMath.ApplyDecay(chunks, 1m);
+
+        Assert.Equal(0m, secondRemainder);
+        Assert.Equal(0m, secondDecayRemainder);
+        Assert.Equal(2m, secondTick["CARD.DEADLY_POISON#1"]);
+        Assert.Equal(2m, secondTick["CARD.NOXIOUS_FUMES#1"]);
+        Assert.Equal(3m, PoisonLedgerMath.TotalRemaining(chunks));
+        Assert.Equal(1m, chunks.Single(chunk => chunk.CardInstanceId == "CARD.DEADLY_POISON#1").Remaining);
+        Assert.Equal(2m, chunks.Single(chunk => chunk.CardInstanceId == "CARD.NOXIOUS_FUMES#1").Remaining);
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
@@ -26,6 +26,7 @@ public class PoisonTooltipTests
         var agg = new CardAggregate
         {
             Plays = 4,
+            TotalPoisonDamageDealt = 7m,
             AppliedEffects =
             {
                 ["POWER.POISON"] = new AppliedEffectAggregate
@@ -66,8 +67,40 @@ public class PoisonTooltipTests
         Assert.Contains("[b]3[/b]", text);
         Assert.Contains("Applications", text);
         Assert.Contains("[b]4[/b]", text);
+        Assert.Contains("Poison damage", text);
+        Assert.Contains("[b]7[/b]", text);
+        Assert.Contains("Avg poison dmg", text);
+        Assert.Contains("[b]1.75[/b]", text);
         Assert.Contains("Blocked by Artifact", text);
         Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendDedicatedPoisonStats_CompactViewShowsPoisonDamageWhenPresent()
+    {
+        var agg = new CardAggregate
+        {
+            TotalPoisonDamageDealt = 5m,
+            AppliedEffects =
+            {
+                ["POWER.POISON"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.POISON",
+                    DisplayName = "Poison",
+                    TimesApplied = 2,
+                    TotalAmountApplied = 6m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        var rendered = AppendDedicatedPoisonStats(sb, agg, compact: true);
+        var text = sb.ToString();
+
+        Assert.True(rendered);
+        Assert.Contains("Poison applied", text);
+        Assert.Contains("Poison damage", text);
+        Assert.Contains("[b]5[/b]", text);
     }
 
     [Fact]

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -88,19 +88,34 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV6Fixture()
+    public void HistoricalLoad_AcceptsLegacyResumableV6Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v6-per-instance-artifact-block-run.json"));
 
         Assert.NotNull(loaded);
-        Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
-        Assert.False(loaded.IsLegacy);
+        Assert.Equal(6, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
         Assert.True(loaded.SupportsResume);
         Assert.True(loaded.HasPerInstanceIdentity);
         Assert.Equal(6, loaded.Data.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         var effect = loaded.Data.Aggregates["CARD.BASH_KIN#1"].AppliedEffects["POWER.WEAK"];
         Assert.Equal(1, effect.TimesBlockedByArtifact);
         Assert.Equal(2m, effect.TotalAmountBlockedByArtifact);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsCurrentV7Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v7-per-instance-poison-ledger-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
+        Assert.False(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        var agg = loaded.Data.Aggregates["CARD.NOXIOUS_FUMES#1"];
+        Assert.Equal(14m, agg.TotalPoisonDamageDealt);
+        Assert.Equal(12m, agg.AppliedEffects["POWER.POISON"].TotalAmountApplied);
     }
 
     [Fact]
@@ -162,16 +177,28 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV6Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV6Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v6-per-instance-artifact-block-run.json"));
 
         Assert.NotNull(resumed);
-        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        Assert.Equal(6, resumed!.SchemaVersion);
         Assert.Equal(6, resumed.Aggregates["CARD.DEFEND_KIN#1"].TotalBlockEffective);
         var effect = resumed.Aggregates["CARD.BASH_KIN#1"].AppliedEffects["POWER.WEAK"];
         Assert.Equal(1, effect.TimesBlockedByArtifact);
         Assert.Equal(2m, effect.TotalAmountBlockedByArtifact);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV7Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v7-per-instance-poison-ledger-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
+        var agg = resumed.Aggregates["CARD.NOXIOUS_FUMES#1"];
+        Assert.Equal(14m, agg.TotalPoisonDamageDealt);
+        Assert.Equal(3m, agg.AppliedEffects["POWER.POISON"].TotalAmountBlockedByArtifact);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- build on the existing poison stats work in #31 instead of re-solving generic poison attribution
- route passive poison from Noxious Fumes through the live Noxious Fumes effect, then feed that into the existing poison-applied / poison-damage tracking
- keep the per-target poison source ledger for downstream poison damage, surface poison damage in the dedicated tooltip, and add schema / fixture coverage

Note: we intentionally do not claim per-instance attribution across stacked Noxious Fumes cards. The recurring poison is treated as coming from the Noxious Fumes effect.

Advances #26 on top of #31.

## Testing
- `dotnet test C:\Users\upstairspc\Documents\Codex\2026-04-20-https-github-com-nelsong6-card-utility-3\noxious-fumes-worktree\Tests\CardUtilityStats.Core.Tests\CardUtilityStats.Core.Tests.csproj`