### PR TITLE
Track forge, Make It So, and Noxious Fumes outcomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attributi
   - Instance numbers never get reused within a run.
   - Combat-generated cards that do not meaningfully exist in the deck may use pooled summaries instead of fake deck-instance identities.
 - Attribution prefers observed outcomes over listed card text whenever the game can diverge from the card face.
-  - Examples already in tree: actual energy gained, Regent stars spent/gained, forge granted, observed cards drawn, Artifact-blocked debuffs, and downstream poison damage.
+  - Examples already in tree: actual energy gained, Regent stars spent/gained, forge granted, observed cards drawn, successful self-summons to hand, Artifact-blocked debuffs, and downstream poison damage.
 - Tooltip style is intentionally quiet.
   - Hand view stays compact.
   - Rows should be self-describing without noisy section headers.
@@ -47,7 +47,7 @@ This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attributi
   - avoid adding loud headers unless they clearly earn their space
 - If you add new attribution:
   - prefer empirical results over intent text
-  - be explicit when attribution is heuristic, pooled, or case-specific
+  - be explicit when attribution is heuristic, pooled, contributor-ledger based, or case-specific
 
 ## Useful Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,14 @@ This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attributi
   - Nothing is promoted to the permanent run file until combat ends.
   - Reload between combats / between floors is supported and expected.
   - Mid-combat restore is intentionally out of scope.
-- The data model is additive through schema `v8`.
+- The data model is additive through schema `v10`.
   - [Core/RunData.cs](D:/repos/CardUtilityStats/Core/RunData.cs:13) is the source of truth for the current schema.
   - [Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs](D:/repos/CardUtilityStats/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs:1) and the checked-in fixtures pin what remains resumable.
 - Card identity is per physical card when the card has stable deck identity.
   - Instance numbers never get reused within a run.
   - Combat-generated cards that do not meaningfully exist in the deck may use pooled summaries instead of fake deck-instance identities.
 - Attribution prefers observed outcomes over listed card text whenever the game can diverge from the card face.
-  - Examples already in tree: actual energy gained, Regent stars spent/gained, observed cards drawn, Artifact-blocked debuffs, and downstream poison damage.
+  - Examples already in tree: actual energy gained, Regent stars spent/gained, forge granted, observed cards drawn, Artifact-blocked debuffs, and downstream poison damage.
 - Tooltip style is intentionally quiet.
   - Hand view stays compact.
   - Rows should be self-describing without noisy section headers.

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
 
 namespace CardUtilityStats.Core.Patches;
@@ -231,6 +232,8 @@ public static class CardHoverShowPatch
             Row3(sb, "Played/Drawn", $"{agg.Plays}/{agg.TimesDrawn}", $"{playRate:F0}%");
         }
 
+        AppendMakeItSoStats(sb, cardModel, agg, compact: false);
+
         bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: false);
         AppendAppliedEffects(sb, agg, compact: false, excludePoison: hasDedicatedPoison);
         AppendArtifactBlockedSummary(sb, agg, excludePoison: hasDedicatedPoison);
@@ -250,6 +253,13 @@ public static class CardHoverShowPatch
             float avgGenerated = agg.Plays > 0 ? (float)agg.TotalStarsGenerated / agg.Plays : 0f;
             Row3(sb, GetStarStatLabel("gained"), agg.TotalStarsGenerated.ToString(), "");
             Row3(sb, GetStarStatLabel("avg gained"), $"{avgGenerated:F1}", "");
+        }
+
+        if (agg.TotalForgeGenerated > 0m)
+        {
+            decimal avgGenerated = agg.Plays > 0 ? agg.TotalForgeGenerated / agg.Plays : 0m;
+            Row3(sb, GetForgeStatLabel("gained"), FormatDecimal(agg.TotalForgeGenerated), "");
+            Row3(sb, GetForgeStatLabel("avg gained"), FormatDecimal(avgGenerated), "");
         }
 
         // Energy-spent rows — only rendered when the card's cost is actually
@@ -406,6 +416,9 @@ public static class CardHoverShowPatch
         if (agg.TotalStarsGenerated > 0)
             Row3(sb, GetStarStatLabel("gained"), agg.TotalStarsGenerated.ToString(), "");
 
+        if (agg.TotalForgeGenerated > 0m)
+            Row3(sb, GetForgeStatLabel("gained"), FormatDecimal(agg.TotalForgeGenerated), "");
+
         if (agg.TotalBlockGained > 0)
             Row3(sb, GetBlockStatLabel("gained"), agg.TotalBlockGained.ToString(), "");
 
@@ -509,15 +522,15 @@ public static class CardHoverShowPatch
 
         decimal avgPoison = agg.Plays > 0 ? poison.Value.TotalAmountApplied / agg.Plays : 0m;
 
-        Row3(sb, GetPoisonStatLabel(poison.Value, "total"), FormatDecimal(poison.Value.TotalAmountApplied), "");
-        Row3(sb, GetPoisonStatLabel(poison.Value, "avg"), FormatDecimal(avgPoison), "");
+        Row3(sb, GetPoisonStatLabel(poison.Value, "total applied"), FormatDecimal(poison.Value.TotalAmountApplied), "");
+        Row3(sb, GetPoisonStatLabel(poison.Value, "avg applied"), FormatDecimal(avgPoison), "");
         Row3(sb, GetPoisonStatLabel(poison.Value, "applications"), poison.Value.TimesApplied.ToString(), "");
 
         if (poison.Value.TotalTriggeredEffectiveDamage > 0m || poison.Value.TotalTriggeredOverkill > 0m)
         {
             decimal avgPoisonDamage = agg.Plays > 0 ? poison.Value.TotalTriggeredEffectiveDamage / agg.Plays : 0m;
             Row3(sb, GetPoisonStatLabel(poison.Value, "damage"), FormatDecimal(poison.Value.TotalTriggeredEffectiveDamage), "");
-            Row3(sb, GetPoisonStatLabel(poison.Value, "avg dmg"), FormatDecimal(avgPoisonDamage), "");
+            Row3(sb, GetPoisonStatLabel(poison.Value, "avg damage"), FormatDecimal(avgPoisonDamage), "");
 
             if (poison.Value.TotalTriggeredOverkill > 0m)
                 Row3(sb, GetPoisonStatLabel(poison.Value, "overkill"), FormatDecimal(poison.Value.TotalTriggeredOverkill), "");
@@ -604,6 +617,48 @@ public static class CardHoverShowPatch
     private static string GetStarStatLabel(string suffix)
     {
         return GetInlineIconStatLabel(StarIconPath, suffix);
+    }
+
+    private static string GetForgeStatLabel(string suffix)
+    {
+        return suffix switch
+        {
+            "avg gained" => "Forge avg",
+            _ => $"Forge {suffix}",
+        };
+    }
+
+    private static void AppendMakeItSoStats(
+        StringBuilder sb,
+        MegaCrit.Sts2.Core.Models.CardModel cardModel,
+        CardAggregate agg,
+        bool compact)
+    {
+        if (cardModel is not MakeItSo) return;
+
+        int? currentCounter = null;
+        int threshold = 0;
+        if (RunTracker.TryGetMakeItSoSkillCounter(cardModel, out var current, out var currentThreshold))
+        {
+            currentCounter = current;
+            threshold = currentThreshold;
+        }
+
+        AppendMakeItSoStats(sb, agg, compact, currentCounter, threshold);
+    }
+
+    private static void AppendMakeItSoStats(
+        StringBuilder sb,
+        CardAggregate agg,
+        bool compact,
+        int? currentCounter,
+        int threshold)
+    {
+        if (currentCounter.HasValue && threshold > 0)
+            Row3(sb, "Skill counter", $"{currentCounter.Value}/{threshold}", "");
+
+        if (!compact && agg.TimesSummonedToHand > 0)
+            Row3(sb, "Summoned to hand", agg.TimesSummonedToHand.ToString(), "");
     }
 
     private static string GetInlineIconStatLabel(string iconPath, string suffix)
@@ -732,6 +787,8 @@ public static class CardHoverShowPatch
             return GetEnergyEffectLabel(label);
         if (IsStarEffect(effect))
             return GetStarEffectLabel(label);
+        if (IsNoxiousFumesEffect(effect))
+            return GetIconBackedEffectLabel(label, effect.IconPath);
 
         return label;
     }
