### PR TITLE
Attribute power-driven energy and stars to source cards

### DIFF
--- a/Core/Patches/PowerExecutionSourcePatch.cs
+++ b/Core/Patches/PowerExecutionSourcePatch.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Preserve the currently-executing power across async hook continuations so
+/// delayed energy/star gains can still be credited to the card that applied
+/// that power. The tracker only reads this for resource-gain attribution,
+/// so we scope the patch to power hook methods that are known to contain
+/// energy/star generation paths.
+/// </summary>
+[HarmonyPatch]
+public static class PowerExecutionSourcePatch
+{
+    private static readonly HashSet<string> TargetMethodNames = new(StringComparer.Ordinal)
+    {
+        "AfterCardDrawn",
+        "AfterCardPlayed",
+        "AfterDamageReceived",
+        "AfterEnergyReset",
+        "AfterEnergySpent",
+        "BeforeCardPlayed",
+    };
+
+    public static IEnumerable<MethodBase> TargetMethods()
+    {
+        return typeof(PowerModel).Assembly.GetTypes()
+            .Where(type => typeof(PowerModel).IsAssignableFrom(type) && !type.IsAbstract)
+            .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            .Where(method => !method.IsAbstract && TargetMethodNames.Contains(method.Name))
+            .Cast<MethodBase>();
+    }
+
+    [HarmonyPrefix]
+    public static void Prefix(PowerModel __instance)
+    {
+        RunTracker.PushExecutionSource(__instance);
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(PowerModel __instance)
+    {
+        RunTracker.PopExecutionSource(__instance);
+    }
+}

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Combat.History.Entries;
 using MegaCrit.Sts2.Core.Entities.Cards;
@@ -53,6 +54,7 @@ public static class RunTracker
     private static CardModel? _pendingEffectSourceCard;
     private static int _pendingEffectSourceHistoryCount;
     private static readonly List<PendingPowerChangeAttempt> _pendingPowerChangeAttempts = new();
+    private static readonly AsyncLocal<ExecutionSourceFrame?> _executionSourceFrame = new();
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
     private static bool _shivAvailableThisRun;
@@ -615,6 +617,7 @@ public static class RunTracker
         _pendingEffectSourceCard = null;
         _pendingEffectSourceHistoryCount = 0;
         _pendingPowerChangeAttempts.Clear();
+        _executionSourceFrame.Value = null;
         _pendingPlayerBlockClearAmount = 0;
         _pendingPlayerBlockClearArmed = false;
     }
@@ -1129,10 +1132,14 @@ public static class RunTracker
     /// which patches <c>PlayerCombatState.GainEnergy</c> and forwards the
     /// ACTUAL post-clamp delta rather than the requested amount.
     ///
