### PR TITLE
Bootstrap self-hosted live test pipeline

### DIFF
--- a/.github/workflows/codex-queue-wakeup.yml
+++ b/.github/workflows/codex-queue-wakeup.yml
@@ -1,0 +1,40 @@
+name: Codex Queue Wakeup
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - labeled
+  workflow_dispatch:
+
+concurrency:
+  group: codex-queue-worker
+  cancel-in-progress: false
+
+jobs:
+  wake-queue-worker:
+    name: Wake autonomous issue worker
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && (
+        (github.event.action == 'labeled' && github.event.label.name == 'codex-queue') ||
+        contains(github.event.issue.labels.*.name, 'codex-queue')
+      ))
+    runs-on:
+      - self-hosted
+      - windows
+      - sts2-live
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run queue worker
+        shell: pwsh
+        run: |
+          ./ops/codex-queue/Run-IssueQueueWorker.ps1 `
+            -RepoRoot $env:GITHUB_WORKSPACE `
+            -WorkerName 'sts2-side-a'

--- a/.github/workflows/live-sts2-manual.yml
+++ b/.github/workflows/live-sts2-manual.yml
@@ -1,0 +1,74 @@
+name: Live STS2 Manual Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario_path:
+        description: Repo-relative scenario manifest to execute on the worker
+        required: true
+        default: LiveScenarios/noxious_fumes_basic.json
+        type: string
+      git_ref:
+        description: Branch, tag, or commit to test
+        required: true
+        default: main
+        type: string
+      configuration:
+        description: Dotnet build configuration
+        required: true
+        default: Release
+        type: choice
+        options:
+          - Release
+          - Debug
+      run_tests:
+        description: Run CardUtilityStats.Core tests before the live scenario
+        required: true
+        default: true
+        type: boolean
+      execute_live_driver:
+        description: Invoke the worker's local STS2 scenario driver
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  live-test:
+    name: Live test on self-hosted STS2 worker
+    runs-on:
+      - self-hosted
+      - windows
+      - sts2-live
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Run live scenario harness
+        shell: pwsh
+        run: |
+          $artifactRoot = Join-Path $env:RUNNER_TEMP 'card-utility-stats-live'
+          ./scripts/ci/run-live-scenario.ps1 `
+            -ScenarioPath '${{ inputs.scenario_path }}' `
+            -ArtifactRoot $artifactRoot `
+            -Configuration '${{ inputs.configuration }}' `
+            -RunTests:${{ inputs.run_tests }} `
+            -ExecuteLiveDriver:${{ inputs.execute_live_driver }}
+
+      - name: Upload live test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-sts2-${{ github.run_id }}-${{ github.run_attempt }}-${{ runner.name }}
+          path: ${{ runner.temp }}/card-utility-stats-live
+          if-no-files-found: warn
+          retention-days: 14

--- a/LiveScenarios/README.md
+++ b/LiveScenarios/README.md
@@ -1,0 +1,40 @@
+# Live Scenarios
+
+These manifests are the repo-owned description of a live STS2 test run.
+
+They are deliberately lightweight:
+
+- GitHub Actions owns dispatch and artifact upload
+- the repo-owned harness owns build/test/deploy and handoff
+- the worker-local live-driver script decides how to drive the game for each manifest
+
+## Current Shape
+
+Each scenario file is JSON with:
+
+- `name`
+- `description`
+- `tags`
+- `intent`
+- `artifact_expectations`
+- `driver`
+
+The `driver` payload is intentionally flexible for the bootstrap phase. It gives us a checked-in, reviewable scenario contract without forcing a single automation engine before the side machines are live.
+
+## Initial Scenarios
+
+- [noxious_fumes_basic.json](D:/repos/card-utility-stats/LiveScenarios/noxious_fumes_basic.json:1)
+- [forge_grant_basic.json](D:/repos/card-utility-stats/LiveScenarios/forge_grant_basic.json:1)
+- [make_it_so_summon_basic.json](D:/repos/card-utility-stats/LiveScenarios/make_it_so_summon_basic.json:1)
+- [tooltip_visual_check.json](D:/repos/card-utility-stats/LiveScenarios/tooltip_visual_check.json:1)
+
+## Driver Guidance
+
+The worker-local automation layer should use the `driver` payload to decide:
+
+- what save/profile/bootstrap state to load
+- what scripted actions to perform
+- when to capture screenshots
+- what success conditions to enforce
+
+If the scenario contract grows beyond this lightweight phase, we can promote it into a dedicated schema with validation.

--- a/LiveScenarios/forge_grant_basic.json
+++ b/LiveScenarios/forge_grant_basic.json
@@ -1,0 +1,28 @@
+{
+  "name": "forge_grant_basic",
+  "description": "Verify forge granted from cards is visible in live run output on a worker machine.",
+  "tags": [
+    "forge",
+    "live"
+  ],
+  "intent": {
+    "primary_assertion": "Forge granted from the scenario card is recorded in run data.",
+    "secondary_assertions": [
+      "The worker captures enough logs to debug a failed live setup."
+    ]
+  },
+  "artifact_expectations": [
+    "screenshots around the forge-grant event",
+    "worker logs for scenario execution",
+    "run JSON containing the recorded forge stat"
+  ],
+  "driver": {
+    "entrypoint": "scenario/forge-grant-basic",
+    "profile": "regent",
+    "capture": [
+      "before-play",
+      "after-play"
+    ],
+    "timeout_minutes": 20
+  }
+}

--- a/LiveScenarios/make_it_so_summon_basic.json
+++ b/LiveScenarios/make_it_so_summon_basic.json
@@ -1,0 +1,28 @@
+{
+  "name": "make_it_so_summon_basic",
+  "description": "Exercise recurring summon-to-hand attribution for Make It So on a live worker.",
+  "tags": [
+    "summon",
+    "live"
+  ],
+  "intent": {
+    "primary_assertion": "Successful self-summons to hand are credited back to the originating card instance.",
+    "secondary_assertions": [
+      "The run JSON and screenshots are sufficient for manual review."
+    ]
+  },
+  "artifact_expectations": [
+    "screenshots before and after the summon returns to hand",
+    "driver logs covering the summon trigger",
+    "run JSON with summon-related attribution"
+  ],
+  "driver": {
+    "entrypoint": "scenario/make-it-so-summon-basic",
+    "profile": "defect",
+    "capture": [
+      "before-play",
+      "after-return-to-hand"
+    ],
+    "timeout_minutes": 20
+  }
+}

--- a/LiveScenarios/noxious_fumes_basic.json
+++ b/LiveScenarios/noxious_fumes_basic.json
@@ -1,0 +1,31 @@
+{
+  "name": "noxious_fumes_basic",
+  "description": "Exercise stacked Noxious Fumes attribution and capture the resulting run-data plus tooltip state.",
+  "tags": [
+    "poison",
+    "artifact",
+    "live"
+  ],
+  "intent": {
+    "primary_assertion": "Observed poison application and poison damage remain attributable to the source card.",
+    "secondary_assertions": [
+      "Artifact-blocked debuffs still surface in the run output.",
+      "The produced run JSON is useful enough for manual review."
+    ]
+  },
+  "artifact_expectations": [
+    "screenshots showing the tooltip or combat state after Noxious Fumes is active",
+    "bridge or driver logs covering scenario setup and completion",
+    "CardUtilityStats run JSON written during or after the scenario"
+  ],
+  "driver": {
+    "entrypoint": "scenario/noxious-fumes-basic",
+    "profile": "silent",
+    "capture": [
+      "combat-start",
+      "after-application",
+      "combat-end"
+    ],
+    "timeout_minutes": 20
+  }
+}

--- a/LiveScenarios/tooltip_visual_check.json
+++ b/LiveScenarios/tooltip_visual_check.json
@@ -1,0 +1,29 @@
+{
+  "name": "tooltip_visual_check",
+  "description": "Capture hand-view and deck-view tooltip screenshots for manual UI review on a live worker.",
+  "tags": [
+    "ui",
+    "tooltip",
+    "live"
+  ],
+  "intent": {
+    "primary_assertion": "Compact hand-view and fuller deck-view tooltips render with expected information density.",
+    "secondary_assertions": [
+      "Screenshot capture and artifact upload remain stable for visual review runs."
+    ]
+  },
+  "artifact_expectations": [
+    "hand tooltip screenshots",
+    "deck-view tooltip screenshots",
+    "driver logs describing capture points"
+  ],
+  "driver": {
+    "entrypoint": "scenario/tooltip-visual-check",
+    "profile": "ui-review",
+    "capture": [
+      "hand-hover",
+      "deck-hover"
+    ],
+    "timeout_minutes": 15
+  }
+}

--- a/docs/codex-issue-queue.md
+++ b/docs/codex-issue-queue.md
@@ -67,13 +67,14 @@ Instead, the bootstrap step copies the installed Codex CLI into a normal local p
 
 ## Scheduling
 
-The intended steady state is:
+The intended steady state is hybrid:
 
-- a Windows Scheduled Task wakes the queue worker regularly
+- GitHub issue events wake the queue worker immediately on the self-hosted runner
+- a Windows Scheduled Task still wakes the queue worker periodically as a recovery mechanism
 - each invocation drains the queue until empty
 - if another invocation starts while one is already running, the lock file causes it to exit cleanly
 
-This gives the machine a real queue-draining process without requiring a permanently open terminal window or a human babysitter.
+This gives the machine fast reaction time without making webhooks or event delivery the only correctness path.
 
 ## Current Scope
 

--- a/docs/codex-issue-queue.md
+++ b/docs/codex-issue-queue.md
@@ -1,0 +1,86 @@
+# Codex Issue Queue
+
+This side machine is not just a one-off CI runner anymore. It is intended to become a persistent autonomous issue worker for `card-utility-stats`.
+
+The key requirement is operational, not prompt-based:
+
+- the machine can stay on by itself
+- Codex can run headlessly on the machine
+- issues are processed through an actual queue
+- the queue is drained one issue at a time until empty
+- progress does not depend on a human repeatedly telling Codex to continue
+
+## Queue Contract
+
+The queue is defined by GitHub issue labels.
+
+Issues are eligible for autonomous work when they have:
+
+- `codex-queue`
+
+Queue state is tracked with:
+
+- `codex-active`
+- `codex-blocked`
+- `codex-complete`
+
+Recommended meaning:
+
+- `codex-queue`
+  - ready for the worker to pick up
+- `codex-active`
+  - currently claimed by the worker
+- `codex-blocked`
+  - removed from the queue pending human input or missing prerequisites
+- `codex-complete`
+  - processed by the queue worker and no longer queued
+
+## Processing Model
+
+The worker script does not process "a couple of issues if the model remembers."
+
+Instead it performs this deterministic loop:
+
+1. acquire a local lock so only one queue run is active on the machine
+2. find the oldest open issue labeled `codex-queue`
+3. claim it by adding `codex-active`
+4. invoke Codex headlessly against the repository for that issue
+5. read the structured result from Codex
+6. update labels/comments based on that result
+7. repeat until no queued issues remain
+
+That outer loop is owned by the script, not by the model.
+
+## Why This Matters
+
+This directly addresses the failure mode where Codex says "I'll keep going through 50 items" but stops after 2 or 3. In this design:
+
+- each Codex run is responsible for one issue only
+- the queue worker is responsible for continuing to the next issue
+- the queue drain only stops when the queue is empty, the worker is blocked, or the machine/process fails
+
+## Headless Codex
+
+The worker does not rely on the packaged WindowsApps alias for `codex.exe`, which is awkward to execute from unattended shells.
+
+Instead, the bootstrap step copies the installed Codex CLI into a normal local path and executes that copy. The copied CLI still uses the existing `~/.codex` auth and configuration on the machine.
+
+## Scheduling
+
+The intended steady state is:
+
+- a Windows Scheduled Task wakes the queue worker regularly
+- each invocation drains the queue until empty
+- if another invocation starts while one is already running, the lock file causes it to exit cleanly
+
+This gives the machine a real queue-draining process without requiring a permanently open terminal window or a human babysitter.
+
+## Current Scope
+
+The worker is repo-specific right now:
+
+- repo: `nelsong6/card-utility-stats`
+- local checkout: `D:\repos\card-utility-stats`
+- worker name: `sts2-side-a`
+
+That is intentional. The first milestone is to make the pattern real and reliable on one side machine. If it works, the queue worker can later be generalized into a shared automation repo.

--- a/docs/live-worker-pipeline.md
+++ b/docs/live-worker-pipeline.md
@@ -1,0 +1,182 @@
+# Live Worker Pipeline
+
+Issue [#51](https://github.com/nelsong6/card-utility-stats/issues/51) proposes a control-plane / worker-pool split:
+
+- the main work machine edits code, dispatches runs, and reviews artifacts
+- dedicated Windows side machines run Slay the Spire 2 and execute live scenarios
+
+This document is the first milestone implementation plan for that setup using GitHub Actions self-hosted runners.
+
+## Current Rollout Phase
+
+The target design is still a small worker pool, but the current rollout should start with one side machine first.
+
+Current shape:
+
+- one Windows self-hosted worker machine
+- that machine is labeled both `sts2-live` and `sts2-side-a`
+- the workflow still targets the shared `sts2-live` label so a second worker can be added later without changing the workflow contract
+
+## Current First Milestone
+
+The repo now includes:
+
+- a manual GitHub Actions workflow at [.github/workflows/live-sts2-manual.yml](D:/repos/card-utility-stats/.github/workflows/live-sts2-manual.yml:1)
+- a runner-side harness at [scripts/ci/run-live-scenario.ps1](D:/repos/card-utility-stats/scripts/ci/run-live-scenario.ps1:1)
+- checked-in scenario manifests under [LiveScenarios](D:/repos/card-utility-stats/LiveScenarios/README.md:1)
+
+The first pass is intentionally conservative:
+
+- dispatch manually with `workflow_dispatch`
+- target any available runner labeled `sts2-live`
+- run repo tests
+- build and deploy the mod to the worker's local STS2 `mods` directory
+- hand off to a worker-local live-driver script
+- upload artifacts back to GitHub Actions
+
+The workflow does not try to solve worker reset, Steam login recovery, or MCP/game automation orchestration centrally yet. Those remain worker-local concerns until the live path is stable.
+
+## Worker Model
+
+Register the first side machine as a self-hosted GitHub Actions runner for this repo.
+
+When a second machine exists later, reuse the same shared label strategy.
+
+Recommended shared labels:
+
+- `self-hosted`
+- `windows`
+- `sts2-live`
+
+Recommended unique label for the first machine:
+
+- `sts2-side-a`
+
+Use the shared label for normal queueing. Keep the unique labels available for debugging or machine-specific dispatch later.
+
+## Required Worker Software
+
+Each side machine should have:
+
+- Steam installed and able to launch Slay the Spire 2 without interactive repair prompts
+- Slay the Spire 2 installed locally
+- GitHub Actions runner service installed and running
+- PowerShell 7 available for workflow steps
+- .NET 9 SDK available, or allow `actions/setup-dotnet` to acquire it per run
+- whatever local MCP bridge / window automation tooling will eventually drive STS2
+
+Recommended but not enforced yet:
+
+- disable sleep while the runner service is active
+- use a dedicated Windows user profile for the runner
+- keep Steam in a stable logged-in state
+- keep game resolution and display arrangement fixed so screenshot comparisons remain meaningful
+
+## Required Worker Environment Variables
+
+Set these on each side machine before expecting live scenario execution to succeed:
+
+- `CARD_UTILITY_STATS_STS2_PATH`
+  - Absolute path to the local Slay the Spire 2 install.
+  - Example: `D:\SteamLibrary\steamapps\common\Slay the Spire 2`
+- `CARD_UTILITY_STATS_LIVE_DRIVER`
+  - Absolute path to the worker-local PowerShell script that actually launches the game, drives the scenario, and captures screenshots/logs.
+  - Example: `D:\automation\card-utility-stats\Invoke-Sts2Scenario.ps1`
+- `CARD_UTILITY_STATS_RUN_DATA_DIR`
+  - Optional override for the directory containing run JSON output.
+  - Default if omitted: `%APPDATA%\SlayTheSpire2\CardUtilityStats\runs`
+
+The repo-owned workflow handles build/test/artifact staging. The worker-local driver handles game-specific automation.
+
+## Dispatch Flow
+
+Run the workflow from GitHub Actions with these inputs:
+
+- `scenario_path`
+  - Repo-relative path to a scenario manifest in `LiveScenarios/`
+- `git_ref`
+  - Branch, tag, or commit to test
+- `configuration`
+  - Usually `Release`
+- `run_tests`
+  - Run the core test suite before live execution
+- `execute_live_driver`
+  - Set to `false` when validating the runner/build/artifact pipeline before the real STS2 automation is ready
+
+The selected runner will:
+
+1. check out the requested ref
+2. install .NET 9
+3. run core tests
+4. build `CardUtilityStats`
+5. deploy the mod into the worker's local STS2 `mods` directory
+6. invoke the worker-local live driver
+7. collect artifacts back into the workflow run
+
+## Artifact Contract
+
+The harness stages these artifact directories:
+
+- `scenario/`
+  - the scenario manifest used for the run
+- `logs/`
+  - test logs and worker-driver logs
+- `screenshots/`
+  - visual captures created by the worker-local driver
+- `run-data/`
+  - `CardUtilityStats` JSON outputs and `prefs.json` when available
+- `build/`
+  - loader build output and the deployed `mods/CardUtilityStats` payload
+- `driver-output/`
+  - any extra files the worker-local driver writes
+
+The worker-local live-driver script should treat those directories as its stable output contract.
+
+## Worker-Local Driver Contract
+
+`scripts/ci/run-live-scenario.ps1` expects `CARD_UTILITY_STATS_LIVE_DRIVER` to point at a PowerShell script that accepts these parameters:
+
+- `-ScenarioPath`
+- `-ArtifactRoot`
+- `-ScreenshotsDir`
+- `-LogsDir`
+- `-RunDataDir`
+- `-Sts2Path`
+
+That driver should be responsible for:
+
+- resetting the worker into a known pre-run state
+- launching STS2
+- applying or loading the requested scenario
+- waiting for the scenario to complete or time out
+- writing logs and screenshots into the provided artifact folders
+- exiting non-zero on failure
+
+Keeping the driver local lets the repo own the pipeline contract now without locking us into one automation implementation too early.
+
+## Scenario Format
+
+Scenario manifests live under `LiveScenarios/` and are intentionally simple JSON files.
+
+Current fields:
+
+- `name`
+- `description`
+- `tags`
+- `intent`
+- `artifact_expectations`
+- `driver`
+
+The `driver` object is the worker-local handoff payload. The repo documents the shape and expected semantics, but the first version does not require a single global scenario engine yet.
+
+## Next Steps
+
+After the bootstrap pipeline is proven on the first side machine, the next likely improvements are:
+
+- add a real worker reset routine before each run
+- promote the worker-local driver contract into a repo-managed script package
+- standardize screenshot naming and metadata
+- add machine health checks
+- split quick validation runs from full live scenario runs
+- add a second `sts2-live` worker once the single-machine path is stable
+- optionally add a second workflow for queued branch validation against the shared `sts2-live` pool

--- a/ops/codex-queue/Install-IssueQueueWorkerTask.ps1
+++ b/ops/codex-queue/Install-IssueQueueWorkerTask.ps1
@@ -3,7 +3,7 @@ param(
     [string]$RepoRoot = "D:\repos\card-utility-stats",
     [string]$TaskName = "Codex Issue Queue Worker",
     [string]$WorkerName = "sts2-side-a",
-    [int]$IntervalMinutes = 5
+    [int]$IntervalMinutes = 30
 )
 
 $ErrorActionPreference = "Stop"

--- a/ops/codex-queue/Install-IssueQueueWorkerTask.ps1
+++ b/ops/codex-queue/Install-IssueQueueWorkerTask.ps1
@@ -1,0 +1,28 @@
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = "D:\repos\card-utility-stats",
+    [string]$TaskName = "Codex Issue Queue Worker",
+    [string]$WorkerName = "sts2-side-a",
+    [int]$IntervalMinutes = 5
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptPath = Join-Path $RepoRoot "ops\codex-queue\Run-IssueQueueWorker.ps1"
+if (-not (Test-Path -LiteralPath $scriptPath)) {
+    throw "Worker script not found at $scriptPath"
+}
+
+$action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoLogo -NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`" -RepoRoot `"$RepoRoot`" -WorkerName `"$WorkerName`""
+$trigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddMinutes(1)) -RepetitionInterval (New-TimeSpan -Minutes $IntervalMinutes)
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable
+
+$existingTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existingTask) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings | Out-Null
+Start-ScheduledTask -TaskName $TaskName
+
+Write-Host "Installed scheduled task '$TaskName' to run every $IntervalMinutes minute(s)."

