### PR TITLE
Draft: separate issue-agent backlog and runnable labels

### DIFF
--- a/.github/workflows/issue-agent.yml
+++ b/.github/workflows/issue-agent.yml
@@ -18,6 +18,7 @@ permissions:
 
 env:
   ISSUE_AGENT_ARTIFACT_NAME: issue-agent-artifacts
+  ISSUE_AGENT_RUN_LABEL: issue-agent-run
 
 concurrency:
   group: spirelens-issue-agent
@@ -29,8 +30,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' && (
-        (github.event.action == 'labeled' && github.event.label.name == 'issue-agent') ||
-        (github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, 'issue-agent'))
+        (github.event.action == 'labeled' && github.event.label.name == env.ISSUE_AGENT_RUN_LABEL) ||
+        (github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, env.ISSUE_AGENT_RUN_LABEL))
       ))
     runs-on:
       - self-hosted
@@ -127,8 +128,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' && (
-        (github.event.action == 'labeled' && github.event.label.name == 'issue-agent') ||
-        (github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, 'issue-agent'))
+        (github.event.action == 'labeled' && github.event.label.name == env.ISSUE_AGENT_RUN_LABEL) ||
+        (github.event.action == 'reopened' && contains(github.event.issue.labels.*.name, env.ISSUE_AGENT_RUN_LABEL))
       ))
     runs-on:
       - self-hosted

--- a/docs/issue-agent-labels.md
+++ b/docs/issue-agent-labels.md
@@ -1,0 +1,8 @@
+# Issue Agent Labels
+
+The issue-agent workflow has two different label concepts:
+
+- `flow improvement`: human backlog and design work. This label must never start automation.
+- `issue-agent-run`: explicit runnable automation label. Applying this label to an issue is a request to run the issue-agent.
+
+Do not use the runnable label while bulk-creating or organizing backlog issues. Prefer `workflow_dispatch` with an explicit issue number when testing a single issue-agent run.


### PR DESCRIPTION
Draft fix for #106. Changes the issue-triggered workflow to require a dedicated `issue-agent-run` label instead of the broader `issue-agent` label, and documents non-runnable backlog labeling.