-    /// Attribution rule: only count gains that happen during a live
-    /// CardPlayStartedEntry → CardPlayFinishedEntry window, and only if the
-    /// resolving card's owner matches the PlayerCombatState being modified.
-    /// This keeps relic / power / start-of-turn gains out of the card stat.
+    /// Attribution rule:
+    ///   - if an owned power is currently executing and it was originally
+    ///     applied by a card, credit the gain to that originating card
+    ///   - otherwise fall back to the currently-resolving card play
+    ///
+    /// This keeps relic / start-of-turn gains out of the card stat while
+    /// letting delayed power-driven gains (Energy Next Turn, Orbit, etc.)
+    /// still land on the card that created the power.
     /// </summary>
     public static void RecordEnergyGained(MegaCrit.Sts2.Core.Entities.Players.PlayerCombatState combatState, int amount)
     {
@@ -1142,17 +1149,9 @@ public static class RunTracker
         {
             try
             {
-                var causingPlay = FindCurrentlyResolvingCardPlay();
-                if (causingPlay?.Card == null) return;
-
-                var sourceCard = causingPlay.Card;
-                var targetPlayer = combatState._player;
-                if (targetPlayer != null && sourceCard.Owner != null
-                    && !ReferenceEquals(sourceCard.Owner, targetPlayer))
-                    return;
-
+                var instanceId = ResolveResourceGainSourceInstanceIdLocked(combatState._player);
+                if (string.IsNullOrWhiteSpace(instanceId)) return;
                 _pendingCombat ??= new PendingCombat();
-                var instanceId = GetOrAssignInstanceId(sourceCard);
                 var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
                 agg.TotalEnergyGenerated += amount;
 
@@ -1184,17 +1183,9 @@ public static class RunTracker
         {
             try
             {
-                var causingPlay = FindCurrentlyResolvingCardPlay();
-                if (causingPlay?.Card == null) return;
-
-                var sourceCard = causingPlay.Card;
-                var targetPlayer = combatState._player;
-                if (targetPlayer != null && sourceCard.Owner != null
-                    && !ReferenceEquals(sourceCard.Owner, targetPlayer))
-                    return;
-
+                var instanceId = ResolveResourceGainSourceInstanceIdLocked(combatState._player);
+                if (string.IsNullOrWhiteSpace(instanceId)) return;
                 _pendingCombat ??= new PendingCombat();
-                var instanceId = GetOrAssignInstanceId(sourceCard);
                 var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
                 agg.TotalStarsGenerated += amount;
 
@@ -1211,6 +1202,61 @@ public static class RunTracker
                 CoreMain.LogDebug($"RecordStarsGained failed: {e.Message}");
             }
         }
+    }
+
+    internal static void PushExecutionSource(AbstractModel? source)
+    {
+        if (source == null) return;
+
+        _executionSourceFrame.Value = new ExecutionSourceFrame
+        {
+            Source = source,
+            Parent = _executionSourceFrame.Value,
+        };
+    }
+
+    internal static void PopExecutionSource(AbstractModel? source)
+    {
+        if (source == null) return;
+
+        var frame = _executionSourceFrame.Value;
+        if (frame != null && ReferenceEquals(frame.Source, source))
+            _executionSourceFrame.Value = frame.Parent;
+    }
+
+    private static string? ResolveResourceGainSourceInstanceIdLocked(Player? targetPlayer)
+    {
+        var executionSource = _executionSourceFrame.Value?.Source;
+        if (executionSource != null)
+            return ResolveOwnedSourceInstanceIdLocked(executionSource, targetPlayer);
+
+        var causingPlay = FindCurrentlyResolvingCardPlay();
+        return causingPlay?.Card == null
+            ? null
+            : ResolveOwnedSourceInstanceIdLocked(causingPlay.Card, targetPlayer);
+    }
+
+    private static string? ResolveOwnedSourceInstanceIdLocked(AbstractModel source, Player? targetPlayer)
+    {
+        if (source is CardModel sourceCard)
+        {
+            if (targetPlayer != null && sourceCard.Owner != null
+                && !ReferenceEquals(sourceCard.Owner, targetPlayer))
+                return null;
+
+            return GetOrAssignInstanceId(sourceCard);
+        }
+
+        if (TryResolvePlayerPowerOwnershipLocked(source, out var ownership) && ownership != null)
+        {
+            if (targetPlayer != null && ownership.OwnerPlayer != null
+                && !ReferenceEquals(ownership.OwnerPlayer, targetPlayer))
+                return null;
+
+            return ownership.CardInstanceId;
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -1940,7 +1986,8 @@ public static class RunTracker
     private static void TrackPlayerPowerOwnershipLocked(
         PowerModel power,
         string instanceId,
-        AppliedEffectAggregate effect)
+        AppliedEffectAggregate effect,
+        Player? ownerPlayer)
     {
         if (_pendingCombat == null) return;
 
@@ -1950,6 +1997,7 @@ public static class RunTracker
             EffectId = effect.EffectId,
             DisplayName = effect.DisplayName,
             IconPath = effect.IconPath,
+            OwnerPlayer = ownerPlayer,
         };
     }
 
@@ -1976,7 +2024,8 @@ public static class RunTracker
             if (match != null &&
                 (!string.Equals(match.CardInstanceId, candidate.CardInstanceId, StringComparison.Ordinal)
                  || !string.Equals(match.DisplayName, candidate.DisplayName, StringComparison.Ordinal)
-                 || !string.Equals(match.IconPath, candidate.IconPath, StringComparison.Ordinal)))
+                 || !string.Equals(match.IconPath, candidate.IconPath, StringComparison.Ordinal)
+                 || !ReferenceEquals(match.OwnerPlayer, candidate.OwnerPlayer)))
             {
                 return false;
             }