--- a/ops/codex-queue/Run-IssueQueueWorker.ps1
+++ b/ops/codex-queue/Run-IssueQueueWorker.ps1
@@ -1,0 +1,621 @@
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = "D:\repos\card-utility-stats",
+    [string]$RepoSlug = "nelsong6/card-utility-stats",
+    [string]$WorkerName = "sts2-side-a",
+    [string]$QueueLabel = "codex-queue",
+    [string]$ActiveLabel = "codex-active",
+    [string]$BlockedLabel = "codex-blocked",
+    [string]$CompleteLabel = "codex-complete",
+    [int]$MaxIssuesPerRun = 100,
+    [int]$MaxAttemptsPerIssue = 3
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Log {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $line = "[$timestamp] $Message"
+    Write-Host $line
+
+    if ($script:WorkerLogPath) {
+        Add-Content -LiteralPath $script:WorkerLogPath -Value $line
+    }
+}
+
+function Ensure-Directory {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    New-Item -ItemType Directory -Force -Path $Path | Out-Null
+    return $Path
+}
+
+function Get-StateRoot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoSlugValue
+    )
+
+    $safeRepoSlug = $RepoSlugValue.Replace("/", "-")
+    return Ensure-Directory -Path (Join-Path $env:LOCALAPPDATA "CodexIssueQueue\$safeRepoSlug")
+}
+
+function Add-ToolPath {
+    $paths = @(
+        "C:\Program Files\Git\cmd",
+        "C:\Program Files\GitHub CLI",
+        "C:\Program Files\PowerShell\7"
+    )
+
+    foreach ($path in $paths) {
+        if ((Test-Path -LiteralPath $path) -and -not (($env:PATH -split ";") -contains $path)) {
+            $env:PATH = "$path;$env:PATH"
+        }
+    }
+}
+
+function Ensure-LocalCodexBinary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot
+    )
+
+    $candidatePaths = @(
+        "C:\Program Files\WindowsApps\OpenAI.Codex_26.421.620.0_x64__2p2nqsd0c76g0\app\resources\codex.exe"
+    )
+
+    $sourcePath = $null
+    foreach ($candidate in $candidatePaths) {
+        if (Test-Path -LiteralPath $candidate) {
+            $sourcePath = $candidate
+            break
+        }
+    }
+
+    if (-not $sourcePath) {
+        throw "Unable to locate the installed Codex CLI binary."
+    }
+
+    $binDir = Ensure-Directory -Path (Join-Path $StateRoot "bin")
+    $targetPath = Join-Path $binDir "codex.exe"
+
+    $shouldCopy = $true
+    if (Test-Path -LiteralPath $targetPath) {
+        $sourceInfo = Get-Item -LiteralPath $sourcePath
+        $targetInfo = Get-Item -LiteralPath $targetPath
+        $shouldCopy = $sourceInfo.Length -ne $targetInfo.Length -or $sourceInfo.LastWriteTimeUtc -gt $targetInfo.LastWriteTimeUtc
+    }
+
+    if ($shouldCopy) {
+        Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Force
+    }
+
+    return $targetPath
+}
+
+function Invoke-GhJson {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $json = & gh @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh command failed: gh $($Arguments -join ' ')"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($json)) {
+        return $null
+    }
+
+    return $json | ConvertFrom-Json
+}
+
+function Ensure-Label {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Color,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    $existing = Invoke-GhJson -Arguments @("label", "list", "--repo", $Repo, "--limit", "200", "--json", "name")
+    if ($existing.name -contains $Name) {
+        return
+    }
+
+    & gh label create $Name --repo $Repo --color $Color --description $Description | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create label '$Name'."
+    }
+}
+
+function Ensure-QueueLabels {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo
+    )
+
+    Ensure-Label -Repo $Repo -Name $QueueLabel -Color "0e8a16" -Description "Queued for autonomous Codex processing"
+    Ensure-Label -Repo $Repo -Name $ActiveLabel -Color "fbca04" -Description "Currently being processed by the Codex queue worker"
+    Ensure-Label -Repo $Repo -Name $BlockedLabel -Color "d93f0b" -Description "Blocked pending human action or missing prerequisites"
+    Ensure-Label -Repo $Repo -Name $CompleteLabel -Color "1d76db" -Description "Processed by the Codex queue worker"
+}
+
+function Get-AttemptFilePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber
+    )
+
+    $attemptsDir = Ensure-Directory -Path (Join-Path $StateRoot "attempts")
+    return Join-Path $attemptsDir "$IssueNumber.json"
+}
+
+function Get-IssueAttemptCount {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber
+    )
+
+    $path = Get-AttemptFilePath -StateRoot $StateRoot -IssueNumber $IssueNumber
+    if (-not (Test-Path -LiteralPath $path)) {
+        return 0
+    }
+
+    return ((Get-Content -LiteralPath $path -Raw | ConvertFrom-Json).attempts)
+}
+
+function Set-IssueAttemptCount {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Attempts
+    )
+
+    $payload = @{
+        issue_number = $IssueNumber
+        attempts = $Attempts
+        updated_at = (Get-Date).ToString("o")
+    }
+
+    $payload | ConvertTo-Json | Set-Content -LiteralPath (Get-AttemptFilePath -StateRoot $StateRoot -IssueNumber $IssueNumber)
+}
+
+function Clear-IssueAttemptCount {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber
+    )
+
+    $path = Get-AttemptFilePath -StateRoot $StateRoot -IssueNumber $IssueNumber
+    if (Test-Path -LiteralPath $path) {
+        Remove-Item -LiteralPath $path -Force
+    }
+}
+
+function Get-NextQueuedIssue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo
+    )
+
+    $issues = Invoke-GhJson -Arguments @(
+        "issue", "list",
+        "--repo", $Repo,
+        "--state", "open",
+        "--label", $QueueLabel,
+        "--limit", "100",
+        "--json", "number,title,createdAt,labels,url"
+    )
+
+    if (-not $issues) {
+        return $null
+    }
+
+    $eligible = $issues | Where-Object {
+        $labelNames = @($_.labels | ForEach-Object { $_.name })
+        -not ($labelNames -contains $ActiveLabel)
+    }
+
+    if (-not $eligible) {
+        return $null
+    }
+
+    return $eligible | Sort-Object createdAt | Select-Object -First 1
+}
+
+function Get-IssuePacket {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber
+    )
+
+    return Invoke-GhJson -Arguments @(
+        "issue", "view", $IssueNumber.ToString(),
+        "--repo", $Repo,
+        "--json", "number,title,body,labels,comments,author,url,assignees,projectItems"
+    )
+}
+
+function Edit-IssueLabels {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber,
+
+        [string[]]$AddLabels = @(),
+
+        [string[]]$RemoveLabels = @()
+    )
+
+    $args = @("issue", "edit", $IssueNumber.ToString(), "--repo", $Repo)
+
+    foreach ($label in $AddLabels) {
+        if (-not [string]::IsNullOrWhiteSpace($label)) {
+            $args += @("--add-label", $label)
+        }
+    }
+
+    foreach ($label in $RemoveLabels) {
+        if (-not [string]::IsNullOrWhiteSpace($label)) {
+            $args += @("--remove-label", $label)
+        }
+    }
+
+    & gh @args | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to edit labels for issue #$IssueNumber."
+    }
+}
+
+function Comment-OnIssue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Body
+    )
+
+    & gh issue comment $IssueNumber --repo $Repo --body $Body | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to comment on issue #$IssueNumber."
+    }
+}
+
+function Invoke-CodexIssueRun {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CodexPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRootValue,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Worker,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$IssuePacket
+    )
+
+    $issueRunRoot = Ensure-Directory -Path (Join-Path $StateRoot "runs\$IssueNumber")
+    $attempt = (Get-IssueAttemptCount -StateRoot $StateRoot -IssueNumber $IssueNumber) + 1
+    Set-IssueAttemptCount -StateRoot $StateRoot -IssueNumber $IssueNumber -Attempts $attempt
+
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $runDir = Ensure-Directory -Path (Join-Path $issueRunRoot "$timestamp-attempt-$attempt")
+    $packetPath = Join-Path $runDir "issue-packet.json"
+    $promptPath = Join-Path $runDir "prompt.md"
+    $stdoutPath = Join-Path $runDir "codex-stdout.log"
+    $stderrPath = Join-Path $runDir "codex-stderr.log"
+    $resultPath = Join-Path $runDir "codex-result.json"
+    $schemaPath = Join-Path $RepoRootValue "ops\codex-queue\issue-output-schema.json"
+    $instructionsPath = Join-Path $RepoRootValue "ops\codex-queue\worker-instructions.md"
+
+    $IssuePacket | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $packetPath
+
+    $instructions = Get-Content -LiteralPath $instructionsPath -Raw
+    $prompt = @"
+$instructions
+
+Repository:
+- slug: $Repo
+- local_path: $RepoRootValue
+- worker_name: $Worker
+
+Target issue:
+- number: $IssueNumber
+- packet_path: $packetPath
+
+Execution requirements:
+- Read the issue packet before acting.
+- Handle exactly this one issue.
+- Use GitHub CLI if you need to inspect PRs or issues.
+- Use git locally for branch/commit work.
+- Do not wait for a human if the issue can be advanced.
+- Return JSON that matches the schema file at: $schemaPath
+"@
+
+    $prompt | Set-Content -LiteralPath $promptPath
+
+    $args = @(
+        "exec",
+        "--cd", $RepoRootValue,
+        "--add-dir", $runDir,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--output-schema", $schemaPath,
+        "--output-last-message", $resultPath,
+        "-"
+    )
+
+    Get-Content -LiteralPath $promptPath -Raw |
+        & $CodexPath @args 1> $stdoutPath 2> $stderrPath
+    $exitCode = $LASTEXITCODE
+
+    $resultObject = $null
+    if (Test-Path -LiteralPath $resultPath) {
+        try {
+            $resultObject = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+        }
+        catch {
+            $resultObject = $null
+        }
+    }
+
+    return @{
+        Attempt = $attempt
+        ExitCode = $exitCode
+        RunDirectory = $runDir
+        Result = $resultObject
+        StdoutPath = $stdoutPath
+        StderrPath = $stderrPath
+        ResultPath = $resultPath
+    }
+}
+
+function Format-WorkerComment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Worker,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Attempt,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Result
+    )
+
+    $validationLines = @()
+    foreach ($line in $Result.validation) {
+        $validationLines += "- $line"
+    }
+
+    if (-not $validationLines) {
+        $validationLines = @("- No validation details were reported.")
+    }
+
+    $prLine = if ($Result.pr_url) { "- PR: $($Result.pr_url)" } else { "- PR: none" }
+    $branchLine = if ($Result.branch) { "- Branch: $($Result.branch)" } else { "- Branch: none" }
+    $commitLine = if ($Result.commit) { "- Commit: $($Result.commit)" } else { "- Commit: none" }
+
+    return @"
+Autonomous worker update from `$Worker`:
+
+- Attempt: $Attempt
+- Status: $($Result.status)
+$branchLine
+$commitLine
+$prLine
+
+Summary:
+$($Result.summary)
+
+Validation:
+$($validationLines -join [Environment]::NewLine)
+
+Worker note:
+$($Result.issue_comment)
+"@
+}
+
+function Apply-ResultToIssue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Worker,
+
+        [Parameter(Mandatory = $true)]
+        [int]$IssueNumber,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$InvocationResult
+    )
+
+    $attempt = $InvocationResult.Attempt
+    $result = $InvocationResult.Result
+    $exitCode = $InvocationResult.ExitCode
+
+    if ($exitCode -ne 0 -or -not $result) {
+        if ($attempt -ge $MaxAttemptsPerIssue) {
+            Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -AddLabels @($BlockedLabel) -RemoveLabels @($ActiveLabel, $QueueLabel)
+            Comment-OnIssue -Repo $Repo -IssueNumber $IssueNumber -Body @"
+Autonomous worker `$Worker` could not complete issue #$IssueNumber after $attempt attempts.
+
+- Codex exit code: $exitCode
+- Last run directory: $($InvocationResult.RunDirectory)
+
+The issue has been moved out of the queue and marked blocked for human review.
+"@
+            return "blocked"
+        }
+
+        Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -RemoveLabels @($ActiveLabel)
+        Comment-OnIssue -Repo $Repo -IssueNumber $IssueNumber -Body @"
+Autonomous worker `$Worker` failed attempt $attempt on issue #$IssueNumber.
+
+- Codex exit code: $exitCode
+- Last run directory: $($InvocationResult.RunDirectory)
+
+The issue remains queued and will be retried automatically.
+"@
+        return "retry"
+    }
+
+    $comment = Format-WorkerComment -Worker $Worker -Attempt $attempt -Result $result
+    Comment-OnIssue -Repo $Repo -IssueNumber $IssueNumber -Body $comment
+
+    switch ($result.status) {
+        "completed" {
+            Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -AddLabels @($CompleteLabel) -RemoveLabels @($QueueLabel, $ActiveLabel, $BlockedLabel)
+            Clear-IssueAttemptCount -StateRoot $StateRoot -IssueNumber $IssueNumber
+            return "completed"
+        }
+        "blocked" {
+            Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -AddLabels @($BlockedLabel) -RemoveLabels @($QueueLabel, $ActiveLabel)
+            return "blocked"
+        }
+        "needs_human" {
+            Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -AddLabels @($BlockedLabel) -RemoveLabels @($QueueLabel, $ActiveLabel)
+            return "needs_human"
+        }
+        default {
+            if ($attempt -ge $MaxAttemptsPerIssue) {
+                Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -AddLabels @($BlockedLabel) -RemoveLabels @($QueueLabel, $ActiveLabel)
+                return "blocked"
+            }
+
+            Edit-IssueLabels -Repo $Repo -IssueNumber $IssueNumber -RemoveLabels @($ActiveLabel)
+            return "retry"
+        }
+    }
+}
+
+function Acquire-Lock {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$StateRoot
+    )
+
+    $lockPath = Join-Path $StateRoot "worker.lock"
+
+    if (Test-Path -LiteralPath $lockPath) {
+        $existing = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json
+        $pidValue = [int]$existing.pid
+        if (Get-Process -Id $pidValue -ErrorAction SilentlyContinue) {
+            Write-Log "Another queue worker process is already active (PID $pidValue). Exiting."
+            return $null
+        }
+    }
+
+    $payload = @{
+        pid = $PID
+        created_at = (Get-Date).ToString("o")
+        repo = $RepoSlug
+    }
+    $payload | ConvertTo-Json | Set-Content -LiteralPath $lockPath
+    return $lockPath
+}
+
+function Release-Lock {
+    param(
+        [string]$LockPath
+    )
+
+    if ($LockPath -and (Test-Path -LiteralPath $LockPath)) {
+        Remove-Item -LiteralPath $LockPath -Force
+    }
+}
+
+Add-ToolPath
+
+$stateRoot = Get-StateRoot -RepoSlugValue $RepoSlug
+$script:WorkerLogPath = Join-Path $stateRoot "worker.log"
+$lockPath = Acquire-Lock -StateRoot $stateRoot
+if (-not $lockPath) {
+    exit 0
+}
+
+try {
+    Ensure-QueueLabels -Repo $RepoSlug
+    $codexPath = Ensure-LocalCodexBinary -StateRoot $stateRoot
+    Write-Log "Using local Codex binary at $codexPath"
+
+    $processedCount = 0
+    while ($processedCount -lt $MaxIssuesPerRun) {
+        $nextIssue = Get-NextQueuedIssue -Repo $RepoSlug
+        if (-not $nextIssue) {
+            Write-Log "Queue is empty."
+            break
+        }
+
+        $issueNumber = [int]$nextIssue.number
+        Write-Log "Claiming issue #$issueNumber - $($nextIssue.title)"
+
+        Edit-IssueLabels -Repo $RepoSlug -IssueNumber $issueNumber -AddLabels @($ActiveLabel) -RemoveLabels @($BlockedLabel, $CompleteLabel)
+        Comment-OnIssue -Repo $RepoSlug -IssueNumber $issueNumber -Body "Autonomous worker `$WorkerName` claimed this issue and is starting work now."
+
+        $packet = Get-IssuePacket -Repo $RepoSlug -IssueNumber $issueNumber
+        $invocation = Invoke-CodexIssueRun -CodexPath $codexPath -RepoRootValue $RepoRoot -StateRoot $stateRoot -Repo $RepoSlug -Worker $WorkerName -IssueNumber $issueNumber -IssuePacket $packet
+        $outcome = Apply-ResultToIssue -Repo $RepoSlug -StateRoot $stateRoot -Worker $WorkerName -IssueNumber $issueNumber -InvocationResult $invocation
+
+        Write-Log "Issue #$issueNumber finished with queue outcome '$outcome'."
+        $processedCount += 1
+    }
+
+    Write-Log "Processed $processedCount issue(s) this run."
+}
+finally {
+    Release-Lock -LockPath $lockPath
+}

