### PR TITLE
Bump BaseLib dep 3.0.8 → 3.0.9

### DIFF
--- a/SpireLens.csproj
+++ b/SpireLens.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="3.0.8" PrivateAssets="All" GeneratePathProperty="true"/>
+        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="3.0.9" PrivateAssets="All" GeneratePathProperty="true"/>
         <PackageReference Include="Krafs.Publicizer" Version="2.3.0" PrivateAssets="All"/>
         <PackageReference Include="Alchyr.Sts2.ModAnalyzers" Version="0.1.9" />
         <!-- Mono.Cecil: rewrites the Core assembly's manifest name per load so


### PR DESCRIPTION
Root-cause fix for the SelfApplyDebuffPatch Harmony failure observed against game v0.104.0.

**Before (3.0.8):** `[BaseLib] Applied 135 patches successfully, 1 failed` — SelfApplyDebuffPatch::Postfix fails because its static `[HarmonyPatch]` attribute targets the old 6-arg `PowerCmd.Apply` signature; v0.104.0 added `PlayerChoiceContext` as a new first parameter.

**After (3.0.9):** `[BaseLib] Applied 138 patches successfully, 0 failed` — BaseLib 3.0.9 replaces the static attribute with a dynamic `TargetMethod()` that tries 7-arg first and falls back to 6-arg.

3.0.9 is published on nuget.org as the latest stable release.