@@ -789,6 +846,23 @@ public static class CardHoverShowPatch
         }
 
         return GetInlineIconStatLabel(StarIconPath, label);
+    }
+
+    private static bool IsNoxiousFumesEffect(AppliedEffectAggregate effect)
+    {
+        if (!string.IsNullOrWhiteSpace(effect.EffectId) &&
+            effect.EffectId.Contains("NOXIOUS_FUMES", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return string.Equals(effect.DisplayName, "Noxious Fumes", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetIconBackedEffectLabel(string label, string? iconPath)
+    {
+        if (string.IsNullOrWhiteSpace(iconPath))
+            return label;
+
+        return GetInlineIconStatLabel(iconPath, label);
     }
 
     private static string FormatDecimal(decimal value)

--- a/Core/Patches/HookAfterCardChangedPilesPatch.cs
+++ b/Core/Patches/HookAfterCardChangedPilesPatch.cs
@@ -1,0 +1,30 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Observe the post-mutation pile-change hook so card-specific recurrence can
+/// count only successful arrivals in Hand, not attempts that got redirected
+/// elsewhere by the game (for example because the hand was full).
+/// </summary>
+[HarmonyPatch(typeof(Hook), nameof(Hook.AfterCardChangedPiles))]
+public static class HookAfterCardChangedPilesPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(CardModel card, PileType oldPile)
+    {
+        try
+        {
+            if (card == null) return;
+            RunTracker.RecordCardChangedPiles(card, oldPile);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"HookAfterCardChangedPilesPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/HookAfterForgePatch.cs
+++ b/Core/Patches/HookAfterForgePatch.cs
@@ -1,23 +1,25 @@
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Hooks;
 using MegaCrit.Sts2.Core.Models;
 
 namespace CardUtilityStats.Core.Patches;
 
 /// <summary>
-/// Preserve the originating card across Forge resolution so any immediate
-/// follow-up draws can still be credited back to that card. This covers
-/// cards like Spoils of Battle where Forge resolves in between the play
-/// and the subsequent draw effect.
+/// Track forge granted by the originating card and preserve that source across
+/// Forge resolution so immediate follow-up effects can still be credited back
+/// correctly. This covers cards like Refine Blade directly, while still
+/// preserving the older "forge in between play and draw" attribution fix.
 /// </summary>
 [HarmonyPatch(typeof(Hook), nameof(Hook.AfterForge))]
 public static class HookAfterForgePatch
 {
     [HarmonyPostfix]
-    public static void Postfix(AbstractModel source)
+    public static void Postfix(decimal amount, Player forger, AbstractModel? source)
     {
         try
         {
+            RunTracker.RecordForgeGranted(amount, forger, source);
             RunTracker.NoteEffectSource(source);
         }
         catch (System.Exception e)

--- a/Core/Patches/MakeItSoAfterCardPlayedLatePatch.cs
+++ b/Core/Patches/MakeItSoAfterCardPlayedLatePatch.cs
@@ -1,0 +1,31 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models.Cards;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Make It So does its self-recurrence in <c>AfterCardPlayedLate</c> by
+/// checking how many Skill cards have finished this turn and then calling
+/// <c>CardPileCmd.Add(this, PileType.Hand)</c> on every threshold. We arm a
+/// one-shot marker here, then resolve it later from the generic
+/// pile-changed hook once we know whether the card really arrived in Hand.
+/// </summary>
+[HarmonyPatch(typeof(MakeItSo), nameof(MakeItSo.AfterCardPlayedLate))]
+public static class MakeItSoAfterCardPlayedLatePatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(MakeItSo __instance, CardPlay cardPlay)
+    {
+        try
+        {
+            if (__instance == null || cardPlay == null) return;
+            RunTracker.NoteMakeItSoSummonAttempt(__instance, cardPlay);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"MakeItSoAfterCardPlayedLatePatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/NoxiousFumesAfterSideTurnStartPatch.cs
+++ b/Core/Patches/NoxiousFumesAfterSideTurnStartPatch.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Arm a short-lived attribution window right as Noxious Fumes begins its
+/// turn-start tick. The ensuing poison applications do not carry a card
+/// source, so this hook lets the tracker route them back through the live
+/// Noxious Fumes effect source before the normal poison ledger takes over.
+/// </summary>
+[HarmonyPatch]
+public static class NoxiousFumesAfterSideTurnStartPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        var noxiousFumesType = AccessTools.TypeByName("MegaCrit.Sts2.Core.Models.Powers.NoxiousFumesPower");
+        return noxiousFumesType == null ? null : AccessTools.Method(noxiousFumesType, "AfterSideTurnStart");
+    }
+
+    [HarmonyPrefix]
+    public static void Prefix(object __instance)
+    {
+        try
+        {
+            if (__instance != null)
+                RunTracker.NoteNoxiousFumesTick(__instance);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"NoxiousFumesAfterSideTurnStartPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace CardUtilityStats.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 8;
+    public const int CurrentSchemaVersion = 10;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -33,6 +33,14 @@ public class RunData
     // v8: add Regent star-resource spend / gain tracking alongside the
     //     existing energy fields. Also additive; older v7 files remain
     //     resumable with the new fields defaulting to 0.
+    // v9: add per-card forge granted tracking so Regent forge cards can
+    //     report actual forge added, alongside the existing star and energy
+    //     resource fields. Also additive; older v8 files remain resumable
+    //     with the new field defaulting to 0.
+    // v10: add per-card "times summoned to hand" tracking for cards whose
+    //      own runtime behavior can recur them to hand (starting with
+    //      Make It So). Also additive; older v9 files remain resumable
+    //      with the new field defaulting to 0.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -128,6 +136,12 @@ public class CardAggregate
     public int TotalStarsSpent { get; set; }
     public int TotalStarsGenerated { get; set; }
 
+    // M3l: Forge granted directly by this card while it is resolving.
+    // Stored as decimal because forge values are sourced from the game's
+    // dynamic vars / command path, which are decimal-backed even when most
+    // current cards use whole numbers.
+    public decimal TotalForgeGenerated { get; set; }
+
     // M2a: Block gained (how much block this card contributed over the run,
     // summed across plays). M2b extends this with absorbed/wasted splits
     // using an ordered provenance ledger for the player's block pool.
@@ -184,6 +198,11 @@ public class CardAggregate
     // Acrobatics etc. depending on the character). Excludes turn-start
     // auto-draw via the game's FromHandDraw flag.
     public int TimesCardsDrawn { get; set; }
+
+    // M3m: Successful self-summons into Hand. Counts actual arrivals in
+    // Hand, not mere attempts, so hand-full redirects to Discard stay out
+    // of this number.
+    public int TimesSummonedToHand { get; set; }
 
     // M4a: Effect / power application summary for this specific card
     // instance. First pass tracks ONLY that the card caused a power/effect
@@ -252,7 +271,7 @@ public class AppliedEffectAggregate
 public class CardEvent
 {
     public string T { get; set; } = "";          // ISO-8601 UTC timestamp
-    public string Type { get; set; } = "";       // "card_played" | "damage_received"
+    public string Type { get; set; } = "";       // "card_played" | "damage_received" | "energy_gained" | "stars_gained" | "forge_gained"
     public string CardId { get; set; } = "";
 
     // card_played fields
@@ -261,6 +280,7 @@ public class CardEvent
     public int? EnergyGained { get; set; }       // actual energy added to the pool while this card was resolving
     public int? StarsSpent { get; set; }         // actual stars paid for this play
     public int? StarsGained { get; set; }        // actual stars added while this card was resolving
+    public decimal? ForgeGained { get; set; }    // actual forge added while this card was resolving
 
     // card_upgraded fields (and general-purpose: Floor also stamped on
     // other event types when useful). UpgradeLevel is the NEW level AFTER

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -109,6 +109,8 @@ public static class RunStorage
             case 5:
             case 6:
             case 7:
+            case 8:
+            case 9:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -9,6 +9,7 @@ using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Entities.Powers;
 using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.Rooms;
 using MegaCrit.Sts2.Core.Runs;
@@ -72,6 +73,7 @@ public static class RunTracker
     // Never decremented. If a Strike is removed, the counter stays put; the
     // next added Strike gets the NEXT number, not a reused old one.
     private static readonly Dictionary<string, int> _defCounters = new();
+    private static readonly HashSet<CardModel> _pendingMakeItSoSummons = new();
 
     /// <summary>
     /// Wire up game event subscriptions. Called by <see cref="CoreMain.Initialize"/>
@@ -358,6 +360,7 @@ public static class RunTracker
         _pendingPowerChangeAttempts.Clear();
         _pendingPlayerBlockClearAmount = 0;
         _pendingPlayerBlockClearArmed = false;
+        _pendingMakeItSoSummons.Clear();
     }
 
     /// <summary>
@@ -930,6 +933,135 @@ public static class RunTracker
     }
 
     /// <summary>
+    /// Record forge added by a card. Sourced directly from
+    /// <see cref="Patches.HookAfterForgePatch"/>, which sees the actual
+    /// forge amount passed through the game's Forge command path.
+    /// </summary>
+    public static void RecordForgeGranted(decimal amount, Player? forger, AbstractModel? source)
+    {
+        if (amount <= 0m) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (source is not CardModel sourceCard) return;
+                if (forger != null && sourceCard.Owner != null
+                    && !ReferenceEquals(sourceCard.Owner, forger))
+                    return;
+
+                _pendingCombat ??= new PendingCombat();
+                var instanceId = GetOrAssignInstanceId(sourceCard);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                agg.TotalForgeGenerated += amount;
+
+                _pendingCombat.CombatEvents.Add(new CardEvent
+                {
+                    T = Now(),
+                    Type = "forge_gained",
+                    CardId = instanceId,
+                    ForgeGained = amount,
+                    Floor = RunManager.Instance?.State?.TotalFloor,
+                });
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordForgeGranted failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Arm a one-shot marker when Make It So is about to try recurring itself
+    /// to Hand. The actual count increments only after the game confirms the
+    /// pile change, so hand-full redirects to Discard do not count.
+    /// </summary>
+    public static void NoteMakeItSoSummonAttempt(MakeItSo makeItSo, CardPlay cardPlay)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (makeItSo.Owner == null || cardPlay?.Card == null) return;
+                if (!ReferenceEquals(cardPlay.Card.Owner, makeItSo.Owner)) return;
+                if (cardPlay.Card.Type != CardType.Skill) return;
+                if (makeItSo.Pile?.Type == PileType.Hand) return;
+
+                int threshold = GetMakeItSoThreshold(makeItSo);
+                if (threshold <= 0) return;
+
+                int skillsPlayedThisTurn = CountSkillsPlayedThisTurnLocked(
+                    makeItSo.Owner,
+                    makeItSo.CombatState ?? cardPlay.Card.CombatState);
+                if (skillsPlayedThisTurn <= 0 || skillsPlayedThisTurn % threshold != 0)
+                    return;
+
+                _pendingMakeItSoSummons.Add(Canonical(makeItSo));
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"NoteMakeItSoSummonAttempt failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolve a pending Make It So summon attempt after the card's pile has
+    /// actually changed. Only a real arrival in Hand counts.
+    /// </summary>
+    public static void RecordCardChangedPiles(CardModel card, PileType oldPile)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (_pendingMakeItSoSummons.Count == 0) return;
+                if (card is not MakeItSo) return;
+                if (oldPile == PileType.Hand) return;
+
+                var key = Canonical(card);
+                if (!_pendingMakeItSoSummons.Remove(key)) return;
+                if (card.Pile?.Type != PileType.Hand) return;
+
+                _pendingCombat ??= new PendingCombat();
+                var instanceId = GetOrAssignInstanceId(card);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                agg.TimesSummonedToHand++;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordCardChangedPiles failed: {e.Message}");
+            }
+        }
+    }
+
+    public static bool TryGetMakeItSoSkillCounter(CardModel card, out int currentCount, out int threshold)
+    {
+        lock (_lock)
+        {
+            currentCount = 0;
+            threshold = 0;
+
+            try
+            {
+                threshold = GetMakeItSoThreshold(card);
+                if (threshold <= 0) return false;
+                if (card.Owner == null || card.CombatState == null) return false;
+                if (CombatManager.Instance == null || !CombatManager.Instance.IsInProgress) return false;
+
+                int skillsPlayedThisTurn = CountSkillsPlayedThisTurnLocked(card.Owner, card.CombatState);
+                currentCount = skillsPlayedThisTurn % threshold;
+                return true;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"TryGetMakeItSoSkillCounter failed: {e.Message}");
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
     /// Log a card upgrade to the run's event stream. Called from the
     /// <see cref="Patches.CardUpgradePatch"/> Harmony postfix — fires for
     /// every upgrade path (rest site, Armaments in combat, events that
@@ -1285,6 +1417,67 @@ public static class RunTracker
         }
     }
 
+    public static void NoteNoxiousFumesTick(object noxiousFumesPower)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (noxiousFumesPower is not PowerModel power) return;
+
+                var owner = GetPowerReceiverCreature(power);
+                if (owner == null) return;
+
+                _pendingCombat ??= new PendingCombat();
+                if (!_pendingCombat.NoxiousFumesContributionsByPower.TryGetValue(power, out var contributions)
+                    || contributions.Count == 0)
+                {
+                    CoreMain.LogDebug(
+                        $"Noxious Fumes tick missing contribution ledger owner={DescribeCreature(owner)} amount={power.Amount}");
+                    return;
+                }
+
+                int recipients = CountLikelyNoxiousFumesRecipients(power, owner);
+                if (recipients <= 0) return;
+
+                var snapshot = contributions.Values
+                    .Where(share => share.Amount > PoisonOwnershipEpsilon)
+                    .Select(share => new NoxiousFumesContributionShare
+                    {
+                        CardInstanceId = share.CardInstanceId,
+                        Amount = share.Amount,
+                    })
+                    .ToList();
+                if (snapshot.Count == 0)
+                {
+                    CoreMain.LogDebug(
+                        $"Noxious Fumes tick had empty contribution snapshot owner={DescribeCreature(owner)} amount={power.Amount}");
+                    return;
+                }
+
+                decimal trackedTotal = snapshot.Sum(share => share.Amount);
+                if (!AreClose(trackedTotal, power.Amount))
+                {
+                    CoreMain.LogDebug(
+                        $"Noxious Fumes contribution mismatch owner={DescribeCreature(owner)} powerAmount={power.Amount} tracked={trackedTotal}");
+                }
+
+                var window = new PendingNoxiousFumesApplicationWindow
+                {
+                    RemainingApplications = recipients,
+                    ExpectedAmount = power.Amount,
+                };
+                foreach (var share in snapshot)
+                    window.Contributions.Add(share);
+                _pendingCombat.PendingNoxiousFumesApplications[owner] = window;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"NoteNoxiousFumesTick failed: {e.Message}");
+            }
+        }
+    }
+
     public static void NotePowerAmountChangeAttempt(
         PowerModel power,
         decimal amount,
@@ -1324,6 +1517,10 @@ public static class RunTracker
             var sourceCard = ResolvePowerChangeSourceCardLocked(attempt, applier);
             if (sourceCard == null)
             {
+                if (IsPoisonPower(canonicalPower)
+                    && TryRecordNoxiousFumesPoisonArtifactBlockLocked(canonicalPower, target, applier, requestedAmount))
+                    return;
+
                 CoreMain.LogDebug(
                     $"Artifact-blocked debuff unattributed power={canonicalPower.Id} amount={requestedAmount} " +
                     $"target={DescribeCreature(target)} applier={DescribeCreature(applier)}");
@@ -1332,10 +1529,7 @@ public static class RunTracker
 
             _pendingCombat ??= new PendingCombat();
             var instanceId = GetOrAssignInstanceId(sourceCard);
-            var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
-            var effect = GetOrCreateAppliedEffect(agg, canonicalPower);
-            effect.TimesBlockedByArtifact++;
-            effect.TotalAmountBlockedByArtifact += requestedAmount;
+            RecordArtifactBlockedEffectLocked(instanceId, canonicalPower, requestedAmount);
         }
     }
 
@@ -1419,6 +1613,216 @@ public static class RunTracker
         {
             return false;
         }
+    }
+
+    private static Creature? GetPowerReceiverCreature(PowerModel power)
+    {
+        try
+        {
+            return power.Owner ?? power.Target;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsNoxiousFumesPower(PowerModel power)
+    {
+        try
+        {
+            var effectId = power.Id.ToString();
+            if (effectId.Contains("NOXIOUS_FUMES", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (power.GetType().Name.Contains("NoxiousFumes", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return string.Equals(GetPowerDisplayName(power), "Noxious Fumes", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static int CountLikelyNoxiousFumesRecipients(PowerModel power, Creature owner)
+    {
+        try
+        {
+            return power.CombatState
+                .GetOpponentsOf(owner)
+                .Count(creature => creature.IsAlive && creature.CanReceivePowers);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static void RecordAppliedEffectLocked(string instanceId, PowerModel power, decimal amount)
+    {
+        if (_pendingCombat == null || amount <= 0m) return;
+
+        var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+        var effect = GetOrCreateAppliedEffect(agg, power);
+        effect.TimesApplied++;
+        effect.TotalAmountApplied += amount;
+    }
+
+    private static void RecordArtifactBlockedEffectLocked(string instanceId, PowerModel power, decimal amount)
+    {
+        if (_pendingCombat == null || amount <= 0m) return;
+
+        var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+        var effect = GetOrCreateAppliedEffect(agg, power);
+        effect.TimesBlockedByArtifact++;
+        effect.TotalAmountBlockedByArtifact += amount;
+    }
+
+    private static void RecordPoisonApplicationLocked(Creature target, string instanceId, PowerModel power, decimal amount)
+    {
+        if (target.IsPlayer || amount <= 0m) return;
+
+        _pendingCombat ??= new PendingCombat();
+        RecordAppliedEffectLocked(instanceId, power, amount);
+        AddPoisonOwnershipLocked(target, instanceId, power, amount);
+    }
+
+    private static bool TryRecordNoxiousFumesPoisonApplicationLocked(
+        PowerModel poisonPower,
+        Creature target,
+        Creature? applier,
+        decimal amount)
+    {
+        if (target.IsPlayer || amount <= 0m) return false;
+        if (!TryTakePendingNoxiousFumesApplicationWindowLocked(applier, out var window)) return false;
+        if (!TryAllocateNoxiousFumesContributions(window, amount, out var allocations, out var unattributed))
+            return false;
+
+        foreach (var allocation in allocations)
+            RecordPoisonApplicationLocked(target, allocation.CardInstanceId, poisonPower, allocation.Amount);
+
+        if (unattributed > PoisonOwnershipEpsilon)
+        {
+            CoreMain.LogDebug(
+                $"Noxious Fumes poison application under-attributed target={DescribeCreature(target)} " +
+                $"requested={amount} tracked={amount - unattributed} remainder={unattributed}");
+        }
+
+        return true;
+    }
+
+    private static bool TryRecordNoxiousFumesPoisonArtifactBlockLocked(
+        PowerModel poisonPower,
+        Creature target,
+        Creature? applier,
+        decimal requestedAmount)
+    {
+        if (target.IsPlayer || requestedAmount <= 0m) return false;
+        if (!TryTakePendingNoxiousFumesApplicationWindowLocked(applier, out var window)) return false;
+        if (!TryAllocateNoxiousFumesContributions(window, requestedAmount, out var allocations, out var unattributed))
+            return false;
+
+        _pendingCombat ??= new PendingCombat();
+        foreach (var allocation in allocations)
+            RecordArtifactBlockedEffectLocked(allocation.CardInstanceId, poisonPower, allocation.Amount);
+
+        if (unattributed > PoisonOwnershipEpsilon)
+        {
+            CoreMain.LogDebug(
+                $"Noxious Fumes Artifact block under-attributed target={DescribeCreature(target)} " +
+                $"requested={requestedAmount} tracked={requestedAmount - unattributed} remainder={unattributed}");
+        }
+
+        return true;
+    }
+
+    private static bool TryTakePendingNoxiousFumesApplicationWindowLocked(
+        Creature? applier,
+        out PendingNoxiousFumesApplicationWindow window)
+    {
+        window = null!;
+        if (_pendingCombat == null || applier == null) return false;
+        if (!_pendingCombat.PendingNoxiousFumesApplications.TryGetValue(applier, out var pendingWindow))
+            return false;
+
+        window = pendingWindow;
+        pendingWindow.RemainingApplications--;
+        if (pendingWindow.RemainingApplications <= 0)
+            _pendingCombat.PendingNoxiousFumesApplications.Remove(applier);
+
+        return true;
+    }
+
+    private static bool TryAllocateNoxiousFumesContributions(
+        PendingNoxiousFumesApplicationWindow window,
+        decimal requestedAmount,
+        out List<NoxiousFumesContributionAllocation> allocations,
+        out decimal unattributed)
+    {
+        allocations = new List<NoxiousFumesContributionAllocation>();
+        unattributed = 0m;
+
+        if (requestedAmount <= 0m) return false;
+
+        var contributors = window.Contributions
+            .Where(share => share.Amount > PoisonOwnershipEpsilon)
+            .ToList();
+        if (contributors.Count == 0) return false;
+
+        decimal trackedTotal = contributors.Sum(share => share.Amount);
+        if (trackedTotal <= PoisonOwnershipEpsilon) return false;
+
+        decimal attributableAmount = Math.Min(requestedAmount, trackedTotal);
+        decimal remainingAttributable = attributableAmount;
+        for (int i = 0; i < contributors.Count; i++)
+        {
+            var contributor = contributors[i];
+            decimal amount = i == contributors.Count - 1
+                ? remainingAttributable
+                : attributableAmount * contributor.Amount / trackedTotal;
+            remainingAttributable -= amount;
+            if (amount <= PoisonOwnershipEpsilon) continue;
+
+            allocations.Add(new NoxiousFumesContributionAllocation
+            {
+                CardInstanceId = contributor.CardInstanceId,
+                Amount = amount,
+            });
+        }
+
+        if (remainingAttributable > PoisonOwnershipEpsilon && allocations.Count > 0)
+            allocations[^1].Amount += remainingAttributable;
+
+        unattributed = Math.Max(0m, requestedAmount - attributableAmount);
+        return allocations.Count > 0;
+    }
+
+    private static void TrackNoxiousFumesContributionLocked(
+        PowerModel power,
+        string sourceCardInstanceId,
+        decimal amount)
+    {
+        if (string.IsNullOrWhiteSpace(sourceCardInstanceId) || amount <= 0m) return;
+
+        _pendingCombat ??= new PendingCombat();
+        if (!_pendingCombat.NoxiousFumesContributionsByPower.TryGetValue(power, out var contributions))
+        {
+            contributions = new Dictionary<string, NoxiousFumesContributionShare>(StringComparer.Ordinal);
+            _pendingCombat.NoxiousFumesContributionsByPower[power] = contributions;
+        }
+
+        if (!contributions.TryGetValue(sourceCardInstanceId, out var share))
+        {
+            share = new NoxiousFumesContributionShare
+            {
+                CardInstanceId = sourceCardInstanceId,
+            };
+            contributions[sourceCardInstanceId] = share;
+        }
+
+        share.Amount += amount;
     }
 
     private static CardModel? FindLikelyBlockSourceCard(Creature receiver)
@@ -1520,27 +1924,35 @@ public static class RunTracker
 
             try
             {
+                var target = TryResolvePowerReceivedTarget(entry);
                 var causingPlay = FindCurrentlyResolvingCardPlay();
                 if (causingPlay?.Card == null)
                 {
+                    if (target != null
+                        && IsPoisonPower(entry.Power)
+                        && TryRecordNoxiousFumesPoisonApplicationLocked(entry.Power, target, entry.Applier, entry.Amount))
+                        return;
+
                     CoreMain.LogDebug(
                         $"PowerReceivedEntry unattributed power={entry.Power.Id} amount={entry.Amount} " +
-                        $"applier={DescribeCreature(entry.Applier)}");
+                        $"target={DescribeCreature(target)} applier={DescribeCreature(entry.Applier)}");
                     return;
                 }
 
                 var instanceId = GetOrAssignInstanceId(causingPlay.Card);
-                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
-                var effect = GetOrCreateAppliedEffect(agg, entry.Power);
-                effect.TimesApplied++;
-                effect.TotalAmountApplied += entry.Amount;
+                if (entry.Amount > 0m
+                    && IsPoisonPower(entry.Power)
+                    && target != null
+                    && !target.IsPlayer)
+                    RecordPoisonApplicationLocked(target, instanceId, entry.Power, entry.Amount);
+                else
+                    RecordAppliedEffectLocked(instanceId, entry.Power, entry.Amount);
 
-                if (entry.Amount > 0m && IsPoisonPower(entry.Power))
-                {
-                    var target = TryResolvePowerReceivedTarget(entry);
-                    if (target != null && !target.IsPlayer)
-                        AddPoisonOwnershipLocked(target, instanceId, entry.Power, entry.Amount);
-                }
+                if (target != null
+                    && target.IsPlayer
+                    && IsNoxiousFumesPower(entry.Power)
+                    && entry.Amount > 0m)
+                    TrackNoxiousFumesContributionLocked(entry.Power, instanceId, entry.Amount);
             }
             catch (Exception e)
             {
@@ -1913,6 +2325,41 @@ public static class RunTracker
         return agg;
     }
 
+    private static int GetMakeItSoThreshold(CardModel card)
+    {
+        if (card is not MakeItSo makeItSo) return 0;
+
+        try
+        {
+            return Math.Max(0, makeItSo.DynamicVars.Cards.IntValue);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static int CountSkillsPlayedThisTurnLocked(Player owner, CombatState? combatState)
+    {
+        if (combatState == null) return 0;
+
+        try
+        {
+            var finishedPlays = CombatManager.Instance?.History?.CardPlaysFinished;
+            if (finishedPlays == null) return 0;
+
+            return finishedPlays.Count(e =>
+                e.CardPlay?.Card != null
+                && ReferenceEquals(e.CardPlay.Card.Owner, owner)
+                && e.CardPlay.Card.Type == CardType.Skill
+                && e.HappenedThisTurn(combatState));
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
     private static CardAggregate CloneAggregate(CardAggregate source)
     {
         var clone = new CardAggregate
@@ -1927,6 +2374,7 @@ public static class RunTracker
             TotalEnergyGenerated = source.TotalEnergyGenerated,
             TotalStarsSpent = source.TotalStarsSpent,
             TotalStarsGenerated = source.TotalStarsGenerated,
+            TotalForgeGenerated = source.TotalForgeGenerated,
             TotalBlockGained = source.TotalBlockGained,
             TotalBlockEffective = source.TotalBlockEffective,
             TotalBlockWasted = source.TotalBlockWasted,
@@ -1938,6 +2386,7 @@ public static class RunTracker
             TimesExhausted = source.TimesExhausted,
             TotalHpLost = source.TotalHpLost,
             TimesCardsDrawn = source.TimesCardsDrawn,
+            TimesSummonedToHand = source.TimesSummonedToHand,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
@@ -1960,6 +2409,7 @@ public static class RunTracker
         target.TotalEnergyGenerated += source.TotalEnergyGenerated;
         target.TotalStarsSpent += source.TotalStarsSpent;
         target.TotalStarsGenerated += source.TotalStarsGenerated;
+        target.TotalForgeGenerated += source.TotalForgeGenerated;
         target.TotalBlockGained += source.TotalBlockGained;
         target.TotalBlockEffective += source.TotalBlockEffective;
         target.TotalBlockWasted += source.TotalBlockWasted;
@@ -1971,6 +2421,7 @@ public static class RunTracker
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
+        target.TimesSummonedToHand += source.TimesSummonedToHand;
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 
@@ -2252,6 +2703,10 @@ internal class PendingCombat
     public Dictionary<string, CardAggregate> CombatAggregates { get; } = new();
     public List<CardEvent> CombatEvents { get; } = new();
     public List<BlockChunk> PlayerBlockLedger { get; } = new();
+    public Dictionary<PowerModel, Dictionary<string, NoxiousFumesContributionShare>> NoxiousFumesContributionsByPower { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Creature, PendingNoxiousFumesApplicationWindow> PendingNoxiousFumesApplications { get; }
+        = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Creature, Dictionary<PoisonOwnershipKey, PoisonOwnershipShare>> PoisonOwnershipByTarget { get; }
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Creature, PendingPoisonTick> PendingPoisonTicks { get; }
@@ -2291,4 +2746,23 @@ internal sealed class PoisonOwnershipShare
 internal sealed class PendingPoisonTick
 {
     public int ArmedAtHistoryCount { get; init; }
+}
+
+internal sealed class PendingNoxiousFumesApplicationWindow
+{
+    public List<NoxiousFumesContributionShare> Contributions { get; } = new();
+    public decimal ExpectedAmount { get; set; }
+    public int RemainingApplications { get; set; }
+}
+
+internal sealed class NoxiousFumesContributionShare
+{
+    public string CardInstanceId { get; set; } = "";
+    public decimal Amount { get; set; }
+}
+
+internal sealed class NoxiousFumesContributionAllocation
+{
+    public string CardInstanceId { get; set; } = "";
+    public decimal Amount { get; set; }
 }

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -23,15 +23,22 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds per-effect downstream damage and overkill counters so
   dedicated poison rows can report observed poison outcomes, not just poison applied.
 - `v8-per-instance-regent-stars-run.json`
-  Current schema. Adds Regent star-resource spend/gain fields alongside the
-  existing energy and per-instance attribution data.
+  Legacy-but-resumable additive schema. Adds Regent star-resource spend/gain
+  fields alongside the existing energy and per-instance attribution data.
+- `v9-per-instance-forge-run.json`
+  Legacy-but-resumable additive schema. Adds per-card forge granted tracking
+  alongside the existing energy, star, and per-instance attribution data.
+- `v10-per-instance-make-it-so-run.json`
+  Current schema. Adds per-card summon-to-hand tracking for cards like
+  `Make It So`, alongside the existing forge, star, and per-instance
+  attribution data.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, and `v7 -> v8`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, `v7 -> v8`, `v8 -> v9`, and `v9 -> v10`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v10-per-instance-make-it-so-run.json
+++ b/Fixtures/RunSchema/v10-per-instance-make-it-so-run.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 10,
+  "run_id": "fixture-v10-per-instance-make-it-so",
+  "started_at": "2026-04-21T12:00:00Z",
+  "updated_at": "2026-04-21T12:07:00Z",
+  "ended_at": "2026-04-21T12:09:00Z",
+  "character": "REG",
+  "ascension": 10,
+  "floor_reached": 10,
+  "outcome": "win",
+  "game_start_time": 1713700800,
+  "aggregates": {
+    "CARD.REFINE_BLADE#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 1,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 9,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_summoned_to_hand": 0,
+      "applied_effects": {
+        "POWER.ENERGY_NEXT_TURN": {
+          "effect_id": "POWER.ENERGY_NEXT_TURN",
+          "display_name": "Energy Next Turn",
+          "icon_path": "res://images/atlases/power_atlas.sprites/energy_next_turn_power.tres",
+          "times_applied": 2,
+          "total_amount_applied": 2,
+          "times_blocked_by_artifact": 0,
+          "total_amount_blocked_by_artifact": 0,
+          "total_triggered_effective_damage": 0,
+          "total_triggered_overkill": 0
+        }
+      },
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.MAKE_IT_SO#1": {
+      "plays": 1,
+      "total_intended": 12,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 12,
+      "kills": 1,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 3,
+      "times_discarded": 2,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_summoned_to_hand": 2,
+      "applied_effects": {},
+      "floor_added": 4,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-21T12:01:00Z",
+      "type": "forge_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "forge_gained": 5,
+      "floor": 4
+    },
+    {
+      "t": "2026-04-21T12:01:00Z",
+      "type": "energy_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "energy_gained": 1,
+      "floor": 4
+    },
+    {
+      "t": "2026-04-21T12:04:00Z",
+      "type": "forge_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "forge_gained": 4,
+      "floor": 7
+    },
+    {
+      "t": "2026-04-21T12:06:00Z",
+      "type": "card_played",
+      "card_id": "CARD.MAKE_IT_SO#1",
+      "energy_spent": 2,
+      "floor": 8
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.REFINE_BLADE": [
+      1
+    ],
+    "CARD.MAKE_IT_SO": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.REFINE_BLADE": 1,
+    "CARD.MAKE_IT_SO": 1
+  }
+}

--- a/Fixtures/RunSchema/v9-per-instance-forge-run.json
+++ b/Fixtures/RunSchema/v9-per-instance-forge-run.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 9,
+  "run_id": "fixture-v9-per-instance-forge",
+  "started_at": "2026-04-21T11:00:00Z",
+  "updated_at": "2026-04-21T11:06:00Z",
+  "ended_at": "2026-04-21T11:08:00Z",
+  "character": "REG",
+  "ascension": 10,
+  "floor_reached": 9,
+  "outcome": "win",
+  "game_start_time": 1713697200,
+  "aggregates": {
+    "CARD.REFINE_BLADE#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 1,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 9,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "applied_effects": {
+        "POWER.ENERGY_NEXT_TURN": {
+          "effect_id": "POWER.ENERGY_NEXT_TURN",
+          "display_name": "Energy Next Turn",
+          "icon_path": "res://images/atlases/power_atlas.sprites/energy_next_turn_power.tres",
+          "times_applied": 2,
+          "total_amount_applied": 2,
+          "times_blocked_by_artifact": 0,
+          "total_amount_blocked_by_artifact": 0,
+          "total_triggered_effective_damage": 0,
+          "total_triggered_overkill": 0
+        }
+      },
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-21T11:02:00Z",
+      "type": "forge_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "forge_gained": 5,
+      "floor": 4
+    },
+    {
+      "t": "2026-04-21T11:02:00Z",
+      "type": "energy_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "energy_gained": 1,
+      "floor": 4
+    },
+    {
+      "t": "2026-04-21T11:05:00Z",
+      "type": "forge_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "forge_gained": 4,
+      "floor": 7
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.REFINE_BLADE": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.REFINE_BLADE": 1
+  }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/). For every card you play, it tracks what actually happened: effective damage vs. overkill, block that absorbed vs. wasted, drawn cards played vs. idle, energy generated vs. unused, and effect-oriented outcomes like poison damage.
 
-**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, forge granted from cards, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
+**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, forge granted from cards, recurring summon-to-hand tracking, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
 
 For codebase orientation, start with [AGENTS.md](D:/repos/CardUtilityStats/AGENTS.md:1) and [docs/architecture.md](D:/repos/CardUtilityStats/docs/architecture.md:1).
 
@@ -54,7 +54,7 @@ Available only on in-run deck-view surfaces for now (not Compendium - lifetime a
 | **M5b** | Run History integration - browse past-run stats | [#9](https://github.com/nelsong6/card-utility-stats/issues/9) |
 | **M6** | Publish v0.1 to Nexus | - |
 
-Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, Regent star-resource tracking, forge granted tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution.
+Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, Regent star-resource tracking, forge granted tracking, recurring summon-to-hand tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution including stacked Noxious Fumes contributor preservation.
 
 Open: [#10 Run outcome detection](https://github.com/nelsong6/card-utility-stats/issues/10) - non-blocking for M1-M3, required before M6.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/). For every card you play, it tracks what actually happened: effective damage vs. overkill, block that absorbed vs. wasted, drawn cards played vs. idle, energy generated vs. unused, and effect-oriented outcomes like poison damage.
 
-**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
+**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, forge granted from cards, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
 
 For codebase orientation, start with [AGENTS.md](D:/repos/CardUtilityStats/AGENTS.md:1) and [docs/architecture.md](D:/repos/CardUtilityStats/docs/architecture.md:1).
 
@@ -54,13 +54,13 @@ Available only on in-run deck-view surfaces for now (not Compendium - lifetime a
 | **M5b** | Run History integration - browse past-run stats | [#9](https://github.com/nelsong6/card-utility-stats/issues/9) |
 | **M6** | Publish v0.1 to Nexus | - |
 
-Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, Regent star-resource tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution.
+Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, Regent star-resource tracking, forge granted tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution.
 
 Open: [#10 Run outcome detection](https://github.com/nelsong6/card-utility-stats/issues/10) - non-blocking for M1-M3, required before M6.
 
 ## Storage
 
-Per-run JSON files at `%APPDATA%/SlayTheSpire2/CardUtilityStats/runs/<run-id>.json` (Godot's `user://` path). Contains both aggregated stats (fast for UI) and a full event log (one entry per card-played / damage-received / card-upgraded / block-gained / card-removed event, for future analysis). Schema versioned - see [issue #4](https://github.com/nelsong6/card-utility-stats/issues/4). The current schema is additive through `v8`; pooled `v1` files remain history-only, while per-instance `v2` through `v8` files are resumable under the current loader. Session preferences (checkbox state) at `prefs.json` in the same dir.
+Per-run JSON files at `%APPDATA%/SlayTheSpire2/CardUtilityStats/runs/<run-id>.json` (Godot's `user://` path). Contains both aggregated stats (fast for UI) and a full event log (one entry per card-played / damage-received / card-upgraded / block-gained / card-removed event, for future analysis). Schema versioned - see [issue #4](https://github.com/nelsong6/card-utility-stats/issues/4). The current schema is additive through `v10`; pooled `v1` files remain history-only, while per-instance `v2` through `v10` files are resumable under the current loader. Session preferences (checkbox state) at `prefs.json` in the same dir.
 
 ## Requirements
 

--- a/Tests/CardUtilityStats.Core.Tests/BlockTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/BlockTooltipTests.cs
@@ -27,6 +27,10 @@ public class BlockTooltipTests
         typeof(CardHoverShowPatch).GetMethod("GetStarStatLabel", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("GetStarStatLabel not found.");
 
+    private static readonly MethodInfo GetForgeStatLabelMethod =
+        typeof(CardHoverShowPatch).GetMethod("GetForgeStatLabel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("GetForgeStatLabel not found.");
+
     private static readonly MethodInfo AppendCompactBodyMethod =
         typeof(CardHoverShowPatch).GetMethod("AppendCompactBody", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("AppendCompactBody not found.");
@@ -87,6 +91,15 @@ public class BlockTooltipTests
     }
 
     [Fact]
+    public void GetForgeStatLabel_UsesQuietTextLabel()
+    {
+        var label = (string)(GetForgeStatLabelMethod.Invoke(null, new object?[] { "gained" })
+            ?? throw new InvalidOperationException("GetForgeStatLabel returned null."));
+
+        Assert.Equal("Forge gained", label);
+    }
+
+    [Fact]
     public void AppendCompactBody_UsesDrawPowerIconForUnplayableDrawRows()
     {
         var cardModel = CreateCardModel(CardType.Curse);
@@ -139,6 +152,26 @@ public class BlockTooltipTests
 
         Assert.Contains("[img=16x16]res://images/packed/sprite_fonts/star_icon.png[/img] gained", text);
         Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendCompactBody_UsesQuietTextForForgeRows()
+    {
+        var cardModel = CreateCardModel(CardType.Skill);
+        var agg = new CardAggregate
+        {
+            Plays = 2,
+            TimesDrawn = 3,
+            TotalForgeGenerated = 6m,
+        };
+
+        var sb = new StringBuilder();
+        _ = AppendCompactBodyMethod.Invoke(null, new object?[] { sb, cardModel, agg });
+        var text = sb.ToString();
+
+        Assert.Contains("Forge gained", text);
+        Assert.DoesNotContain("[img=16x16]", text);
+        Assert.Contains("[b]6[/b]", text);
     }
 
     private static CardModel CreateCardModel(CardType type)

--- a/Tests/CardUtilityStats.Core.Tests/MakeItSoTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/MakeItSoTooltipTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using System.Text;
+using CardUtilityStats.Core;
+using CardUtilityStats.Core.Patches;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class MakeItSoTooltipTests
+{
+    private static readonly MethodInfo AppendMakeItSoStatsMethod =
+        typeof(CardHoverShowPatch).GetMethod(
+            "AppendMakeItSoStats",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(StringBuilder), typeof(CardAggregate), typeof(bool), typeof(int?), typeof(int) },
+            modifiers: null)
+        ?? throw new InvalidOperationException("AppendMakeItSoStats overload not found.");
+
+    [Fact]
+    public void AppendMakeItSoStats_RendersLiveSkillCounter()
+    {
+        var sb = new StringBuilder();
+
+        _ = AppendMakeItSoStatsMethod.Invoke(null, new object?[] { sb, new CardAggregate(), false, 2, 3 });
+        var text = sb.ToString();
+
+        Assert.Contains("Skill counter", text);
+        Assert.Contains("[b]2/3[/b]", text);
+    }
+
+    [Fact]
+    public void AppendMakeItSoStats_FullViewRendersSummonedCount()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate
+        {
+            TimesSummonedToHand = 2,
+        };
+
+        _ = AppendMakeItSoStatsMethod.Invoke(null, new object?[] { sb, agg, false, null, 0 });
+        var text = sb.ToString();
+
+        Assert.Contains("Summoned to hand", text);
+        Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendMakeItSoStats_CompactViewSkipsSummonedCount()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate
+        {
+            TimesSummonedToHand = 2,
+        };
+
+        _ = AppendMakeItSoStatsMethod.Invoke(null, new object?[] { sb, agg, true, null, 0 });
+        var text = sb.ToString();
+
+        Assert.DoesNotContain("Summoned to hand", text);
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/NoxiousFumesContributionTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/NoxiousFumesContributionTests.cs
@@ -1,0 +1,98 @@
+using System.Collections;
+using System.Reflection;
+using CardUtilityStats.Core;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class NoxiousFumesContributionTests
+{
+    private static readonly MethodInfo AllocateMethod =
+        typeof(RunTracker).GetMethod("TryAllocateNoxiousFumesContributions", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TryAllocateNoxiousFumesContributions not found.");
+
+    private static readonly Type WindowType =
+        typeof(RunTracker).Assembly.GetType("CardUtilityStats.Core.PendingNoxiousFumesApplicationWindow", throwOnError: true)
+        ?? throw new InvalidOperationException("PendingNoxiousFumesApplicationWindow type not found.");
+
+    private static readonly Type ShareType =
+        typeof(RunTracker).Assembly.GetType("CardUtilityStats.Core.NoxiousFumesContributionShare", throwOnError: true)
+        ?? throw new InvalidOperationException("NoxiousFumesContributionShare type not found.");
+
+    [Fact]
+    public void Allocate_SplitsAcrossTrackedContributors()
+    {
+        var window = CreateWindow(("CARD.NOXIOUS_FUMES#1", 2m), ("CARD.NOXIOUS_FUMES#2", 3m));
+
+        var (allocated, unattributed) = Allocate(window, 5m);
+
+        Assert.Equal(0m, unattributed);
+        Assert.Equal(2m, allocated["CARD.NOXIOUS_FUMES#1"]);
+        Assert.Equal(3m, allocated["CARD.NOXIOUS_FUMES#2"]);
+    }
+
+    [Fact]
+    public void Allocate_LeavesRemainderUnattributed_WhenTrackedTotalIsLowerThanRequested()
+    {
+        var window = CreateWindow(("CARD.NOXIOUS_FUMES#1", 2m), ("CARD.NOXIOUS_FUMES#2", 3m));
+
+        var (allocated, unattributed) = Allocate(window, 6m);
+
+        Assert.Equal(1m, unattributed);
+        Assert.Equal(2m, allocated["CARD.NOXIOUS_FUMES#1"]);
+        Assert.Equal(3m, allocated["CARD.NOXIOUS_FUMES#2"]);
+    }
+
+    [Fact]
+    public void Allocate_ScalesContributorsDown_WhenTrackedTotalExceedsRequested()
+    {
+        var window = CreateWindow(("CARD.NOXIOUS_FUMES#1", 2m), ("CARD.NOXIOUS_FUMES#2", 3m));
+
+        var (allocated, unattributed) = Allocate(window, 4m);
+
+        Assert.Equal(0m, unattributed);
+        Assert.Equal(1.6m, allocated["CARD.NOXIOUS_FUMES#1"]);
+        Assert.Equal(2.4m, allocated["CARD.NOXIOUS_FUMES#2"]);
+    }
+
+    private static object CreateWindow(params (string CardInstanceId, decimal Amount)[] shares)
+    {
+        var window = Activator.CreateInstance(WindowType)
+            ?? throw new InvalidOperationException("Failed to create pending Noxious Fumes window.");
+        var contributions = (IList)(WindowType.GetProperty("Contributions")?.GetValue(window)
+            ?? throw new InvalidOperationException("Contributions property not found."));
+
+        foreach (var (cardInstanceId, amount) in shares)
+        {
+            var share = Activator.CreateInstance(ShareType)
+                ?? throw new InvalidOperationException("Failed to create contribution share.");
+            ShareType.GetProperty("CardInstanceId")?.SetValue(share, cardInstanceId);
+            ShareType.GetProperty("Amount")?.SetValue(share, amount);
+            contributions.Add(share);
+        }
+
+        return window;
+    }
+
+    private static (Dictionary<string, decimal> Allocated, decimal Unattributed) Allocate(object window, decimal requestedAmount)
+    {
+        var args = new object?[] { window, requestedAmount, null, 0m };
+        var allocated = (bool)(AllocateMethod.Invoke(null, args)
+            ?? throw new InvalidOperationException("TryAllocateNoxiousFumesContributions returned null."));
+        Assert.True(allocated);
+
+        var result = new Dictionary<string, decimal>(StringComparer.Ordinal);
+        var allocations = (IEnumerable)(args[2] ?? throw new InvalidOperationException("Allocations out param was null."));
+        foreach (var allocation in allocations)
+        {
+            var allocationType = allocation.GetType();
+            var cardInstanceId = (string?)(allocationType.GetProperty("CardInstanceId")?.GetValue(allocation))
+                ?? throw new InvalidOperationException("Allocation CardInstanceId missing.");
+            var amount = (decimal)(allocationType.GetProperty("Amount")?.GetValue(allocation)
+                ?? throw new InvalidOperationException("Allocation Amount missing."));
+            result[cardInstanceId] = amount;
+        }
+
+        return (result, (decimal)(args[3] ?? 0m));
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/PoisonTooltipTests.cs
@@ -66,15 +66,15 @@ public class PoisonTooltipTests
 
         Assert.True(rendered);
         Assert.DoesNotContain("[color=#b5b5b5]Poison applied[/color]", text);
-        Assert.Contains("[img=16x16]res://art/powers/poison.png[/img] total", text);
+        Assert.Contains("[img=16x16]res://art/powers/poison.png[/img] total applied", text);
         Assert.Contains("[b]12[/b]", text);
-        Assert.Contains("avg", text);
+        Assert.Contains("avg applied", text);
         Assert.Contains("[b]3[/b]", text);
         Assert.Contains("applications", text);
         Assert.Contains("[b]4[/b]", text);
         Assert.Contains("damage", text);
         Assert.Contains("[b]12[/b]", text);
-        Assert.Contains("avg dmg", text);
+        Assert.Contains("avg damage", text);
         Assert.Contains("overkill", text);
         Assert.Contains("[b]2[/b]", text);
         Assert.Contains("blocked by Artifact", text);
@@ -196,6 +196,32 @@ public class PoisonTooltipTests
 
         Assert.Contains("[img=16x16]res://images/packed/sprite_fonts/star_icon.png[/img] Next Turn", text);
         Assert.Contains("[b]2[/b]", text);
+    }
+
+    [Fact]
+    public void AppendAppliedEffects_UsesPowerIconForNoxiousFumes()
+    {
+        var agg = new CardAggregate
+        {
+            AppliedEffects =
+            {
+                ["POWER.NOXIOUS_FUMES"] = new AppliedEffectAggregate
+                {
+                    EffectId = "POWER.NOXIOUS_FUMES",
+                    DisplayName = "Noxious Fumes",
+                    IconPath = "res://art/powers/noxious_fumes.png",
+                    TimesApplied = 1,
+                    TotalAmountApplied = 3m,
+                },
+            }
+        };
+
+        var sb = new StringBuilder();
+        AppendAppliedEffects(sb, agg, compact: false, excludePoison: false);
+        var text = sb.ToString();
+
+        Assert.Contains("[img=16x16]res://art/powers/noxious_fumes.png[/img] Noxious Fumes", text);
+        Assert.Contains("[b]3[/b]", text);
     }
 
     [Fact]

--- a/Tests/CardUtilityStats.Core.Tests/RunTrackerAggregateTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/RunTrackerAggregateTests.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using CardUtilityStats.Core;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+public class RunTrackerAggregateTests
+{
+    private static readonly MethodInfo CloneAggregateMethod =
+        typeof(RunTracker).GetMethod("CloneAggregate", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("CloneAggregate not found.");
+
+    private static readonly MethodInfo MergeAggregateIntoMethod =
+        typeof(RunTracker).GetMethod("MergeAggregateInto", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("MergeAggregateInto not found.");
+
+    [Fact]
+    public void CloneAggregate_CopiesTimesSummonedToHand()
+    {
+        var source = new CardAggregate
+        {
+            TimesSummonedToHand = 2,
+            TotalForgeGenerated = 9m,
+        };
+
+        var clone = (CardAggregate)(CloneAggregateMethod.Invoke(null, new object?[] { source })
+            ?? throw new InvalidOperationException("CloneAggregate returned null."));
+
+        Assert.Equal(2, clone.TimesSummonedToHand);
+        Assert.Equal(9m, clone.TotalForgeGenerated);
+    }
+
+    [Fact]
+    public void MergeAggregateInto_AddsTimesSummonedToHand()
+    {
+        var target = new CardAggregate
+        {
+            TimesSummonedToHand = 1,
+        };
+        var source = new CardAggregate
+        {
+            TimesSummonedToHand = 2,
+        };
+
+        _ = MergeAggregateIntoMethod.Invoke(null, new object?[] { target, source });
+
+        Assert.Equal(3, target.TimesSummonedToHand);
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/SchemaLoadingTests.cs
@@ -119,19 +119,50 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV8Fixture()
+    public void HistoricalLoad_AcceptsLegacyResumableV8Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v8-per-instance-regent-stars-run.json"));
 
         Assert.NotNull(loaded);
         Assert.Equal(8, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Contains("resumable", loaded.CompatibilityNote!, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
+        Assert.Equal(2, loaded.Data.Events[1].StarsSpent);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsLegacyResumableV9Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v9-per-instance-forge-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(9, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Contains("resumable", loaded.CompatibilityNote!, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(9m, loaded.Data.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
+        Assert.Equal(5m, loaded.Data.Events[0].ForgeGained);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsCurrentV10Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v10-per-instance-make-it-so-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(10, loaded!.SourceSchemaVersion);
         Assert.False(loaded.IsLegacy);
         Assert.True(loaded.SupportsResume);
         Assert.True(loaded.HasPerInstanceIdentity);
         Assert.Null(loaded.CompatibilityNote);
-        Assert.Equal(2, loaded.Data.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
-        Assert.Equal(2, loaded.Data.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
-        Assert.Equal(2, loaded.Data.Events[1].StarsSpent);
+        Assert.Equal(9m, loaded.Data.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.MAKE_IT_SO#1"].TimesSummonedToHand);
+        Assert.Equal(4m, loaded.Data.Events[2].ForgeGained);
     }
 
     [Fact]
@@ -218,7 +249,7 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV8Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV8Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v8-per-instance-regent-stars-run.json"));
 
@@ -227,6 +258,29 @@ public class SchemaLoadingTests
         Assert.Equal(2, resumed.Aggregates["CARD.VENERATE#1"].TotalStarsGenerated);
         Assert.Equal(2, resumed.Aggregates["CARD.STARDUST#1"].TotalStarsSpent);
         Assert.Equal(1, resumed.Aggregates["CARD.VENERATE#1"].TimesDrawn);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsLegacyResumableV9Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v9-per-instance-forge-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(9, resumed!.SchemaVersion);
+        Assert.Equal(9m, resumed.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
+        Assert.Equal(1, resumed.Aggregates["CARD.REFINE_BLADE#1"].TimesDrawn);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV10Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v10-per-instance-make-it-so-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(10, resumed!.SchemaVersion);
+        Assert.Equal(9m, resumed.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
+        Assert.Equal(2, resumed.Aggregates["CARD.MAKE_IT_SO#1"].TimesSummonedToHand);
+        Assert.Equal(3, resumed.Aggregates["CARD.MAKE_IT_SO#1"].TimesDrawn);
     }
 
     [Fact]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ This combat-boundary rule is important:
 
 - [Core/RunData.cs](D:/repos/CardUtilityStats/Core/RunData.cs:6) defines the serialized run shape.
 - [Core/RunStorage.cs](D:/repos/CardUtilityStats/Core/RunStorage.cs:9) handles load/save and resumability rules.
-- Schema changes are additive when possible. The current schema is `v8`.
+- Schema changes are additive when possible. The current schema is `v10`.
 
 Historical compatibility is pinned by:
 
@@ -58,6 +58,7 @@ Examples already implemented:
 - block gained / effective / wasted
 - actual energy generated
 - Regent stars spent / generated
+- forge granted from cards
 - observed cards drawn from draw effects
 - effect applications credited back to the source card
 - Artifact-blocked debuffs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,9 +60,11 @@ Examples already implemented:
 - Regent stars spent / generated
 - forge granted from cards
 - observed cards drawn from draw effects
+- successful self-summons to hand for recurring cards like Make It So
 - effect applications credited back to the source card
 - Artifact-blocked debuffs
 - downstream poison damage and poison overkill
+- stacked merged effects like Noxious Fumes preserve per-source contribution ledgers before their poison fanout is charged back into the poison ownership ledger
 
 When attribution is not naturally one-card-to-one-outcome, the code prefers:
 


### PR DESCRIPTION
## Summary
- track actual forge gained from card resolution and persist the new per-card fields through schema v9/v10 fixtures and loaders
- count Make It So self-summons only when the card really returns to hand, and surface its live skill counter plus summon totals in the tooltip
- attribute Noxious Fumes poison applications and Artifact blocks back to contributing card instances, with tooltip polish and regression coverage

## Testing
- dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -c Debug