### PR TITLE
Use icons for Strength and Dexterity effect rows

### DIFF
--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -748,6 +748,10 @@ public static class CardHoverShowPatch
             return GetEnergyEffectLabel(label);
         if (IsStarEffect(effect))
             return GetStarEffectLabel(label);
+        if (IsStrengthEffect(effect))
+            return GetStrengthEffectLabel(effect, label);
+        if (IsDexterityEffect(effect))
+            return GetDexterityEffectLabel(effect, label);
 
         return label;
     }
@@ -805,6 +809,55 @@ public static class CardHoverShowPatch
         }
 
         return GetInlineIconStatLabel(StarIconPath, label);
+    }
+
+    private static bool IsStrengthEffect(AppliedEffectAggregate effect)
+    {
+        if (!string.IsNullOrWhiteSpace(effect.EffectId) &&
+            effect.EffectId.Contains("STRENGTH", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return !string.IsNullOrWhiteSpace(effect.DisplayName) &&
+               effect.DisplayName.Contains("Strength", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetStrengthEffectLabel(AppliedEffectAggregate effect, string label)
+    {
+        return GetDynamicIconEffectLabel(effect.IconPath, label, "Strength");
+    }
+
+    private static bool IsDexterityEffect(AppliedEffectAggregate effect)
+    {
+        if (!string.IsNullOrWhiteSpace(effect.EffectId) &&
+            effect.EffectId.Contains("DEXTERITY", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return !string.IsNullOrWhiteSpace(effect.DisplayName) &&
+               effect.DisplayName.Contains("Dexterity", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetDexterityEffectLabel(AppliedEffectAggregate effect, string label)
+    {
+        return GetDynamicIconEffectLabel(effect.IconPath, label, "Dexterity");
+    }
+
+    private static string GetDynamicIconEffectLabel(string? iconPath, string label, params string[] prefixes)
+    {
+        if (string.IsNullOrWhiteSpace(iconPath))
+            return label;
+
+        foreach (var prefix in prefixes)
+        {
+            string prefixWithSpace = $"{prefix} ";
+            if (!label.StartsWith(prefixWithSpace, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var suffix = label.Substring(prefixWithSpace.Length).Trim();
+            if (!string.IsNullOrWhiteSpace(suffix))
+                return GetInlineIconStatLabel(iconPath, suffix);
+        }
+
+        return GetInlineIconStatLabel(iconPath, label);
     }
 
     private static string FormatDecimal(decimal value)

--- a/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
@@ -199,6 +199,58 @@ public class PoisonTooltipTests
     }
 
     [Fact]
+    public void AppendAppliedEffects_UsesEffectIconForStrengthEffects()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.STRENGTH"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.STRENGTH",
+                    DisplayName = "Strength Next Turn",
+                    IconPath = "res://images/atlases/power_atlas.sprites/strength_power.tres",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 2m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: false);
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/atlases/power_atlas.sprites/strength_power.tres[/img] Next Turn", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendAppliedEffects_UsesEffectIconForDexterityEffects()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.DEXTERITY"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.DEXTERITY",
+                    DisplayName = "Dexterity Up",
+                    IconPath = "res://images/atlases/power_atlas.sprites/dexterity_power.tres",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 2m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: false);
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://images/atlases/power_atlas.sprites/dexterity_power.tres[/img] Up", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
     public void AppendDedicatedPoisonStats_CompactViewDoesNotHidePoisonOnlyArtifactBlocks()
     {
         var agg = new CardAggregate


### PR DESCRIPTION
## Summary
- use the effect's own icon path for Strength and Dexterity applied-effect rows instead of falling back to plain text
- keep the existing prefix-stripping behavior so labels like "Strength Next Turn" and "Dexterity Up" render with the icon plus the meaningful suffix
- add focused tooltip tests for both Strength and Dexterity icon rendering alongside the existing energy/star coverage

## Testing
- `dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -c Debug -p:SkipModsDeploy=true`