--- a/ops/codex-queue/issue-output-schema.json
+++ b/ops/codex-queue/issue-output-schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "completed",
+        "needs_human",
+        "blocked",
+        "failed"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issue_comment": {
+      "type": "string",
+      "minLength": 1
+    },
+    "branch": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "commit": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "pr_url": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "validation": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "needs_follow_up": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "status",
+    "summary",
+    "issue_comment",
+    "branch",
+    "commit",
+    "pr_url",
+    "validation",
+    "needs_follow_up"
+  ]
+}

--- a/ops/codex-queue/worker-instructions.md
+++ b/ops/codex-queue/worker-instructions.md
@@ -1,0 +1,26 @@
+You are the autonomous issue worker for this repository.
+
+Your job is to handle exactly one GitHub issue end-to-end.
+
+Important constraints:
+
+- Do not ask a human whether to continue.
+- Do not stop after partial analysis if the issue can be advanced further.
+- Work the issue until it reaches a terminal state:
+  - `completed`
+  - `needs_human`
+  - `blocked`
+  - `failed`
+- If the issue is actionable, make the code changes, run validation, commit, push, and open or update a PR when appropriate.
+- If the issue is blocked, explain precisely what is missing and what a human must do next.
+
+Operational rules:
+
+- Use the local repository checkout as the source of truth.
+- Prefer existing project conventions over inventing new ones.
+- Use a dedicated branch for the issue if you make changes.
+- If you create or update a PR, include the issue number in the PR body or references when appropriate.
+- Leave the repository in a coherent state.
+- At the end, return JSON matching the provided output schema.
+
+The queue worker script will handle outer queue state and issue labels. Your responsibility is only this one issue.

