### PR TITLE
Wire issue-agent to SpireLensMcp bridge

### DIFF
--- a/.github/scripts/restart-sts2.ps1
+++ b/.github/scripts/restart-sts2.ps1
@@ -7,7 +7,7 @@ param(
     [int]$ShutdownTimeoutSeconds = 45,
     [string]$LaunchArguments = '--rendering-driver opengl3',
     [string]$BridgeHost = '127.0.0.1',
-    [int]$BridgePort = 21337
+    [int]$BridgePort = 15526
 )
 
 $ErrorActionPreference = 'Stop'
@@ -51,56 +51,20 @@ function Invoke-BridgePing {
         [int]$TimeoutMilliseconds = 2000
     )
 
-    $client = New-Object System.Net.Sockets.TcpClient
+    # SpireLens MCP exposes an HTTP server on this port; the index route
+    # answers with `{"message": "Hello from SpireLens MCP v...", "status": "ok"}`.
+    $uri = "http://${HostName}:${Port}/"
+    $timeoutSec = [int][Math]::Max(1, [Math]::Ceiling($TimeoutMilliseconds / 1000.0))
+
     try {
-        $connect = $client.BeginConnect($HostName, $Port, $null, $null)
-        if (-not $connect.AsyncWaitHandle.WaitOne($TimeoutMilliseconds, $false)) {
-            return @{ ok = $false; error = 'connect timed out' }
-        }
-        $client.EndConnect($connect)
-        $client.ReceiveTimeout = $TimeoutMilliseconds
-        $client.SendTimeout = $TimeoutMilliseconds
-
-        $stream = $client.GetStream()
-        $payload = [System.Text.Encoding]::UTF8.GetBytes('{"method":"ping","id":1}' + "`n")
-        $stream.Write($payload, 0, $payload.Length)
-
-        $buffer = New-Object byte[] 4096
-        $builder = New-Object System.Text.StringBuilder
-        $deadline = (Get-Date).AddMilliseconds($TimeoutMilliseconds)
-
-        while ((Get-Date) -lt $deadline) {
-            if ($stream.DataAvailable) {
-                $read = $stream.Read($buffer, 0, $buffer.Length)
-                if ($read -le 0) {
-                    break
-                }
-                $chunk = [System.Text.Encoding]::UTF8.GetString($buffer, 0, $read)
-                [void]$builder.Append($chunk)
-                if ($chunk.Contains("`n") -or $chunk.Contains("`r")) {
-                    break
-                }
-            } else {
-                Start-Sleep -Milliseconds 100
-            }
-        }
-
-        $text = $builder.ToString().Trim()
-        if ([string]::IsNullOrWhiteSpace($text)) {
-            return @{ ok = $false; error = 'empty bridge response' }
-        }
-
-        $json = $text | ConvertFrom-Json -ErrorAction Stop
-        $status = [string]$json.result.status
+        $response = Invoke-RestMethod -Uri $uri -Method Get -TimeoutSec $timeoutSec -ErrorAction Stop
+        $status = [string]$response.status
         if ($status -eq 'ok') {
-            return @{ ok = $true; response = $json }
+            return @{ ok = $true; response = $response }
         }
-
-        return @{ ok = $false; error = "unexpected bridge status '$status'"; response = $json }
+        return @{ ok = $false; error = "unexpected bridge status '$status'"; response = $response }
     } catch {
         return @{ ok = $false; error = $_.Exception.Message }
-    } finally {
-        $client.Close()
     }
 }
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,9 +2,13 @@
   "mcpServers": {
     "sts2-modding": {
       "type": "stdio",
-      "command": "D:\\repos\\sts2-modding-mcp\\venv\\Scripts\\python.exe",
+      "command": "uv",
       "args": [
-        "D:\\repos\\sts2-modding-mcp\\run.py"
+        "run",
+        "--directory",
+        "D:\\repos\\spire-lens-mcp\\mcp",
+        "python",
+        "server.py"
       ],
       "env": {
         "STS2_GAME_DIR": "D:\\SteamLibrary\\steamapps\\common\\Slay the Spire 2"

--- a/docs/live-worker-pipeline.md
+++ b/docs/live-worker-pipeline.md
@@ -41,10 +41,13 @@ Common local layout:
 
 The project `.mcp.json` should point Claude to `sts2-modding`.
 
-Expected live MCP endpoints when STS2 is running with the MCP bridge mods installed:
+Expected live MCP endpoint when STS2 is running with `SpireLensMcp` installed:
 
-- `localhost:21337`
-- `localhost:27020`
+- `http://localhost:15526/` — index route returns `{"status": "ok"}` when the in-game HTTP listener is healthy (used by `restart-sts2.ps1` for the readiness probe).
+- `http://localhost:15526/api/v1/singleplayer` — singleplayer state and action endpoints.
+- `http://localhost:15526/api/v1/multiplayer` — multiplayer-only endpoints, guarded against cross-mode use.
+
+The bridge is provided by [`nelsong6/spire-lens-mcp`](https://github.com/nelsong6/spire-lens-mcp) (vendored from `Gennadiyev/STS2MCP` under MIT). The Python MCP server in that repo's `mcp/` directory is what the project's `.mcp.json` invokes via `uv run`.
 
 ## Auth And Visibility
 


### PR DESCRIPTION
## Summary
- Replace stale MCP wiring (path that didn't exist on laptop runner, TCP/JSONL probe on port 21337) with the in-house [SpireLensMcp](https://github.com/nelsong6/spire-lens-mcp) mod and its Python MCP server
- `.mcp.json` now invokes `uv run --directory D:\repos\spire-lens-mcp\mcp python server.py`
- `restart-sts2.ps1` probes `http://localhost:15526/` (the SpireLensMcp index route) instead of TCP-21337
- Docs updated to describe the actual endpoints

## Background
The previous `issue-agent` dispatch on #56 timed out at the STS2 restart step because nothing was listening on port 21337 — that protocol/port came from an earlier bridge implementation. The current mod (SpireLensMcp, vendored from kunology/STS2MCP under MIT) speaks HTTP on 15526.

The mod is built and deployed on the laptop runner already. Game-API drift from STS2 v0.103.2 → v0.104.0 (`CombatManager.IsPlayPhase` removed; `Creature.CombatState` returns `ICombatState`) is fixed in spire-lens-mcp@71d7e18.

## Test plan
- [ ] Merge this PR
- [ ] Restart STS2 (the workflow does this; mod is on disk)
- [ ] Re-dispatch issue-agent on #56 and confirm the restart-STS2 step succeeds (bridge probe returns `{"status": "ok"}` on `localhost:15526`)
- [ ] Confirm Claude can call `mcp__sts2__get_game_state` etc. and produce a screenshot in the PR it opens for #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)