### PR TITLE
Keep BaseLib at the boundary and add config/API bridges

### DIFF
--- a/Api/CardUtilityStatsApiRegistry.cs
+++ b/Api/CardUtilityStatsApiRegistry.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using CardUtilityStats.Loader;
+
+namespace CardUtilityStats.Api;
+
+public static class CardUtilityStatsApiRegistry
+{
+    public static ICardUtilityStatsApi Api { get; } = new ReflectionBackedCardUtilityStatsApi();
+
+    public static bool IsCoreLoaded => Api.IsCoreLoaded;
+    public static int CurrentSchemaVersion => Api.CurrentSchemaVersion;
+    public static string GetRuntimeOptionsJson() => Api.GetRuntimeOptionsJson();
+    public static string? GetCurrentRunJson() => Api.GetCurrentRunJson();
+    public static string? TryGetCardAggregateJson(object? cardModel) => Api.TryGetCardAggregateJson(cardModel);
+
+    private sealed class ReflectionBackedCardUtilityStatsApi : ICardUtilityStatsApi
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new();
+
+        public bool IsCoreLoaded => ResolveLatestCoreType("CardUtilityStats.Core.RunTracker") != null;
+
+        public int CurrentSchemaVersion
+        {
+            get
+            {
+                var field = ResolveLatestCoreType("CardUtilityStats.Core.RunData")
+                    ?.GetField("CurrentSchemaVersion", BindingFlags.Public | BindingFlags.Static);
+                var value = field?.GetValue(null);
+                return value is int schemaVersion ? schemaVersion : 0;
+            }
+        }
+
+        public string GetRuntimeOptionsJson()
+        {
+            return RuntimeOptionsBridge.GetCurrentOptionsJson();
+        }
+
+        public string? GetCurrentRunJson()
+        {
+            var currentRun = ResolveLatestCoreType("CardUtilityStats.Core.RunTracker")
+                ?.GetProperty("Current", BindingFlags.Public | BindingFlags.Static)
+                ?.GetValue(null);
+            return Serialize(currentRun);
+        }
+
+        public string? TryGetCardAggregateJson(object? cardModel)
+        {
+            if (cardModel == null) return null;
+
+            var method = ResolveLatestCoreType("CardUtilityStats.Core.RunTracker")
+                ?.GetMethod("GetEffectiveAggregate", BindingFlags.Public | BindingFlags.Static);
+            if (method == null) return null;
+
+            var parameters = method.GetParameters();
+            if (parameters.Length != 1 || !parameters[0].ParameterType.IsInstanceOfType(cardModel))
+                return null;
+
+            var aggregate = method.Invoke(null, new[] { cardModel });
+            return Serialize(aggregate);
+        }
+
+        private static Type? ResolveLatestCoreType(string typeName)
+        {
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .Select(assembly => new { Assembly = assembly, Type = assembly.GetType(typeName, throwOnError: false) })
+                .Where(entry => entry.Type != null)
+                .OrderByDescending(entry => GetCoreGeneration(entry.Assembly))
+                .Select(entry => entry.Type)
+                .FirstOrDefault();
+        }
+
+        private static int GetCoreGeneration(Assembly assembly)
+        {
+            const string prefix = "CardUtilityStats.Core.";
+            var name = assembly.GetName().Name ?? string.Empty;
+            if (name.StartsWith(prefix, StringComparison.Ordinal) &&
+                int.TryParse(name.Substring(prefix.Length), out var generation))
+                return generation;
+
+            return 0;
+        }
+
+        private static string? Serialize(object? value)
+        {
+            if (value == null) return null;
+            return JsonSerializer.Serialize(value, value.GetType(), JsonOptions);
+        }
+    }
+}

--- a/Api/ICardUtilityStatsApi.cs
+++ b/Api/ICardUtilityStatsApi.cs
@@ -1,0 +1,10 @@
+namespace CardUtilityStats.Api;
+
+public interface ICardUtilityStatsApi
+{
+    bool IsCoreLoaded { get; }
+    int CurrentSchemaVersion { get; }
+    string GetRuntimeOptionsJson();
+    string? GetCurrentRunJson();
+    string? TryGetCardAggregateJson(object? cardModel);
+}