@@ -2360,7 +2409,7 @@ public static class RunTracker
 
                 var target = TryResolvePowerReceivedTarget(entry);
                 if (target?.IsPlayer == true && entry.Amount > 0m)
-                    TrackPlayerPowerOwnershipLocked(entry.Power, instanceId, effect);
+                    TrackPlayerPowerOwnershipLocked(entry.Power, instanceId, effect, causingPlay.Card.Owner);
 
                 if (entry.Amount > 0m && IsPoisonPower(entry.Power))
                 {
@@ -3232,6 +3281,13 @@ internal sealed class PlayerPowerOwnershipShare
     public required string EffectId { get; init; }
     public required string DisplayName { get; init; }
     public string? IconPath { get; init; }
+    public Player? OwnerPlayer { get; init; }
+}
+
+internal sealed class ExecutionSourceFrame
+{
+    public required AbstractModel Source { get; init; }
+    public ExecutionSourceFrame? Parent { get; init; }
 }
 
 internal readonly record struct PoisonOwnershipKey(string CardInstanceId, string EffectId);

--- a/Tests/CardUtilityStats.Core.Tests/RunTrackerPowerResourceAttributionTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/RunTrackerPowerResourceAttributionTests.cs
@@ -1,0 +1,189 @@
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using CardUtilityStats.Core;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class RunTrackerPowerResourceAttributionTests
+{
+    private static readonly FieldInfo PendingCombatField =
+        typeof(RunTracker).GetField("_pendingCombat", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("_pendingCombat not found.");
+
+    private static readonly Type PendingCombatType =
+        typeof(RunTracker).Assembly.GetType("CardUtilityStats.Core.PendingCombat")
+        ?? throw new InvalidOperationException("PendingCombat type not found.");
+
+    private static readonly PropertyInfo CombatAggregatesProperty =
+        PendingCombatType.GetProperty("CombatAggregates", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CombatAggregates not found.");
+
+    private static readonly PropertyInfo CombatEventsProperty =
+        PendingCombatType.GetProperty("CombatEvents", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CombatEvents not found.");
+
+    private static readonly MethodInfo TrackPlayerPowerOwnershipLockedMethod =
+        typeof(RunTracker).GetMethod("TrackPlayerPowerOwnershipLocked", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TrackPlayerPowerOwnershipLocked not found.");
+
+    private static readonly MethodInfo PushExecutionSourceMethod =
+        typeof(RunTracker).GetMethod("PushExecutionSource", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("PushExecutionSource not found.");
+
+    private static readonly MethodInfo PopExecutionSourceMethod =
+        typeof(RunTracker).GetMethod("PopExecutionSource", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("PopExecutionSource not found.");
+
+    [Fact]
+    public void RecordEnergyGained_AttributesOwnedPowerSourceToTheApplyingCard()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = Activator.CreateInstance(PendingCombatType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create PendingCombat.");
+        PendingCombatField.SetValue(null, pendingCombat);
+
+        try
+        {
+            var power = CreatePowerModel();
+            var effect = new AppliedEffectAggregate
+            {
+                EffectId = "POWER.ENERGY_NEXT_TURN",
+                DisplayName = "Energy Next Turn",
+            };
+
+            _ = TrackPlayerPowerOwnershipLockedMethod.Invoke(
+                null,
+                new object?[] { power, "CARD.OUTMANEUVER#1", effect, null });
+            _ = PushExecutionSourceMethod.Invoke(null, new object?[] { power });
+
+            try
+            {
+                RunTracker.RecordEnergyGained(CreatePlayerCombatState(), 2);
+            }
+            finally
+            {
+                _ = PopExecutionSourceMethod.Invoke(null, new object?[] { power });
+            }
+
+            var aggregates = (Dictionary<string, CardAggregate>)(CombatAggregatesProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatAggregates returned null."));
+            var aggregate = Assert.Contains("CARD.OUTMANEUVER#1", aggregates);
+            Assert.Equal(2, aggregate.TotalEnergyGenerated);
+
+            var events = (IEnumerable<CardEvent>)(CombatEventsProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatEvents returned null."));
+            var energyEvent = Assert.Single(events);
+            Assert.Equal("energy_gained", energyEvent.Type);
+            Assert.Equal("CARD.OUTMANEUVER#1", energyEvent.CardId);
+            Assert.Equal(2, energyEvent.EnergyGained);
+        }
+        finally
+        {
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    [Fact]
+    public void RecordStarsGained_AttributesOwnedPowerSourceToTheApplyingCard()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = Activator.CreateInstance(PendingCombatType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create PendingCombat.");
+        PendingCombatField.SetValue(null, pendingCombat);
+
+        try
+        {
+            var power = CreatePowerModel();
+            var effect = new AppliedEffectAggregate
+            {
+                EffectId = "POWER.STAR_NEXT_TURN",
+                DisplayName = "Star Next Turn",
+            };
+
+            _ = TrackPlayerPowerOwnershipLockedMethod.Invoke(
+                null,
+                new object?[] { power, "CARD.HIDDEN_CACHE#1", effect, null });
+            _ = PushExecutionSourceMethod.Invoke(null, new object?[] { power });
+
+            try
+            {
+                RunTracker.RecordStarsGained(CreatePlayerCombatState(), 3);
+            }
+            finally
+            {
+                _ = PopExecutionSourceMethod.Invoke(null, new object?[] { power });
+            }
+
+            var aggregates = (Dictionary<string, CardAggregate>)(CombatAggregatesProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatAggregates returned null."));
+            var aggregate = Assert.Contains("CARD.HIDDEN_CACHE#1", aggregates);
+            Assert.Equal(3, aggregate.TotalStarsGenerated);
+
+            var events = (IEnumerable<CardEvent>)(CombatEventsProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatEvents returned null."));
+            var starsEvent = Assert.Single(events);
+            Assert.Equal("stars_gained", starsEvent.Type);
+            Assert.Equal("CARD.HIDDEN_CACHE#1", starsEvent.CardId);
+            Assert.Equal(3, starsEvent.StarsGained);
+        }
+        finally
+        {
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    [Fact]
+    public void RecordEnergyGained_IgnoresUnownedPowerSources()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = Activator.CreateInstance(PendingCombatType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create PendingCombat.");
+        PendingCombatField.SetValue(null, pendingCombat);
+
+        try
+        {
+            var power = CreatePowerModel();
+
+            _ = PushExecutionSourceMethod.Invoke(null, new object?[] { power });
+
+            try
+            {
+                RunTracker.RecordEnergyGained(CreatePlayerCombatState(), 2);
+            }
+            finally
+            {
+                _ = PopExecutionSourceMethod.Invoke(null, new object?[] { power });
+            }
+
+            var aggregates = (Dictionary<string, CardAggregate>)(CombatAggregatesProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatAggregates returned null."));
+            var events = (IEnumerable<CardEvent>)(CombatEventsProperty.GetValue(pendingCombat)
+                ?? throw new InvalidOperationException("CombatEvents returned null."));
+
+            Assert.Empty(aggregates);
+            Assert.Empty(events);
+        }
+        finally
+        {
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    private static PlayerCombatState CreatePlayerCombatState()
+    {
+        return (PlayerCombatState)RuntimeHelpers.GetUninitializedObject(typeof(PlayerCombatState));
+    }
+
+    private static PowerModel CreatePowerModel()
+    {
+        var concretePowerType = typeof(PowerModel).Assembly.GetTypes()
+            .FirstOrDefault(type => typeof(PowerModel).IsAssignableFrom(type) && !type.IsAbstract)
+            ?? throw new InvalidOperationException("No concrete PowerModel subtype found.");
+
+        return (PowerModel)RuntimeHelpers.GetUninitializedObject(concretePowerType);
+    }
+}


### PR DESCRIPTION
## Summary
- attribute delayed energy and star gains through owned powers instead of only the currently resolving card play
- add an async-flow-safe execution-source patch for resource-generating power hooks like Energy Next Turn, Star Next Turn, Orbit, Automation, Subroutine, and The Sealed Throne
- add focused RunTracker tests for owned and unowned power-driven resource gains

## Testing
- dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -c Debug

## Related
- refs #40
- refs #41
- refs #43