### PR TITLE
Attribute power-triggered forge to the source card

### DIFF
--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1216,7 +1216,10 @@ public static class RunTracker
     /// <summary>
     /// Record forge added by a card. Sourced directly from
     /// <see cref="Patches.HookAfterForgePatch"/>, which sees the actual
-    /// forge amount passed through the game's Forge command path.
+    /// forge amount passed through the game's Forge command path. When the
+    /// forge source is a persistent power (for example Furnace or
+    /// Hammer Time), we reuse the combat-local power ownership map so the
+    /// originating card instance keeps credit for the downstream forge.
     /// </summary>
     public static void RecordForgeGranted(decimal amount, Player? forger, AbstractModel? source)
     {
@@ -1226,13 +1229,10 @@ public static class RunTracker
         {
             try
             {
-                if (source is not CardModel sourceCard) return;
-                if (forger != null && sourceCard.Owner != null
-                    && !ReferenceEquals(sourceCard.Owner, forger))
-                    return;
-
                 _pendingCombat ??= new PendingCombat();
-                var instanceId = GetOrAssignInstanceId(sourceCard);
+                var instanceId = ResolveForgeSourceInstanceIdLocked(forger, source);
+                if (string.IsNullOrWhiteSpace(instanceId)) return;
+
                 var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
                 agg.TotalForgeGenerated += amount;
 
@@ -1250,6 +1250,25 @@ public static class RunTracker
                 CoreMain.LogDebug($"RecordForgeGranted failed: {e.Message}");
             }
         }
+    }
+
+    private static string? ResolveForgeSourceInstanceIdLocked(Player? forger, AbstractModel? source)
+    {
+        if (source is CardModel sourceCard)
+        {
+            if (forger != null && sourceCard.Owner != null
+                && !ReferenceEquals(sourceCard.Owner, forger))
+                return null;
+
+            return GetOrAssignInstanceId(sourceCard);
+        }
+
+        if (source != null
+            && TryResolvePlayerPowerOwnershipLocked(source, out var ownership)
+            && ownership != null)
+            return ownership.CardInstanceId;
+
+        return null;
     }
 
     /// <summary>

--- a/Tests/CardUtilityStats.Core.Tests/RunTrackerForgeAttributionTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/RunTrackerForgeAttributionTests.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using CardUtilityStats.Core;
+using MegaCrit.Sts2.Core.Models;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class RunTrackerForgeAttributionTests
+{
+    private static readonly FieldInfo PendingCombatField =
+        typeof(RunTracker).GetField("_pendingCombat", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("_pendingCombat not found.");
+
+    private static readonly Type PendingCombatType =
+        typeof(RunTracker).Assembly.GetType("CardUtilityStats.Core.PendingCombat")
+        ?? throw new InvalidOperationException("PendingCombat type not found.");
+
+    private static readonly PropertyInfo CombatAggregatesProperty =
+        PendingCombatType.GetProperty("CombatAggregates", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CombatAggregates not found.");
+
+    private static readonly PropertyInfo CombatEventsProperty =
+        PendingCombatType.GetProperty("CombatEvents", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CombatEvents not found.");
+
+    private static readonly MethodInfo TrackPlayerPowerOwnershipLockedMethod =
+        typeof(RunTracker).GetMethod("TrackPlayerPowerOwnershipLocked", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TrackPlayerPowerOwnershipLocked not found.");
+
+    [Fact]
+    public void RecordForgeGranted_AttributesPowerTriggeredForgeToOwningCard()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = Activator.CreateInstance(PendingCombatType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create PendingCombat.");
+        PendingCombatField.SetValue(null, pendingCombat);
+
+        try
+        {
+            var power = CreatePowerModel();
+            var effect = new AppliedEffectAggregate
+            {
+                EffectId = "POWER.FURNACE",
+                DisplayName = "Furnace",
+            };
+
+            _ = TrackPlayerPowerOwnershipLockedMethod.Invoke(
+                null,
+                new object?[] { power, "CARD.FURNACE#1", effect });
+
+            RunTracker.RecordForgeGranted(4m, forger: null, source: power);
+
+            var aggregates = (Dictionary<string, CardAggregate>)(CombatAggregatesProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatAggregates returned null."));
+            var aggregate = Assert.Contains("CARD.FURNACE#1", aggregates);
+            Assert.Equal(4m, aggregate.TotalForgeGenerated);
+
+            var events = (IEnumerable<CardEvent>)(CombatEventsProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatEvents returned null."));
+            var forgeEvent = Assert.Single(events);
+            Assert.Equal("forge_gained", forgeEvent.Type);
+            Assert.Equal("CARD.FURNACE#1", forgeEvent.CardId);
+            Assert.Equal(4m, forgeEvent.ForgeGained);
+        }
+        finally
+        {
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    [Fact]
+    public void RecordForgeGranted_IgnoresUnownedPowerSources()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = Activator.CreateInstance(PendingCombatType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create PendingCombat.");
+        PendingCombatField.SetValue(null, pendingCombat);
+
+        try
+        {
+            var power = CreatePowerModel();
+
+            RunTracker.RecordForgeGranted(4m, forger: null, source: power);
+
+            var aggregates = (Dictionary<string, CardAggregate>)(CombatAggregatesProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatAggregates returned null."));
+            var events = (IEnumerable<CardEvent>)(CombatEventsProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatEvents returned null."));
+
+            Assert.Empty(aggregates);
+            Assert.Empty(events);
+        }
+        finally
+        {
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    private static PowerModel CreatePowerModel()
+    {
+        var concretePowerType = typeof(PowerModel).Assembly.GetTypes()
+            .FirstOrDefault(type => typeof(PowerModel).IsAssignableFrom(type) && !type.IsAbstract)
+            ?? throw new InvalidOperationException("No concrete PowerModel subtype found.");
+
+        return (PowerModel)RuntimeHelpers.GetUninitializedObject(concretePowerType);
+    }
+}


### PR DESCRIPTION
## Summary
- attribute forge triggered by persistent powers back to the card that applied the power
- reuse the existing combat-local power ownership map instead of adding a new lineage system
- add focused RunTracker tests for owned and unowned power-source forge

## Testing
- dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -c Debug

## Related
- refs #41