--- a/CardUtilityStats.csproj
+++ b/CardUtilityStats.csproj
@@ -35,9 +35,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="*" PrivateAssets="All" GeneratePathProperty="true"/>
+        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="3.0.8" PrivateAssets="All" GeneratePathProperty="true"/>
         <PackageReference Include="Krafs.Publicizer" Version="2.3.0" PrivateAssets="All"/>
-        <PackageReference Include="Alchyr.Sts2.ModAnalyzers" Version="*" />
+        <PackageReference Include="Alchyr.Sts2.ModAnalyzers" Version="0.1.9" />
         <!-- Mono.Cecil: rewrites the Core assembly's manifest name per load so
              the ALC treats each reload as a distinct assembly. Without this,
              .NET dedupes by short name and hot reload silently no-ops. -->

--- a/Config/CardUtilityStatsConfig.cs
+++ b/Config/CardUtilityStatsConfig.cs
@@ -1,0 +1,20 @@
+using BaseLib.Config;
+
+namespace CardUtilityStats.Config;
+
+public sealed class CardUtilityStatsConfig : SimpleModConfig
+{
+    [ConfigSection("Deck View")]
+    public static bool ViewStatsToggleEnabled { get; set; }
+
+    public static bool ShowRemovedCardsInDeckView { get; set; } = true;
+
+    [ConfigSection("Tooltips")]
+    public static bool ShowHandTooltips { get; set; } = true;
+
+    [ConfigSection("Diagnostics")]
+    public static bool EnableDebugLogging { get; set; }
+
+    [ConfigHideInUI]
+    public static bool LegacyPrefsMigrated { get; set; }
+}

--- a/Core/CardUtilityStats.Core.csproj
+++ b/Core/CardUtilityStats.Core.csproj
@@ -52,7 +52,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="*" PrivateAssets="All"/>
         <PackageReference Include="Krafs.Publicizer" Version="2.3.0" PrivateAssets="All"/>
     </ItemGroup>
 

--- a/Core/CoreMain.cs
+++ b/Core/CoreMain.cs
@@ -28,8 +28,8 @@ namespace CardUtilityStats.Core;
 /// We previously tried collectible AssemblyLoadContext (to actually reclaim
 /// memory on unload) but that approach is "fundamentally flawed" per
 /// Microsoft's own runtime team: it requires every dependency to be