--- a/scripts/ci/run-live-scenario.ps1
+++ b/scripts/ci/run-live-scenario.ps1
@@ -1,0 +1,178 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScenarioPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactRoot,
+
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+
+    [bool]$RunTests = $true,
+
+    [bool]$ExecuteLiveDriver = $true
+)
+
+$ErrorActionPreference = "Stop"
+
+function New-ArtifactDirectory {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    New-Item -ItemType Directory -Force -Path $Path | Out-Null
+    return $Path
+}
+
+function Copy-IfExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Destination
+    )
+
+    if (Test-Path -LiteralPath $Source) {
+        Copy-Item -LiteralPath $Source -Destination $Destination -Recurse -Force
+        return $true
+    }
+
+    return $false
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$resolvedScenarioPath = (Resolve-Path (Join-Path $repoRoot $ScenarioPath)).Path
+$startTime = Get-Date
+
+$artifactRoot = New-ArtifactDirectory -Path $ArtifactRoot
+$logsDir = New-ArtifactDirectory -Path (Join-Path $artifactRoot "logs")
+$screenshotsDir = New-ArtifactDirectory -Path (Join-Path $artifactRoot "screenshots")
+$runDataDir = New-ArtifactDirectory -Path (Join-Path $artifactRoot "run-data")
+$buildDir = New-ArtifactDirectory -Path (Join-Path $artifactRoot "build")
+$scenarioDir = New-ArtifactDirectory -Path (Join-Path $artifactRoot "scenario")
+$driverOutputDir = New-ArtifactDirectory -Path (Join-Path $artifactRoot "driver-output")
+
+Copy-Item -LiteralPath $resolvedScenarioPath -Destination (Join-Path $scenarioDir (Split-Path $resolvedScenarioPath -Leaf)) -Force
+
+$sts2Path = $env:CARD_UTILITY_STATS_STS2_PATH
+if ([string]::IsNullOrWhiteSpace($sts2Path)) {
+    $sts2Path = "C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2"
+}
+
+$modsPath = Join-Path $sts2Path "mods"
+$defaultUserRoot = Join-Path $env:APPDATA "SlayTheSpire2\CardUtilityStats"
+$liveRunDataSource = $env:CARD_UTILITY_STATS_RUN_DATA_DIR
+if ([string]::IsNullOrWhiteSpace($liveRunDataSource)) {
+    $liveRunDataSource = Join-Path $defaultUserRoot "runs"
+}
+
+$driverScript = $env:CARD_UTILITY_STATS_LIVE_DRIVER
+$metadata = [ordered]@{
+    started_at = $startTime.ToString("o")
+    scenario_path = $ScenarioPath
+    scenario_manifest = $resolvedScenarioPath
+    execute_live_driver = $ExecuteLiveDriver
+    run_tests = $RunTests
+    runner_name = $env:RUNNER_NAME
+    runner_os = $env:RUNNER_OS
+    git_sha = $env:GITHUB_SHA
+    git_ref = $env:GITHUB_REF
+    repository = $env:GITHUB_REPOSITORY
+    sts2_path = $sts2Path
+    run_data_source = $liveRunDataSource
+    mods_path = $modsPath
+    driver_script = $driverScript
+}
+
+$metadata | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $artifactRoot "run-metadata.json")
+
+Push-Location $repoRoot
+try {
+    $testProject = Join-Path $repoRoot "Tests\CardUtilityStats.Core.Tests\CardUtilityStats.Core.Tests.csproj"
+    $testResultsDir = Join-Path $logsDir "test-results"
+    $testArgs = @(
+        "test",
+        $testProject,
+        "-c", $Configuration,
+        "--results-directory", $testResultsDir,
+        "--logger", "trx;LogFileName=tests.trx"
+    )
+    $buildArgs = @(
+        "build",
+        "CardUtilityStats.csproj",
+        "-c", $Configuration,
+        "/p:ContinuousIntegrationBuild=true"
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($sts2Path)) {
+        $testArgs += "/p:Sts2Path=$sts2Path"
+        $buildArgs += "/p:Sts2Path=$sts2Path"
+    }
+
+    if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        throw "dotnet is not available on PATH for this worker. Install the .NET SDK or keep actions/setup-dotnet enabled."
+    }
+
+    if ($RunTests) {
+        & dotnet @testArgs
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet test failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    & dotnet @buildArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet build failed with exit code $LASTEXITCODE"
+    }
+
+    $releaseOutput = Join-Path $repoRoot ("bin\" + $Configuration)
+    Copy-IfExists -Source $releaseOutput -Destination (Join-Path $buildDir "loader-output") | Out-Null
+    Copy-IfExists -Source (Join-Path $modsPath "CardUtilityStats") -Destination (Join-Path $buildDir "mods-deploy") | Out-Null
+
+    if ($ExecuteLiveDriver) {
+        if ([string]::IsNullOrWhiteSpace($driverScript)) {
+            throw "CARD_UTILITY_STATS_LIVE_DRIVER is not set on this worker. Point it at the local STS2 automation script."
+        }
+
+        if (-not (Test-Path -LiteralPath $driverScript)) {
+            throw "Live driver script '$driverScript' does not exist on this worker."
+        }
+
+        & $driverScript `
+            -ScenarioPath $resolvedScenarioPath `
+            -ArtifactRoot $driverOutputDir `
+            -ScreenshotsDir $screenshotsDir `
+            -LogsDir $logsDir `
+            -RunDataDir $runDataDir `
+            -Sts2Path $sts2Path
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "Live driver failed with exit code $LASTEXITCODE"
+        }
+    }
+    else {
+        @(
+            "Live driver execution was skipped for this dispatch.",
+            "Set execute_live_driver=true when the worker-local automation script is ready."
+        ) | Set-Content -LiteralPath (Join-Path $driverOutputDir "driver-skipped.txt")
+    }
+
+    if (Test-Path -LiteralPath $liveRunDataSource) {
+        Get-ChildItem -LiteralPath $liveRunDataSource -File |
+            Where-Object { $_.LastWriteTime -ge $startTime } |
+            ForEach-Object {
+                Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $runDataDir $_.Name) -Force
+            }
+    }
+
+    $prefsPath = Join-Path $defaultUserRoot "prefs.json"
+    if (Test-Path -LiteralPath $prefsPath) {
+        Copy-Item -LiteralPath $prefsPath -Destination (Join-Path $runDataDir "prefs.json") -Force
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow for self-hosted Windows STS2 live runs
- add a runner-side PowerShell harness for build, test, artifact staging, and worker-local live-driver handoff
- document the live worker bootstrap flow and check in initial scenario manifests

## Validation
- dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -c Release /p:Sts2Path='D:\SteamLibrary\steamapps\common\Slay the Spire 2'
- dotnet build CardUtilityStats.csproj -c Release /p:Sts2Path='D:\SteamLibrary\steamapps\common\Slay the Spire 2'
- registered this machine as self-hosted runner sts2-side-a with labels sts2-live,sts2-side-a

## Notes
- current rollout is one side machine first; the workflow still targets the shared sts2-live label so a second worker can be added later
- execute_live_driver=false can be used until the worker-local STS2 automation script exists