### PR TITLE
Document pull-only GitHub-source-of-truth workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attribution: not just what a card says it should do, but what it actually caused in the run.
 
+## GitHub Source Of Truth
+
+This repo now uses a **pull-only** workflow with GitHub as the source of truth. The policy is documented in [docs/pull-only-workflow.md](docs/pull-only-workflow.md).
+
+- Do not read from the local filesystem for repository state.
+- Do not write to the local filesystem for repository changes.
+- Do not use local `git` or local `gh` as the normal mutation path.
+- Read and write repo state through GitHub-backed tools only.
+- If a remote branch, commit, or PR cannot be produced, stop and report blocked.
+
 ## Current Truths
 
 - Runtime is split into a stable loader and a hot-reloaded core.
@@ -29,6 +39,7 @@ This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attributi
 ## Start Here
 
 - Read [README.md](D:/repos/CardUtilityStats/README.md:1) for the product-level overview.
+- Read [docs/pull-only-workflow.md](docs/pull-only-workflow.md) for the repo's GitHub-native workflow policy.
 - Read [docs/architecture.md](D:/repos/CardUtilityStats/docs/architecture.md:1) for subsystem layout and data flow.
 - For tracking behavior, start in [Core/RunTracker.cs](D:/repos/CardUtilityStats/Core/RunTracker.cs:18).
 - For tooltip/UI behavior, start in:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered
 
 For codebase orientation, start with [AGENTS.md](D:/repos/CardUtilityStats/AGENTS.md:1) and [docs/architecture.md](D:/repos/CardUtilityStats/docs/architecture.md:1).
 
+## Development Workflow
+
+This repo now runs in **pull-only** mode for assistant-driven work, with GitHub as the source of truth.
+
+- Assistant sessions should read and write repository state through GitHub-backed tools only.
+- Local filesystem reads and writes are out of bounds for normal repo work.
+- Changes should materialize as remote artifacts: branch, commit, and pull request.
+- If a remote artifact cannot be produced, the work should stop as blocked rather than leaving hidden local state behind.
+
+The detailed policy lives in [docs/pull-only-workflow.md](docs/pull-only-workflow.md).
+
 ## Why
 
 Existing stats mods answer "how often did I *pick* this card" ([SlayTheStats](https://www.nexusmods.com/slaythespire2/mods/349)) or "how much value did this *relic* provide" ([Relic Stats](https://www.nexusmods.com/slaythespire2/mods/327)). Nothing tracks how much of what each card *attempted* actually mattered. A 6-damage Strike into a 4-HP enemy and a 6-damage Strike into a fresh elite look the same on a play counter, but they have very different value.

--- a/docs/pull-only-workflow.md
+++ b/docs/pull-only-workflow.md
@@ -1,0 +1,41 @@
+# Pull-Only Workflow
+
+This repo is operated in **pull-only** mode, with GitHub as the source of truth for repository state.
+
+## Policy
+
+- Do not read from the local filesystem to determine repo state.
+- Do not write to the local filesystem to make repo changes.
+- Do not use local `git` or local `gh` as the normal repo mutation path.
+- Use GitHub-backed tools to read files, create branches, update files, and open pull requests.
+- If a remote branch, commit, or PR cannot be produced, stop and report the blocker.
+
+## Expected Flow
+
+1. Read the current repo state from GitHub.
+2. Create or update a remote branch.
+3. Materialize changes as remote commits.
+4. Open or update a pull request early so progress is visible.
+5. Pull or fetch locally only when a human explicitly wants to inspect or sync the remote result.
+
+## Why
+
+Local repository state is hidden, mutable, and workstation-specific. Remote GitHub artifacts are visible, reviewable, and durable.
+
+This workflow keeps the unit of change explicit:
+
+- branch URL instead of "I changed it"
+- commit URL instead of "it's ready locally"
+- pull request URL instead of "I can push next"
+
+## Communication Contract
+
+Report outcomes as:
+
+- `no local changes made`
+- `remote branch created`
+- `commit pushed`
+- `PR opened`
+- `blocked`
+
+Avoid ambiguous wording like "I updated it" unless the remote artifact is named explicitly.


### PR DESCRIPTION
## Summary
- add a dedicated pull-only workflow doc
- make the GitHub-source-of-truth policy visible in `AGENTS.md`
- add the new assistant workflow policy to `README.md`

## Testing
- not run (docs only)