-/// collectible-safe, and Harmony + Godot + Publicizer + BaseLib are not.
-/// See research commit for details.
+/// collectible-safe, and Harmony + Godot + Publicizer + loader-side BaseLib
+/// are not. See research commit for details.
 /// </summary>
 public static class CoreMain
 {
@@ -45,9 +45,10 @@ public static class CoreMain
     /// <summary>
     /// Our own debug gate — when true, per-event and per-hook logs write out;
     /// when false, only structural milestones (Initialize/Shutdown/RunStarted/
-    /// CombatEnded etc.) do. Toggled by the CUS_DEBUG environment variable
-    /// at Initialize time. NOT using MegaCrit's GlobalLogLevel because that's
-    /// process-wide — flipping it would make every other mod spam too.
+    /// CombatEnded etc.) do. Toggled by the BaseLib-backed settings UI or the
+    /// CUS_DEBUG environment variable. NOT using MegaCrit's GlobalLogLevel
+    /// because that's process-wide — flipping it would make every other mod
+    /// spam too.
     /// </summary>
     public static bool DebugLogging { get; private set; }
 
@@ -67,15 +68,16 @@ public static class CoreMain
     public static void Initialize()
     {
         Logger.ActivateGameLogger();
+        RuntimeOptionsProvider.Refresh();
 
-        // Read debug gate from env var. Any non-empty truthy value enables;
-        // default (unset / "0" / "false") stays quiet. Read in Initialize so
-        // a dev can flip it between hot-reloads by changing their shell env
-        // before relaunching — though in practice once set it usually stays.
+        // Read debug gate from both config and env var. The env var remains a
+        // handy one-off override for development sessions without touching the
+        // persisted settings UI toggle.
         var envDebug = System.Environment.GetEnvironmentVariable("CUS_DEBUG");
-        DebugLogging = !string.IsNullOrEmpty(envDebug)
+        var envDebugEnabled = !string.IsNullOrEmpty(envDebug)
             && envDebug != "0"
             && !envDebug.Equals("false", StringComparison.OrdinalIgnoreCase);
+        DebugLogging = RuntimeOptionsProvider.Current.EnableDebugLogging || envDebugEnabled;
 
         Logger.Info($"Core.Initialize starting (harmony_id={_harmonyId}, debug={DebugLogging})");
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -44,6 +44,10 @@ public static class CardHoverShowPatch
         // hovers on cards with multiple keyword tooltips like Coolheaded),
         // we stack above instead.
 
+        RuntimeOptionsProvider.Refresh();
+        if (__instance is NHandCardHolder && !RuntimeOptionsProvider.Current.ShowHandTooltips)
+            return;
+
         // Gate on our checkbox state. If it's not even injected yet (no deck
         // view opened this session) or unchecked, do nothing.
         var tickbox = ViewStatsInjectorPatch.LastInjectedTickbox;
@@ -411,6 +415,7 @@ public static class CardHoverShowPatch
 
         if (isUnplayable)
         {
+            // For unplayable cards, just show Drawn. Played is always 0.
             Row3(sb, GetDrawStatLabel("drawn"), agg.TimesDrawn.ToString(), "");
         }
         else
@@ -419,8 +424,8 @@ public static class CardHoverShowPatch
             Row3(sb, "Played/Drawn", $"{agg.Plays}/{agg.TimesDrawn}", $"{playRate:F0}%");
         }
 
-        if (isAttack || agg.TotalEffective > 0)
-            Row3(sb, "Total damage", agg.TotalEffective.ToString(), "");
+        bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: true);
+        AppendAppliedEffects(sb, agg, compact: true, excludePoison: hasDedicatedPoison);
 
         if (agg.TotalEnergyGenerated > 0)
             Row3(sb, GetEnergyStatLabel("gained"), agg.TotalEnergyGenerated.ToString(), "");
@@ -431,23 +436,27 @@ public static class CardHoverShowPatch
         if (agg.TotalForgeGenerated > 0m)
             Row3(sb, GetForgeStatLabel("gained"), FormatDecimal(agg.TotalForgeGenerated), "");
 
+        AppendMakeItSoStats(sb, cardModel, agg, compact: true);
+
+        bool showDamage = isAttack || agg.TotalIntended > 0;
+        if (showDamage)
+        {
+            Row3(sb, "Total damage", agg.TotalEffective.ToString(), "");
+            if (agg.Kills > 0) Row3(sb, "Kills", agg.Kills.ToString(), "");
+        }
+
         if (agg.TotalBlockGained > 0)
             Row3(sb, GetBlockStatLabel("gained"), agg.TotalBlockGained.ToString(), "");
 
-        bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: true);
-        AppendAppliedEffects(sb, agg, compact: true, excludePoison: hasDedicatedPoison);
-        AppendArtifactBlockedSummary(sb, agg, excludePoison: hasDedicatedPoison);
-
-        if (agg.Kills > 0)
-            Row3(sb, "Kills", agg.Kills.ToString(), "");
+        if (agg.TotalHpLost > 0)
+            Row3(sb, "HP lost", agg.TotalHpLost.ToString(), "");
     }
 
     /// <summary>
-    /// Whether this card is a member of the player's permanent deck, vs.
-    /// a transient combat-only card (Souls, Shivs, short-lived generated
-    /// cards, transformed cards that haven't been added to the deck).
-    /// We canonicalize both sides — combat clones' DeckVersion points at
-    /// their deck original, so comparing canonical refs lands correctly.
+    /// A deck card is "in deck" if its canonical deck reference still
+    /// exists in the player's permanent deck list. Combat clones point back
+    /// to the deck original via DeckVersion; deck-view cards are already the
+    /// canonical object. Removed cards are intentionally NOT in the list.
     ///
     /// If we can't read the deck state (no active run, etc.) we default to
     /// TRUE so we fall back to the normal lineage display. That's the safer

--- a/Core/Patches/DeckViewInjectRemovedPatch.cs
+++ b/Core/Patches/DeckViewInjectRemovedPatch.cs
@@ -48,6 +48,9 @@ public static class DeckViewInjectRemovedPatch
             // (a separate field on the screen), not the order of _cards.
             __instance._cards = __instance._pile.Cards.ToList();
 
