### PR TITLE
Attribute power-driven card draw to source cards

### DIFF
--- a/Core/Patches/CardPileDrawPatch.cs
+++ b/Core/Patches/CardPileDrawPatch.cs
@@ -1,0 +1,31 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Flush any unconsumed extra turn-start draw attempts after the game's
+/// hand-draw command finishes so they cannot leak into a later draw action.
+/// Leftover attempts are recorded as blocked "other" gaps.
+/// </summary>
+[HarmonyPatch(typeof(CardPileCmd), nameof(CardPileCmd.Draw),
+    [typeof(PlayerChoiceContext), typeof(decimal), typeof(Player), typeof(bool)])]
+public static class CardPileDrawPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(Player player, bool fromHandDraw)
+    {
+        try
+        {
+            if (!fromHandDraw) return;
+            RunTracker.CompletePendingHandDraw(player);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"CardPileDrawPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/HookModifyHandDrawPatch.cs
+++ b/Core/Patches/HookModifyHandDrawPatch.cs
@@ -1,0 +1,40 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Hooks;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Bracket the game's turn-start hand-draw calculation so individual power
+/// modifier patches can report their exact deltas into a single resolution
+/// session before the actual hand-draw begins.
+/// </summary>
+[HarmonyPatch(typeof(Hook), nameof(Hook.ModifyHandDraw))]
+public static class HookModifyHandDrawPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Player player)
+    {
+        try
+        {
+            RunTracker.BeginHandDrawResolution(player);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"HookModifyHandDrawPatch failed during prefix: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(Player player)
+    {
+        try
+        {
+            RunTracker.FinalizeHandDrawResolution(player);
+        }
+        catch (System.Exception e)
+        {
+            CoreMain.Logger.Error($"HookModifyHandDrawPatch failed during postfix: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/PowerExecutionSourcePatch.cs
+++ b/Core/Patches/PowerExecutionSourcePatch.cs
@@ -8,10 +8,9 @@ namespace CardUtilityStats.Core.Patches;
 
 /// <summary>
 /// Preserve the currently-executing power across async hook continuations so
-/// delayed energy/star gains can still be credited to the card that applied
-/// that power. The tracker only reads this for resource-gain attribution,
-/// so we scope the patch to power hook methods that are known to contain
-/// energy/star generation paths.
+/// delayed follow-on effects can still be credited to the card that applied
+/// that power. This now feeds both resource attribution and direct power-
+/// driven draw attribution.
 /// </summary>
 [HarmonyPatch]
 public static class PowerExecutionSourcePatch
@@ -20,9 +19,12 @@ public static class PowerExecutionSourcePatch
     {
         "AfterCardDrawn",
         "AfterCardPlayed",
+        "AfterCardExhausted",
         "AfterDamageReceived",
         "AfterEnergyReset",
         "AfterEnergySpent",
+        "AfterPowerAmountChanged",
+        "AfterTurnEnd",
         "BeforeCardPlayed",
     };
 

--- a/Core/Patches/PowerModifyHandDrawPatch.cs
+++ b/Core/Patches/PowerModifyHandDrawPatch.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+
+namespace CardUtilityStats.Core.Patches;
+
+/// <summary>
+/// Observe concrete power overrides of <c>ModifyHandDraw</c> so we can record
+/// the exact integer draw delta each owned power contributes to the turn-
+/// start hand-draw calculation.
+/// </summary>
+[HarmonyPatch]
+public static class PowerModifyHandDrawPatch
+{
+    public static IEnumerable<MethodBase> TargetMethods()
+    {
+        return typeof(PowerModel).Assembly.GetTypes()
+            .Where(type => typeof(PowerModel).IsAssignableFrom(type) && !type.IsAbstract)
+            .Select(type => type.GetMethod(
+                nameof(AbstractModel.ModifyHandDraw),
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly,
+                binder: null,
+                [typeof(Player), typeof(decimal)],
+                modifiers: null))
+            .Where(method => method != null)
+            .Cast<MethodBase>();
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(PowerModel __instance, Player player, decimal count, decimal __result)
+    {
+        try
+        {
+            RunTracker.RecordHandDrawModification(__instance, player, count, __result);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"PowerModifyHandDrawPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -49,12 +49,14 @@ public static class RunTracker
     private static CardPlay? _currentPlayerCardPlay;
     private static CardPlay? _recentCompletedPlayerCardPlay;
     private static int _recentCompletedPlayerCardPlayHistoryCount;
-    private static CardModel? _pendingDrawSourceCard;
+    private static string? _pendingDrawSourceInstanceId;
     private static readonly List<PendingDrawAttempt> _pendingDrawAttempts = new();
+    private static readonly List<PendingHandDrawSource> _pendingHandDrawSources = new();
     private static CardModel? _pendingEffectSourceCard;
     private static int _pendingEffectSourceHistoryCount;
     private static readonly List<PendingPowerChangeAttempt> _pendingPowerChangeAttempts = new();
     private static readonly AsyncLocal<ExecutionSourceFrame?> _executionSourceFrame = new();
+    private static PendingHandDrawResolution? _pendingHandDrawResolution;
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
     private static bool _shivAvailableThisRun;
@@ -612,12 +614,14 @@ public static class RunTracker
         _currentPlayerCardPlay = null;
         _recentCompletedPlayerCardPlay = null;
         _recentCompletedPlayerCardPlayHistoryCount = 0;
-        _pendingDrawSourceCard = null;
+        _pendingDrawSourceInstanceId = null;
         _pendingDrawAttempts.Clear();
+        _pendingHandDrawSources.Clear();
         _pendingEffectSourceCard = null;
         _pendingEffectSourceHistoryCount = 0;
         _pendingPowerChangeAttempts.Clear();
         _executionSourceFrame.Value = null;
+        _pendingHandDrawResolution = null;
         _pendingPlayerBlockClearAmount = 0;
         _pendingPlayerBlockClearArmed = false;
     }
@@ -1103,7 +1107,7 @@ public static class RunTracker
             _currentPlayerCardPlay = cardPlay;
             _recentCompletedPlayerCardPlay = null;
             _recentCompletedPlayerCardPlayHistoryCount = 0;
-            _pendingDrawSourceCard = null;
+            _pendingDrawSourceInstanceId = null;
             _pendingDrawAttempts.Clear();
             _pendingEffectSourceCard = null;
             _pendingEffectSourceHistoryCount = 0;
@@ -1638,32 +1642,140 @@ public static class RunTracker
         {
             if (fromHandDraw)
             {
-                _pendingDrawSourceCard = null;
+                _pendingDrawSourceInstanceId = null;
                 return;
             }
 
             try
             {
-                _pendingDrawSourceCard = FindLikelyDrawSourceCard(player);
-                if (_pendingDrawSourceCard != null)
+                _pendingDrawSourceInstanceId = ResolveLikelyDrawSourceInstanceIdLocked(player);
+                if (_pendingDrawSourceInstanceId != null)
                 {
                     _pendingCombat ??= new PendingCombat();
-                    var sourceId = GetOrAssignInstanceId(_pendingDrawSourceCard);
-                    var sourceAgg = GetOrCreateAggregate(_pendingCombat, sourceId);
+                    var sourceAgg = GetOrCreateAggregate(_pendingCombat, _pendingDrawSourceInstanceId);
                     sourceAgg.TimesCardsDrawAttempted++;
                     _pendingDrawAttempts.Add(new PendingDrawAttempt
                     {
                         Player = player,
-                        SourceCard = _pendingDrawSourceCard,
+                        SourceInstanceId = _pendingDrawSourceInstanceId,
                     });
                 }
             }
             catch (Exception e)
             {
-                _pendingDrawSourceCard = null;
+                _pendingDrawSourceInstanceId = null;
                 _pendingDrawAttempts.Clear();
                 CoreMain.LogDebug($"NoteDrawAttempt failed: {e.Message}");
             }
+        }
+    }
+
+    internal static void BeginHandDrawResolution(Player? player)
+    {
+        if (player == null) return;
+
+        lock (_lock)
+        {
+            RemovePendingHandDrawSourcesLocked(player);
+            _pendingHandDrawResolution = new PendingHandDrawResolution
+            {
+                Player = player,
+            };
+        }
+    }
+
+    internal static void RecordHandDrawModification(AbstractModel? modifier, Player? player, decimal beforeCount, decimal afterCount)
+    {
+        if (modifier == null || player == null) return;
+
+        int delta = (int)afterCount - (int)beforeCount;
+        if (delta == 0) return;
+
+        lock (_lock)
+        {
+            if (_pendingHandDrawResolution == null
+                || !ReferenceEquals(_pendingHandDrawResolution.Player, player))
+            {
+                return;
+            }
+
+            _pendingHandDrawResolution.Modifications.Add(new HandDrawModification
+            {
+                Modifier = modifier,
+                Delta = delta,
+            });
+        }
+    }
+
+    internal static void FinalizeHandDrawResolution(Player? player)
+    {
+        if (player == null) return;
+
+        lock (_lock)
+        {
+            var resolution = _pendingHandDrawResolution;
+            _pendingHandDrawResolution = null;
+
+            if (resolution == null || !ReferenceEquals(resolution.Player, player))
+                return;
+
+            _pendingCombat ??= new PendingCombat();
+            var pendingExtraDraws = new List<string>();
+
+            foreach (var modification in resolution.Modifications)
+            {
+                if (modification.Delta > 0)
+                {
+                    if (!TryResolvePlayerPowerOwnershipLocked(modification.Modifier, out var ownership)
+                        || ownership == null)
+                    {
+                        continue;
+                    }
+
+                    if (ownership.OwnerPlayer != null && !ReferenceEquals(ownership.OwnerPlayer, player))
+                        continue;
+
+                    var sourceAgg = GetOrCreateAggregate(_pendingCombat, ownership.CardInstanceId);
+                    sourceAgg.TimesCardsDrawAttempted += modification.Delta;
+
+                    for (int i = 0; i < modification.Delta; i++)
+                        pendingExtraDraws.Add(ownership.CardInstanceId);
+
+                    continue;
+                }
+
+                int blockedCount = -modification.Delta;
+                while (blockedCount-- > 0 && pendingExtraDraws.Count > 0)
+                {
+                    string sourceInstanceId = pendingExtraDraws[^1];
+                    pendingExtraDraws.RemoveAt(pendingExtraDraws.Count - 1);
+                    RecordBlockedDrawAttemptLocked(player, sourceInstanceId, modification.Modifier);
+                }
+            }
+
+            foreach (var sourceInstanceId in pendingExtraDraws)
+            {
+                _pendingHandDrawSources.Add(new PendingHandDrawSource
+                {
+                    Player = player,
+                    SourceInstanceId = sourceInstanceId,
+                });
+            }
+        }
+    }
+
+    internal static void CompletePendingHandDraw(Player? player)
+    {
+        if (player == null) return;
+
+        lock (_lock)
+        {
+            DrainPendingHandDrawSourcesLocked(
+                player,
+                modifier: null,
+                forcedReasonId: "other",
+                forcedDisplayName: "other",
+                suppressBlockingEffect: true);
         }
     }
 
@@ -2178,24 +2290,32 @@ public static class RunTracker
         return null;
     }
 
-    private static CardModel? FindLikelyDrawSourceCard(Player targetPlayer)
+    private static string? ResolveLikelyDrawSourceInstanceIdLocked(Player targetPlayer)
     {
         if (_pendingEffectSourceCard != null && IsOwnedBy(_pendingEffectSourceCard, targetPlayer))
         {
             int historyCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
             if (historyCount == _pendingEffectSourceHistoryCount)
-                return _pendingEffectSourceCard;
+                return GetOrAssignInstanceId(_pendingEffectSourceCard);
+        }
+
+        var executionSource = _executionSourceFrame.Value?.Source;
+        if (executionSource != null)
+        {
+            var ownedSourceInstanceId = ResolveOwnedSourceInstanceIdLocked(executionSource, targetPlayer);
+            if (ownedSourceInstanceId != null)
+                return ownedSourceInstanceId;
         }
 
         var causingPlay = FindCurrentlyResolvingCardPlay();
         if (causingPlay?.Card != null && IsOwnedBy(causingPlay.Card, targetPlayer))
-            return Canonical(causingPlay.Card);
+            return GetOrAssignInstanceId(causingPlay.Card);
 
         if (_recentCompletedPlayerCardPlay?.Card != null && IsOwnedBy(_recentCompletedPlayerCardPlay.Card, targetPlayer))
         {
             int historyCount = CombatManager.Instance?.History?.Entries?.Count() ?? 0;
             if (historyCount == _recentCompletedPlayerCardPlayHistoryCount)
-                return Canonical(_recentCompletedPlayerCardPlay.Card);
+                return GetOrAssignInstanceId(_recentCompletedPlayerCardPlay.Card);
         }
 
         return null;
@@ -2234,6 +2354,60 @@ public static class RunTracker
         return true;
     }
 
+    private static bool TryConsumePendingHandDrawSource(Player? player, out PendingHandDrawSource? source)
+    {
+        source = null;
+        if (_pendingHandDrawSources.Count == 0) return false;
+
+        int index = -1;
+        if (player != null)
+        {
+            for (int i = 0; i < _pendingHandDrawSources.Count; i++)
+            {
+                if (ReferenceEquals(_pendingHandDrawSources[i].Player, player))
+                {
+                    index = i;
+                    break;
+                }
+            }
+        }
+
+        if (index < 0)
+            index = 0;
+
+        source = _pendingHandDrawSources[index];
+        _pendingHandDrawSources.RemoveAt(index);
+        return true;
+    }
+
+    private static void RemovePendingHandDrawSourcesLocked(Player player)
+    {
+        for (int i = _pendingHandDrawSources.Count - 1; i >= 0; i--)
+        {
+            if (ReferenceEquals(_pendingHandDrawSources[i].Player, player))
+                _pendingHandDrawSources.RemoveAt(i);
+        }
+    }
+
+    private static void DrainPendingHandDrawSourcesLocked(
+        Player player,
+        AbstractModel? modifier,
+        string? forcedReasonId = null,
+        string? forcedDisplayName = null,
+        bool suppressBlockingEffect = false)
+    {
+        while (TryConsumePendingHandDrawSource(player, out var pendingSource))
+        {
+            RecordBlockedDrawAttemptLocked(
+                player,
+                pendingSource!.SourceInstanceId,
+                modifier,
+                forcedReasonId,
+                forcedDisplayName,
+                suppressBlockingEffect);
+        }
+    }
+
     public static void RecordDrawFromCard(CardModel card, bool fromHandDraw)
     {
         lock (_lock)
@@ -2243,39 +2417,34 @@ public static class RunTracker
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
             agg.TimesDrawn++;
 
-            // If the draw is NOT a turn-start hand-draw (fromHandDraw=true
-            // means turn-start), it was caused by some card's play effect.
-            // Attribute to the currently-resolving play so that card can
-            // show "drew N cards this run" in its stats. Skip self-draw
-            // (drawing a card that happens to be the one being played)
-            // since that's uncommon and introduces noise.
-            if (!fromHandDraw)
+            try
             {
-                try
+                if (fromHandDraw)
                 {
-                    CardModel? sourceCard = null;
-                    if (TryConsumePendingDrawAttempt(card.Owner, out var pendingAttempt))
-                        sourceCard = pendingAttempt!.SourceCard;
-
-                    sourceCard ??= _pendingDrawSourceCard;
-                    if (sourceCard == null)
+                    if (TryConsumePendingHandDrawSource(card.Owner, out var handDrawSource)
+                        && handDrawSource != null)
                     {
-                        var causingPlay = FindCurrentlyResolvingCardPlay();
-                        sourceCard = causingPlay?.Card;
-                    }
-
-                    if (sourceCard != null
-                        && !ReferenceEquals(Canonical(sourceCard), Canonical(card)))
-                    {
-                        var causerId = GetOrAssignInstanceId(sourceCard);
-                        var causerAgg = GetOrCreateAggregate(_pendingCombat, causerId);
+                        var causerAgg = GetOrCreateAggregate(_pendingCombat, handDrawSource.SourceInstanceId);
                         causerAgg.TimesCardsDrawn++;
                     }
+
+                    return;
                 }
-                catch (Exception e)
+
+                string? sourceInstanceId = null;
+                if (TryConsumePendingDrawAttempt(card.Owner, out var pendingAttempt))
+                    sourceInstanceId = pendingAttempt!.SourceInstanceId;
+
+                sourceInstanceId ??= _pendingDrawSourceInstanceId ?? ResolveLikelyDrawSourceInstanceIdLocked(card.Owner);
+                if (sourceInstanceId != null && !string.Equals(sourceInstanceId, instanceId, StringComparison.Ordinal))
                 {
-                    CoreMain.LogDebug($"RecordDrawFromCard attribution failed: {e.Message}");
+                    var causerAgg = GetOrCreateAggregate(_pendingCombat, sourceInstanceId);
+                    causerAgg.TimesCardsDrawn++;
                 }
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordDrawFromCard attribution failed: {e.Message}");
             }
         }
     }
@@ -2284,18 +2453,22 @@ public static class RunTracker
     {
         lock (_lock)
         {
-            if (fromHandDraw) return;
-
             _pendingCombat ??= new PendingCombat();
 
             try
             {
-                CardModel? sourceCard = null;
-                if (TryConsumePendingDrawAttempt(player, out var pendingAttempt))
-                    sourceCard = pendingAttempt!.SourceCard;
+                if (fromHandDraw)
+                {
+                    DrainPendingHandDrawSourcesLocked(player, modifier);
+                    return;
+                }
 
-                sourceCard ??= _pendingDrawSourceCard ?? FindLikelyDrawSourceCard(player);
-                RecordBlockedDrawAttemptLocked(player, sourceCard, modifier);
+                string? sourceInstanceId = null;
+                if (TryConsumePendingDrawAttempt(player, out var pendingAttempt))
+                    sourceInstanceId = pendingAttempt!.SourceInstanceId;
+
+                sourceInstanceId ??= _pendingDrawSourceInstanceId ?? ResolveLikelyDrawSourceInstanceIdLocked(player);
+                RecordBlockedDrawAttemptLocked(player, sourceInstanceId, modifier);
             }
             catch (Exception e)
             {
@@ -2324,7 +2497,7 @@ public static class RunTracker
 
                 RecordBlockedDrawAttemptLocked(
                     player,
-                    pendingAttempt!.SourceCard,
+                    pendingAttempt!.SourceInstanceId,
                     modifier: null,
                     forcedReasonId: "full_hand",
                     forcedDisplayName: "hand full",
@@ -2339,7 +2512,7 @@ public static class RunTracker
 
     private static void RecordBlockedDrawAttemptLocked(
         Player player,
-        CardModel? sourceCard,
+        string? sourceInstanceId,
         AbstractModel? modifier,
         string? forcedReasonId = null,
         string? forcedDisplayName = null,
@@ -2347,10 +2520,9 @@ public static class RunTracker
     {
         bool recordedSourceBlockedDraw = false;
         CardAggregate? sourceAgg = null;
-        if (sourceCard != null)
+        if (!string.IsNullOrWhiteSpace(sourceInstanceId))
         {
-            var sourceId = GetOrAssignInstanceId(sourceCard);
-            sourceAgg = GetOrCreateAggregate(_pendingCombat!, sourceId);
+            sourceAgg = GetOrCreateAggregate(_pendingCombat!, sourceInstanceId);
             sourceAgg.TimesCardsDrawBlocked++;
             recordedSourceBlockedDraw = true;
         }
@@ -3272,7 +3444,25 @@ internal sealed class PendingPowerChangeAttempt
 internal sealed class PendingDrawAttempt
 {
     public required Player Player { get; init; }
-    public required CardModel SourceCard { get; init; }
+    public required string SourceInstanceId { get; init; }
+}
+
+internal sealed class PendingHandDrawSource
+{
+    public required Player Player { get; init; }
+    public required string SourceInstanceId { get; init; }
+}
+
+internal sealed class PendingHandDrawResolution
+{
+    public required Player Player { get; init; }
+    public List<HandDrawModification> Modifications { get; } = new();
+}
+
+internal sealed class HandDrawModification
+{
+    public required AbstractModel Modifier { get; init; }
+    public required int Delta { get; init; }
 }
 
 internal sealed class PlayerPowerOwnershipShare

--- a/Tests/CardUtilityStats.Core.Tests/RunTrackerPowerDrawAttributionTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/RunTrackerPowerDrawAttributionTests.cs
@@ -1,0 +1,303 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using CardUtilityStats.Core;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Powers;
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+[Collection("RunTrackerSerial")]
+public class RunTrackerPowerDrawAttributionTests
+{
+    private static readonly FieldInfo PendingCombatField =
+        typeof(RunTracker).GetField("_pendingCombat", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("_pendingCombat not found.");
+
+    private static readonly Type PendingCombatType =
+        typeof(RunTracker).Assembly.GetType("CardUtilityStats.Core.PendingCombat")
+        ?? throw new InvalidOperationException("PendingCombat type not found.");
+
+    private static readonly PropertyInfo CombatAggregatesProperty =
+        PendingCombatType.GetProperty("CombatAggregates", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CombatAggregates not found.");
+
+    private static readonly MethodInfo ResetCombatContextStateMethod =
+        typeof(RunTracker).GetMethod("ResetCombatContextState", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("ResetCombatContextState not found.");
+
+    private static readonly MethodInfo TrackPlayerPowerOwnershipLockedMethod =
+        typeof(RunTracker).GetMethod("TrackPlayerPowerOwnershipLocked", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("TrackPlayerPowerOwnershipLocked not found.");
+
+    private static readonly MethodInfo PushExecutionSourceMethod =
+        typeof(RunTracker).GetMethod("PushExecutionSource", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("PushExecutionSource not found.");
+
+    private static readonly MethodInfo PopExecutionSourceMethod =
+        typeof(RunTracker).GetMethod("PopExecutionSource", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("PopExecutionSource not found.");
+
+    private static readonly MethodInfo BeginHandDrawResolutionMethod =
+        typeof(RunTracker).GetMethod("BeginHandDrawResolution", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BeginHandDrawResolution not found.");
+
+    private static readonly MethodInfo RecordHandDrawModificationMethod =
+        typeof(RunTracker).GetMethod("RecordHandDrawModification", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordHandDrawModification not found.");
+
+    private static readonly MethodInfo FinalizeHandDrawResolutionMethod =
+        typeof(RunTracker).GetMethod("FinalizeHandDrawResolution", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("FinalizeHandDrawResolution not found.");
+
+    private static readonly MethodInfo CompletePendingHandDrawMethod =
+        typeof(RunTracker).GetMethod("CompletePendingHandDraw", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("CompletePendingHandDraw not found.");
+
+    private static readonly FieldInfo AbstractModelIdField =
+        typeof(AbstractModel).GetField("<Id>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("AbstractModel.Id backing field not found.");
+
+    private static readonly FieldInfo AbstractModelIsMutableField =
+        typeof(AbstractModel).GetField("<IsMutable>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("AbstractModel.IsMutable backing field not found.");
+
+    private static readonly FieldInfo CardOwnerField =
+        typeof(CardModel).GetField("_owner", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CardModel._owner not found.");
+
+    private static readonly MethodInfo ModelDbGetIdMethod =
+        typeof(ModelDb).GetMethod(nameof(ModelDb.GetId), BindingFlags.Public | BindingFlags.Static, null, [typeof(Type)], null)
+        ?? throw new InvalidOperationException("ModelDb.GetId(Type) not found.");
+
+    [Fact]
+    public void DirectPowerDraw_AttachesAttemptAndDrawToApplyingCard()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = CreatePendingCombat();
+        PendingCombatField.SetValue(null, pendingCombat);
+        ResetTrackerState();
+
+        try
+        {
+            var player = CreatePlayer();
+            var power = CreatePowerModel(typeof(DarkEmbracePower));
+            var drawnCard = CreateCardModel(player);
+
+            TrackPowerOwnership(power, "CARD.DARK_EMBRACE#1", player);
+            _ = PushExecutionSourceMethod.Invoke(null, new object?[] { power });
+
+            try
+            {
+                RunTracker.NoteDrawAttempt(player, fromHandDraw: false);
+                RunTracker.RecordDrawFromCard(drawnCard, fromHandDraw: false);
+            }
+            finally
+            {
+                _ = PopExecutionSourceMethod.Invoke(null, new object?[] { power });
+            }
+
+            var aggregates = GetAggregates(pendingCombat);
+            var sourceAggregate = Assert.Contains("CARD.DARK_EMBRACE#1", aggregates);
+            Assert.Equal(1, sourceAggregate.TimesCardsDrawAttempted);
+            Assert.Equal(1, sourceAggregate.TimesCardsDrawn);
+
+            var drawnAggregate = Assert.Single(aggregates, kv => kv.Key != "CARD.DARK_EMBRACE#1");
+            Assert.Equal(1, drawnAggregate.Value.TimesDrawn);
+        }
+        finally
+        {
+            ResetTrackerState();
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    [Fact]
+    public void HandDrawPower_AttributesExtraTurnStartDrawsToApplyingCard()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = CreatePendingCombat();
+        PendingCombatField.SetValue(null, pendingCombat);
+        ResetTrackerState();
+
+        try
+        {
+            var player = CreatePlayer();
+            var power = CreatePowerModel(typeof(MachineLearningPower));
+
+            TrackPowerOwnership(power, "CARD.MACHINE_LEARNING#1", player);
+            BeginHandDrawResolution(player);
+            RecordHandDrawModification(power, player, 5m, 7m);
+            FinalizeHandDrawResolution(player);
+
+            RunTracker.RecordDrawFromCard(CreateCardModel(player), fromHandDraw: true);
+            RunTracker.RecordDrawFromCard(CreateCardModel(player), fromHandDraw: true);
+            CompletePendingHandDraw(player);
+
+            var sourceAggregate = Assert.Contains("CARD.MACHINE_LEARNING#1", GetAggregates(pendingCombat));
+            Assert.Equal(2, sourceAggregate.TimesCardsDrawAttempted);
+            Assert.Equal(2, sourceAggregate.TimesCardsDrawn);
+            Assert.Equal(0, sourceAggregate.TimesCardsDrawBlocked);
+        }
+        finally
+        {
+            ResetTrackerState();
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    [Fact]
+    public void HandDrawPower_RecordsBlockedGapWhenLaterModifierCancelsExtraDraw()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = CreatePendingCombat();
+        PendingCombatField.SetValue(null, pendingCombat);
+        ResetTrackerState();
+
+        try
+        {
+            var player = CreatePlayer();
+            var drawPower = CreatePowerModel(typeof(MachineLearningPower));
+            var blocker = CreatePowerModel(typeof(MindRotPower));
+
+            TrackPowerOwnership(drawPower, "CARD.MACHINE_LEARNING#1", player);
+            BeginHandDrawResolution(player);
+            RecordHandDrawModification(drawPower, player, 5m, 7m);
+            RecordHandDrawModification(blocker, player, 7m, 6m);
+            FinalizeHandDrawResolution(player);
+
+            RunTracker.RecordDrawFromCard(CreateCardModel(player), fromHandDraw: true);
+            CompletePendingHandDraw(player);
+
+            var sourceAggregate = Assert.Contains("CARD.MACHINE_LEARNING#1", GetAggregates(pendingCombat));
+            Assert.Equal(2, sourceAggregate.TimesCardsDrawAttempted);
+            Assert.Equal(1, sourceAggregate.TimesCardsDrawn);
+            Assert.Equal(1, sourceAggregate.TimesCardsDrawBlocked);
+            Assert.Single(sourceAggregate.BlockedDrawReasons.Values, reason => reason.Count > 0);
+        }
+        finally
+        {
+            ResetTrackerState();
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    [Fact]
+    public void HandDrawPower_UsesBlockedDrawHookForTurnStartNoDrawStylePrevention()
+    {
+        var previousPendingCombat = PendingCombatField.GetValue(null);
+        var pendingCombat = CreatePendingCombat();
+        PendingCombatField.SetValue(null, pendingCombat);
+        ResetTrackerState();
+
+        try
+        {
+            var player = CreatePlayer();
+            var drawPower = CreatePowerModel(typeof(MachineLearningPower));
+            var blocker = CreatePowerModel(typeof(MindRotPower));
+
+            TrackPowerOwnership(drawPower, "CARD.MACHINE_LEARNING#1", player);
+            BeginHandDrawResolution(player);
+            RecordHandDrawModification(drawPower, player, 5m, 7m);
+            FinalizeHandDrawResolution(player);
+
+            RunTracker.RecordBlockedDrawAttempt(player, fromHandDraw: true, blocker);
+            CompletePendingHandDraw(player);
+
+            var sourceAggregate = Assert.Contains("CARD.MACHINE_LEARNING#1", GetAggregates(pendingCombat));
+            Assert.Equal(2, sourceAggregate.TimesCardsDrawAttempted);
+            Assert.Equal(0, sourceAggregate.TimesCardsDrawn);
+            Assert.Equal(2, sourceAggregate.TimesCardsDrawBlocked);
+            Assert.Equal(2, sourceAggregate.BlockedDrawReasons.Values.Sum(reason => reason.Count));
+        }
+        finally
+        {
+            ResetTrackerState();
+            PendingCombatField.SetValue(null, previousPendingCombat);
+        }
+    }
+
+    private static object CreatePendingCombat()
+    {
+        return Activator.CreateInstance(PendingCombatType, nonPublic: true)
+            ?? throw new InvalidOperationException("Failed to create PendingCombat.");
+    }
+
+    private static Dictionary<string, CardAggregate> GetAggregates(object pendingCombat)
+    {
+        return (Dictionary<string, CardAggregate>)(CombatAggregatesProperty.GetValue(pendingCombat)
+            ?? throw new InvalidOperationException("CombatAggregates returned null."));
+    }
+
+    private static void ResetTrackerState()
+    {
+        _ = ResetCombatContextStateMethod.Invoke(null, null);
+    }
+
+    private static void TrackPowerOwnership(PowerModel power, string sourceInstanceId, Player player)
+    {
+        var effect = new AppliedEffectAggregate
+        {
+            EffectId = power.Id.ToString(),
+            DisplayName = power.Id.Entry,
+        };
+
+        _ = TrackPlayerPowerOwnershipLockedMethod.Invoke(
+            null,
+            new object?[] { power, sourceInstanceId, effect, player });
+    }
+
+    private static void BeginHandDrawResolution(Player player)
+    {
+        _ = BeginHandDrawResolutionMethod.Invoke(null, new object?[] { player });
+    }
+
+    private static void RecordHandDrawModification(PowerModel power, Player player, decimal before, decimal after)
+    {
+        _ = RecordHandDrawModificationMethod.Invoke(null, new object?[] { power, player, before, after });
+    }
+
+    private static void FinalizeHandDrawResolution(Player player)
+    {
+        _ = FinalizeHandDrawResolutionMethod.Invoke(null, new object?[] { player });
+    }
+
+    private static void CompletePendingHandDraw(Player player)
+    {
+        _ = CompletePendingHandDrawMethod.Invoke(null, new object?[] { player });
+    }
+
+    private static Player CreatePlayer()
+    {
+        return (Player)RuntimeHelpers.GetUninitializedObject(typeof(Player));
+    }
+
+    private static CardModel CreateCardModel(Player owner)
+    {
+        var concreteCardType = typeof(CardModel).Assembly.GetTypes()
+            .FirstOrDefault(type => typeof(CardModel).IsAssignableFrom(type) && !type.IsAbstract)
+            ?? throw new InvalidOperationException("No concrete CardModel subtype found.");
+
+        var card = (CardModel)RuntimeHelpers.GetUninitializedObject(concreteCardType);
+        InitializeMutableModel(card, concreteCardType);
+        CardOwnerField.SetValue(card, owner);
+        return card;
+    }
+
+    private static PowerModel CreatePowerModel(Type powerType)
+    {
+        var power = (PowerModel)RuntimeHelpers.GetUninitializedObject(powerType);
+        InitializeMutableModel(power, powerType);
+        return power;
+    }
+
+    private static void InitializeMutableModel(AbstractModel model, Type concreteType)
+    {
+        var modelId = (ModelId)(ModelDbGetIdMethod.Invoke(null, new object?[] { concreteType })
+            ?? throw new InvalidOperationException("ModelDb.GetId returned null."));
+
+        AbstractModelIdField.SetValue(model, modelId);
+        AbstractModelIsMutableField.SetValue(model, true);
+    }
+}

--- a/Tests/CardUtilityStats.Core.Tests/RunTrackerPowerResourceAttributionTests.cs
+++ b/Tests/CardUtilityStats.Core.Tests/RunTrackerPowerResourceAttributionTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace CardUtilityStats.Core.Tests;
 
+[Collection("RunTrackerSerial")]
 public class RunTrackerPowerResourceAttributionTests
 {
     private static readonly FieldInfo PendingCombatField =

--- a/Tests/CardUtilityStats.Core.Tests/RunTrackerSerialCollection.cs
+++ b/Tests/CardUtilityStats.Core.Tests/RunTrackerSerialCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace CardUtilityStats.Core.Tests;
+
+[CollectionDefinition("RunTrackerSerial", DisableParallelization = true)]
+public sealed class RunTrackerSerialCollection
+{
+}


### PR DESCRIPTION
## Summary
- attribute direct power-triggered draws back to the card that applied the power
- track turn-start hand-draw bonuses from owned powers as attempted/successful/blocked draw stats on the source card
- flush leftover hand-draw attempts so blocked gaps do not leak into later draw actions

## Testing
- dotnet test D:\workspace\CardUtilityStats\worktrees\power-draw-attribution\Tests\CardUtilityStats.Core.Tests\CardUtilityStats.Core.Tests.csproj -c Debug
