### PR TITLE
Draft: audit issue-agent prompts for hidden policy examples

### DIFF
--- a/.github/scripts/assert-issue-agent-prompts.ps1
+++ b/.github/scripts/assert-issue-agent-prompts.ps1
@@ -1,0 +1,28 @@
+param(
+    [string]$PromptScriptPath = (Join-Path $PSScriptRoot 'run-issue-agent-phases.ps1')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$blockedPatterns = @(
+    @{ Pattern = 'For Make It So'; Reason = 'Card-specific prompt law belongs in issue body or fixtures, not generic phase prompts.' },
+    @{ Pattern = 'MAKE_IT_SO plus'; Reason = 'Card-specific deck recipes must not be embedded in generic prompts.' },
+    @{ Pattern = 'Watcher card'; Reason = 'STS1/legacy character assumptions must not be prompt examples.' },
+    @{ Pattern = 'run_scenario_command'; Reason = 'Removed scenario-command surfaces must not appear in phase prompts.' },
+    @{ Pattern = 'LiveScenarios/'; Reason = 'Legacy side-channel references must not be prompt examples.' }
+)
+
+$content = Get-Content -LiteralPath $PromptScriptPath -Raw
+$findings = New-Object System.Collections.Generic.List[object]
+foreach ($item in $blockedPatterns) {
+    if ($content -match [regex]::Escape($item.Pattern)) {
+        $findings.Add([ordered]@{ pattern = $item.Pattern; reason = $item.Reason }) | Out-Null
+    }
+}
+
+if ($findings.Count -gt 0) {
+    $findings | ConvertTo-Json -Depth 10 | Write-Host
+    throw "Issue-agent prompt audit found hidden-policy/stale prompt patterns."
+}
+
+Write-Host "Issue-agent prompt audit passed."

--- a/.github/workflows/issue-agent.yml
+++ b/.github/workflows/issue-agent.yml
@@ -50,6 +50,11 @@ jobs:
           fetch-depth: 0
           path: ${{ env.ISSUE_AGENT_CHECKOUT_PATH }}
 
+      - name: Audit issue-agent prompts
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
+        run: |
+          & (Join-Path (Join-Path $env:GITHUB_WORKSPACE $env:ISSUE_AGENT_CHECKOUT_PATH) ".github\scripts\assert-issue-agent-prompts.ps1")
+
       - name: Prepare issue-agent host
         env:
           CONFIGURED_CLAUDE_CLI_PATH: ${{ vars.ISSUE_AGENT_CLAUDE_CLI_PATH }}
@@ -147,6 +152,11 @@ jobs:
         with:
           fetch-depth: 0
           path: ${{ env.ISSUE_AGENT_CHECKOUT_PATH }}
+
+      - name: Audit issue-agent prompts
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
+        run: |
+          & (Join-Path (Join-Path $env:GITHUB_WORKSPACE $env:ISSUE_AGENT_CHECKOUT_PATH) ".github\scripts\assert-issue-agent-prompts.ps1")
 
       - name: Prepare issue-agent host
         env:
@@ -261,6 +271,11 @@ jobs:
         with:
           fetch-depth: 0
           path: ${{ env.ISSUE_AGENT_CHECKOUT_PATH }}
+
+      - name: Audit issue-agent prompts
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
+        run: |
+          & (Join-Path (Join-Path $env:GITHUB_WORKSPACE $env:ISSUE_AGENT_CHECKOUT_PATH) ".github\scripts\assert-issue-agent-prompts.ps1")
 
       - name: Download test plan artifacts
         if: always()


### PR DESCRIPTION
Draft fix for #101. Adds a prompt-audit script for stale/card-specific examples and runs it before the test-plan phase so hidden policy does not quietly poison runs again.