+            RuntimeOptionsProvider.Refresh();
+            if (!RuntimeOptionsProvider.Current.ShowRemovedCardsInDeckView) return;
+
             var tickbox = ViewStatsInjectorPatch.LastInjectedTickbox;
             if (tickbox == null || !tickbox.IsTicked) return;
 

--- a/Core/Prefs.cs
+++ b/Core/Prefs.cs
@@ -1,19 +1,12 @@
 using System;
-using System.IO;
-using System.Text.Json;
 using System.Text.Json.Serialization;
-using Godot;
 
 namespace CardUtilityStats.Core;
 
 /// <summary>
-/// Cross-reload user preferences. Lives on disk next to run files so it
-/// survives Core hot reloads (static state resets every reload, so memory-
-/// only preferences would get wiped on every F5).
-///
-/// Currently minimal — just the View Stats checkbox state. Expand as more
-/// session-level preferences accumulate (sort preferences, display
-/// toggles, etc.).
+/// Compatibility shim for the old deck-view toggle persistence path.
+/// The injected deck-view UI still reads and writes PrefsStorage, but the
+/// actual persisted state now lives in the loader-side BaseLib config.
 /// </summary>
 public class Prefs
 {
@@ -23,35 +16,25 @@ public class Prefs
 
 public static class PrefsStorage
 {
-    private static readonly JsonSerializerOptions Options = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
-    public static string Path => ProjectSettings.GlobalizePath("user://CardUtilityStats/prefs.json");
-
     public static Prefs Load()
     {
         try
         {
-            if (File.Exists(Path))
-                return JsonSerializer.Deserialize<Prefs>(File.ReadAllText(Path), Options) ?? new Prefs();
+            var options = RuntimeOptionsProvider.Refresh();
+            return new Prefs { ViewStatsTicked = options.ViewStatsToggleEnabled };
         }
         catch (Exception e)
         {
             CoreMain.Logger.Error($"PrefsStorage.Load failed: {e}");
+            return new Prefs();
         }
-        return new Prefs();
     }
 
     public static void Save(Prefs prefs)
     {
         try
         {
-            var dir = System.IO.Path.GetDirectoryName(Path);
-            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-            File.WriteAllText(Path, JsonSerializer.Serialize(prefs, Options));
+            RuntimeOptionsProvider.SetViewStatsToggleEnabled(prefs.ViewStatsTicked);
         }
         catch (Exception e)
         {

--- a/Core/RuntimeOptions.cs
+++ b/Core/RuntimeOptions.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+
+namespace CardUtilityStats.Core;
+
+public sealed class RuntimeOptions
+{
+    public bool ViewStatsToggleEnabled { get; set; }
+    public bool ShowRemovedCardsInDeckView { get; set; } = true;
+    public bool ShowHandTooltips { get; set; } = true;
+    public bool EnableDebugLogging { get; set; }
+}
+
+public static class RuntimeOptionsProvider
+{
+    private const string BridgeTypeName = "CardUtilityStats.Loader.RuntimeOptionsBridge";
+    private const string GetCurrentOptionsJsonMethodName = "GetCurrentOptionsJson";
+    private const string SetViewStatsToggleEnabledMethodName = "SetViewStatsToggleEnabled";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static Type? _bridgeType;
+    private static MethodInfo? _getCurrentOptionsJsonMethod;
+    private static MethodInfo? _setViewStatsToggleEnabledMethod;
+    private static bool _loggedMissingBridge;
+    private static bool _loggedRefreshFailure;
+    private static bool _loggedToggleFailure;
+
+    public static RuntimeOptions Current { get; private set; } = new();
+
+    public static RuntimeOptions Refresh()
+    {
+        try
+        {
+            var getOptionsMethod = ResolveGetCurrentOptionsJsonMethod();
+            if (getOptionsMethod == null) return Current;
+
+            var json = getOptionsMethod.Invoke(null, null) as string;
+            if (string.IsNullOrWhiteSpace(json)) return Current;
+
+            Current = JsonSerializer.Deserialize<RuntimeOptions>(json, JsonOptions) ?? new RuntimeOptions();
+            _loggedRefreshFailure = false;
+        }
+        catch (Exception e)
+        {
+            if (!_loggedRefreshFailure)
+            {
+                CoreMain.Logger.Warn($"RuntimeOptionsProvider.Refresh failed: {e.Message}");
+                _loggedRefreshFailure = true;
+            }
+        }
+
+        return Current;
+    }
+
+    public static void SetViewStatsToggleEnabled(bool isEnabled)
+    {
+        try
+        {
+            var setToggleMethod = ResolveSetViewStatsToggleEnabledMethod();
+            setToggleMethod?.Invoke(null, new object?[] { isEnabled });
+            _loggedToggleFailure = false;
+        }
+        catch (Exception e)
+        {
+            if (!_loggedToggleFailure)
+            {
+                CoreMain.Logger.Warn($"RuntimeOptionsProvider.SetViewStatsToggleEnabled failed: {e.Message}");
+                _loggedToggleFailure = true;
+            }
+        }
+
+        Refresh();
+    }
+
+    private static MethodInfo? ResolveGetCurrentOptionsJsonMethod()
+    {
+        _getCurrentOptionsJsonMethod ??= ResolveBridgeType()?.GetMethod(
+            GetCurrentOptionsJsonMethodName,
+            BindingFlags.Public | BindingFlags.Static);
+        return _getCurrentOptionsJsonMethod;
+    }
+
+    private static MethodInfo? ResolveSetViewStatsToggleEnabledMethod()
+    {
+        _setViewStatsToggleEnabledMethod ??= ResolveBridgeType()?.GetMethod(
+            SetViewStatsToggleEnabledMethodName,
+            BindingFlags.Public | BindingFlags.Static);
+        return _setViewStatsToggleEnabledMethod;
+    }
+
+    private static Type? ResolveBridgeType()
+    {
+        if (_bridgeType != null) return _bridgeType;
+
+        _bridgeType = AppDomain.CurrentDomain.GetAssemblies()
+            .Select(assembly => assembly.GetType(BridgeTypeName, throwOnError: false))
+            .FirstOrDefault(type => type != null);
+
+        if (_bridgeType == null && !_loggedMissingBridge)
+        {
+            CoreMain.Logger.Warn("RuntimeOptionsProvider could not find the loader bridge; using default options.");
+            _loggedMissingBridge = true;
+        }
+
+        return _bridgeType;
+    }
+}

--- a/Loader/LoaderMain.cs
+++ b/Loader/LoaderMain.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading;
+using BaseLib.Config;
+using CardUtilityStats.Config;
 using Godot;
 using MegaCrit.Sts2.Core.Logging;
 using MegaCrit.Sts2.Core.Modding;
@@ -12,9 +14,10 @@ using Logger = MegaCrit.Sts2.Core.Logging.Logger;
 namespace CardUtilityStats.Loader;
 
 /// <summary>
-/// Stable bootstrap. This class never unloads — it's loaded by BaseLib once
-/// at game startup via the standard [ModInitializer] contract. Its sole job
-/// is to host the hot-reloadable Core and provide an F5 hotkey to reload.
+/// Stable bootstrap. This class never unloads — it's loaded once
+/// at game startup by the game's mod manager via the standard [ModInitializer]
+/// contract. It owns the BaseLib-backed config/runtime boundary and hosts
+/// the hot-reloadable Core with an F5 hotkey to reload.
 ///
 /// Model: BepInEx ScriptEngine pattern.
 ///
@@ -64,7 +67,7 @@ public partial class LoaderMain : Node
     private static string? _currentTempPath;
     private static Node? _inputNode;
 
-    /// <summary>BaseLib entry point — called once on game startup.</summary>
+    /// <summary>Mod entry point — called once on game startup.</summary>
     public static void Initialize()
     {
         D("Initialize entry");
@@ -86,6 +89,18 @@ public partial class LoaderMain : Node
             }
         }
         catch (Exception e) { D($"resolver wire failed: {e.Message}"); }
+
+        try
+        {
+            ModConfigRegistry.Register(ModId, new CardUtilityStatsConfig());
+            RuntimeOptionsBridge.Initialize();
+            D("config registry initialized");
+        }
+        catch (Exception e)
+        {
+            D($"config bootstrap threw: {e.GetType().Name}: {e.Message}");
+            Logger.Error($"Config bootstrap threw: {e}");
+        }
 
         try { D("about to LoadCore"); LoadCore(); D("LoadCore returned"); }
         catch (Exception e) { D($"LoadCore threw: {e.GetType().Name}: {e.Message}"); Logger.Error($"LoadCore threw: {e}"); }
@@ -153,7 +168,8 @@ public partial class LoaderMain : Node
         // (MegaCrit.Sts2.Core.Modding.ModManager.cs line 647-650)
         //
         // Godot's .NET integration uses a specific managed ALC, not Default.
-        // sts2.dll, GodotSharp, BaseLib, 0Harmony are all in that context.
+        // sts2.dll, GodotSharp, 0Harmony, BaseLib, and this stable Loader
+        // all live in that context.
         // Putting Core into Default (what we tried first) or a custom ALC
         // means Core's type references to Godot/sts2/Harmony resolve
         // cross-context, which crashes the native bridge (SIGSEGV).

--- a/Loader/RuntimeOptionsBridge.cs
+++ b/Loader/RuntimeOptionsBridge.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BaseLib.Config;
+using CardUtilityStats.Config;
+using Godot;
+
+namespace CardUtilityStats.Loader;
+
+public sealed class RuntimeOptionsSnapshot
+{
+    public bool ViewStatsToggleEnabled { get; set; }
+    public bool ShowRemovedCardsInDeckView { get; set; } = true;
+    public bool ShowHandTooltips { get; set; } = true;
+    public bool EnableDebugLogging { get; set; }
+}
+
+public static class RuntimeOptionsBridge
+{
+    private static readonly JsonSerializerOptions JsonOptions = new();
+    private static readonly JsonSerializerOptions LegacyPrefsOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public static void Initialize()
+    {
+        MigrateLegacyPrefsIfNeeded();
+    }
+
+    public static string GetCurrentOptionsJson()
+    {
+        return JsonSerializer.Serialize(CreateSnapshot(), JsonOptions);
+    }
+
+    public static void SetViewStatsToggleEnabled(bool isEnabled)
+    {
+        if (CardUtilityStatsConfig.ViewStatsToggleEnabled == isEnabled) return;
+
+        CardUtilityStatsConfig.ViewStatsToggleEnabled = isEnabled;
+        ModConfig.SaveDebounced<CardUtilityStatsConfig>();
+    }
+
+    private static RuntimeOptionsSnapshot CreateSnapshot()
+    {
+        return new RuntimeOptionsSnapshot
+        {
+            ViewStatsToggleEnabled = CardUtilityStatsConfig.ViewStatsToggleEnabled,
+            ShowRemovedCardsInDeckView = CardUtilityStatsConfig.ShowRemovedCardsInDeckView,
+            ShowHandTooltips = CardUtilityStatsConfig.ShowHandTooltips,
+            EnableDebugLogging = CardUtilityStatsConfig.EnableDebugLogging,
+        };
+    }
+
+    private static void MigrateLegacyPrefsIfNeeded()
+    {
+        if (CardUtilityStatsConfig.LegacyPrefsMigrated) return;
+
+        try
+        {
+            var legacyPath = ProjectSettings.GlobalizePath("user://CardUtilityStats/prefs.json");
+            if (File.Exists(legacyPath))
+            {
+                var json = File.ReadAllText(legacyPath);
+                var legacyPrefs = JsonSerializer.Deserialize<LegacyPrefs>(json, LegacyPrefsOptions);
+                if (legacyPrefs != null)
+                {
+                    CardUtilityStatsConfig.ViewStatsToggleEnabled = legacyPrefs.ViewStatsTicked;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            LoaderMain.Logger.Error($"RuntimeOptionsBridge migration failed: {e}");
+        }
+
+        CardUtilityStatsConfig.LegacyPrefsMigrated = true;
+        ModConfig.SaveDebounced<CardUtilityStatsConfig>();
+    }
+
+    private sealed class LegacyPrefs
+    {
+        [JsonPropertyName("view_stats_ticked")]
+        public bool ViewStatsTicked { get; set; }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,18 +9,24 @@ This codebase has two big goals:
 
 ### Loader
 
-- [Loader/LoaderMain.cs](D:/repos/CardUtilityStats/Loader/LoaderMain.cs:14) is the stable bootstrap loaded once by BaseLib.
+- [Loader/LoaderMain.cs](D:/repos/CardUtilityStats/Loader/LoaderMain.cs:14) is the stable bootstrap loaded once by the game's mod manager.
 - It owns the `F5` workflow:
   - copy the Core DLL to a fresh temp path
   - load that copy
   - call `CoreMain.Initialize()`
   - on reload, call the previous `CoreMain.Shutdown()` first
+- It also owns the stable BaseLib boundary:
+  - [Config/CardUtilityStatsConfig.cs](D:/repos/CardUtilityStats/Config/CardUtilityStatsConfig.cs:1) defines the BaseLib-backed mod settings UI
+  - [Loader/RuntimeOptionsBridge.cs](D:/repos/CardUtilityStats/Loader/RuntimeOptionsBridge.cs:1) exposes a stable runtime-options bridge to the hot-reloaded Core
+  - [Api/CardUtilityStatsApiRegistry.cs](D:/repos/CardUtilityStats/Api/CardUtilityStatsApiRegistry.cs:1) exposes a small public API surface other mods can call into
 - The loader does not try to truly unload old contexts; it relies on explicit cleanup plus process-lifetime tolerance.
 
 ### Core
 
 - [Core/CoreMain.cs](D:/repos/CardUtilityStats/Core/CoreMain.cs:8) is the hot-reloaded entry point.
 - It applies Harmony patches, wires tracker hooks, resumes active run state after reload, and tears all of that back down on `Shutdown()`.
+- The Core intentionally does not reference BaseLib directly anymore.
+- Loader-owned config is consumed through [Core/RuntimeOptions.cs](D:/repos/CardUtilityStats/Core/RuntimeOptions.cs:1), which keeps the hot-reloaded assembly focused on domain logic instead of framework glue.
 
 ## Data Flow
 
@@ -78,6 +84,7 @@ When attribution is not naturally one-card-to-one-outcome, the code prefers:
 - [Core/Patches/ViewStatsInjectorPatch.cs](D:/repos/CardUtilityStats/Core/Patches/ViewStatsInjectorPatch.cs:11) injects the `View Stats` toggle into the deck view.
 - [Core/Patches/CardHoverTooltipPatch.cs](D:/repos/CardUtilityStats/Core/Patches/CardHoverTooltipPatch.cs:11) builds compact and full tooltip bodies.
 - [Core/StatsTooltip.cs](D:/repos/CardUtilityStats/Core/StatsTooltip.cs:1) renders the side tooltip panel.
+- [Config/CardUtilityStatsConfig.cs](D:/repos/CardUtilityStats/Config/CardUtilityStatsConfig.cs:1) provides the persistent mod-settings UI for runtime display options.
 
 Current UI conventions:
 


### PR DESCRIPTION
## Summary
- pin the loader-side BaseLib and analyzer versions
- remove BaseLib from the hot-reloaded Core project
- add a BaseLib-backed mod config and loader runtime-options bridge
- route the old deck-view prefs shim through the loader boundary
- add a small public API registry for other mods to query runtime state/data
- document the new loader/Core boundary in architecture docs

## Validation
- `dotnet build CardUtilityStats.csproj -c Debug /p:SkipModsDeploy=true` ✅
- `dotnet build Core/CardUtilityStats.Core.csproj -c Debug /p:SkipModsDeploy=true` fails on the same preexisting `RunTracker.cs` `ICombatState` -> `CombatState?` mismatch seen on `main`
- `dotnet test Tests/CardUtilityStats.Core.Tests/CardUtilityStats.Core.Tests.csproj -c Debug` fails on the same preexisting baseline errors from `main`

## Notes
- BaseLib stays in the stable loader boundary for config/UI and future interop.
- The hot-reloaded Core now consumes runtime options through a small reflection bridge instead of a direct BaseLib dependency.
- The new API registry is provider-side only; sibling mods can call it directly or via optional interop later.