### PR TITLE
Draft: provision Azure screenshot storage for issue-agent previews

### DIFF
--- a/infra/opentofu/issue-agent-screenshot-storage/README.md
+++ b/infra/opentofu/issue-agent-screenshot-storage/README.md
@@ -1,0 +1,73 @@
+# Issue-Agent Screenshot Storage
+
+This OpenTofu stack provisions public-read Azure Blob Storage for issue-agent screenshot previews.
+
+It creates:
+
+- a resource group
+- a StorageV2 account with public blob access enabled
+- a public-read container for screenshot PNGs
+- a user-assigned managed identity for GitHub Actions uploads
+- GitHub OIDC federated identity credentials for the configured subjects
+- `Storage Blob Data Contributor` on the storage account for the upload identity
+- an optional lifecycle rule to delete old screenshots
+
+## Authentication Model
+
+GitHub Actions should use OIDC through `azure/login` with the `github_uploader_client_id` output.
+
+Example workflow shape:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: azure/login@v2
+    with:
+      client-id: ${{ vars.AZURE_SCREENSHOT_UPLOADER_CLIENT_ID }}
+      tenant-id: ${{ vars.AZURE_TENANT_ID }}
+      subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+  - name: Upload screenshots
+    shell: powershell
+    run: |
+      az storage blob upload-batch `
+        --auth-mode login `
+        --account-name $env:AZURE_SCREENSHOT_STORAGE_ACCOUNT `
+        --destination $env:AZURE_SCREENSHOT_CONTAINER `
+        --destination-path $env:GITHUB_RUN_ID `
+        --source $env:SCREENSHOT_DIR `
+        --pattern *.png `
+        --overwrite true
+```
+
+The public preview URL for a screenshot is:
+
+```text
+https://<storage-account>.blob.core.windows.net/<container>/<run-id>/<filename>.png
+```
+
+## Applying
+
+```powershell
+cd infra/opentofu/issue-agent-screenshot-storage
+tofu init
+tofu plan `
+  -var "location=eastus" `
+  -var "resource_group_name=rg-spirelens-issue-agent-evidence"
+tofu apply
+```
+
+The provider can authenticate with Azure CLI locally or OIDC in CI. Backend configuration is intentionally not committed yet; add backend config once we decide where OpenTofu state should live.
+
+## Variables To Export Back To GitHub
+
+After apply, set these repository variables/secrets for the upload workflow:
+
+- `AZURE_SCREENSHOT_UPLOADER_CLIENT_ID` = `github_uploader_client_id`
+- `AZURE_SCREENSHOT_STORAGE_ACCOUNT` = `storage_account_name`
+- `AZURE_SCREENSHOT_CONTAINER` = `container_name`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`

--- a/infra/opentofu/issue-agent-screenshot-storage/main.tf
+++ b/infra/opentofu/issue-agent-screenshot-storage/main.tf
@@ -1,0 +1,95 @@
+locals {
+  storage_account_name = substr("${var.name_prefix}${random_string.storage_suffix.result}", 0, 24)
+
+  federated_subjects = {
+    for idx, subject in var.github_federated_subjects : tostring(idx) => subject
+  }
+}
+
+resource "random_string" "storage_suffix" {
+  length  = 6
+  upper   = false
+  special = false
+  numeric = true
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.location
+  tags     = var.tags
+}
+
+resource "azurerm_storage_account" "screenshots" {
+  name                            = local.storage_account_name
+  resource_group_name             = azurerm_resource_group.this.name
+  location                        = azurerm_resource_group.this.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  min_tls_version                 = "TLS1_2"
+  https_traffic_only_enabled      = true
+  public_network_access_enabled   = true
+  allow_nested_items_to_be_public = true
+  shared_access_key_enabled       = false
+
+  blob_properties {
+    delete_retention_policy {
+      days = 7
+    }
+
+    container_delete_retention_policy {
+      days = 7
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "screenshots" {
+  name                  = var.container_name
+  storage_account_id    = azurerm_storage_account.screenshots.id
+  container_access_type = "blob"
+}
+
+resource "azurerm_user_assigned_identity" "github_uploader" {
+  name                = "${var.name_prefix}-github-uploader"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  tags                = var.tags
+}
+
+resource "azurerm_federated_identity_credential" "github" {
+  for_each            = local.federated_subjects
+  name                = "github-${each.key}"
+  resource_group_name = azurerm_resource_group.this.name
+  parent_id           = azurerm_user_assigned_identity.github_uploader.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = each.value
+}
+
+resource "azurerm_role_assignment" "blob_data_contributor" {
+  scope                = azurerm_storage_account.screenshots.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.github_uploader.principal_id
+}
+
+resource "azurerm_storage_management_policy" "screenshots" {
+  count              = var.retention_days > 0 ? 1 : 0
+  storage_account_id = azurerm_storage_account.screenshots.id
+
+  rule {
+    name    = "delete-old-issue-agent-screenshots"
+    enabled = true
+
+    filters {
+      blob_types = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = var.retention_days
+      }
+    }
+  }
+}

--- a/infra/opentofu/issue-agent-screenshot-storage/outputs.tf
+++ b/infra/opentofu/issue-agent-screenshot-storage/outputs.tf
@@ -1,0 +1,29 @@
+output "resource_group_name" {
+  description = "Resource group containing screenshot evidence resources."
+  value       = azurerm_resource_group.this.name
+}
+
+output "storage_account_name" {
+  description = "Storage account that hosts public screenshot blobs."
+  value       = azurerm_storage_account.screenshots.name
+}
+
+output "container_name" {
+  description = "Public-read screenshot container name."
+  value       = azurerm_storage_container.screenshots.name
+}
+
+output "container_url" {
+  description = "Base public URL for screenshot blobs."
+  value       = "https://${azurerm_storage_account.screenshots.name}.blob.core.windows.net/${azurerm_storage_container.screenshots.name}"
+}
+
+output "github_uploader_client_id" {
+  description = "Client ID for azure/login from GitHub Actions."
+  value       = azurerm_user_assigned_identity.github_uploader.client_id
+}
+
+output "github_uploader_principal_id" {
+  description = "Principal ID granted Storage Blob Data Contributor on the screenshot storage account."
+  value       = azurerm_user_assigned_identity.github_uploader.principal_id
+}

--- a/infra/opentofu/issue-agent-screenshot-storage/variables.tf
+++ b/infra/opentofu/issue-agent-screenshot-storage/variables.tf
@@ -1,0 +1,62 @@
+variable "location" {
+  description = "Azure region for screenshot evidence resources."
+  type        = string
+  default     = "eastus"
+}
+
+variable "resource_group_name" {
+  description = "Resource group to create for issue-agent screenshot evidence storage."
+  type        = string
+  default     = "rg-spirelens-issue-agent-evidence"
+}
+
+variable "name_prefix" {
+  description = "Lowercase prefix used for globally unique Azure resource names. Keep short; storage account names max at 24 chars."
+  type        = string
+  default     = "spirelensshots"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,18}$", var.name_prefix))
+    error_message = "name_prefix must be 3-18 lowercase letters/numbers."
+  }
+}
+
+variable "container_name" {
+  description = "Public-read blob container for issue-agent screenshots."
+  type        = string
+  default     = "issue-agent-screenshots"
+}
+
+variable "github_repository" {
+  description = "GitHub repository allowed to federate into the upload identity, in owner/name form."
+  type        = string
+  default     = "nelsong6/spirelens"
+}
+
+variable "github_federated_subjects" {
+  description = "GitHub OIDC subject claims allowed to assume the user-assigned managed identity."
+  type        = list(string)
+  default = [
+    "repo:nelsong6/spirelens:ref:refs/heads/main"
+  ]
+}
+
+variable "retention_days" {
+  description = "How long to retain issue-agent screenshot blobs before automatic deletion. Set to 0 to disable lifecycle deletion."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.retention_days >= 0
+    error_message = "retention_days must be zero or greater."
+  }
+}
+
+variable "tags" {
+  description = "Tags applied to all Azure resources."
+  type        = map(string)
+  default = {
+    project = "spirelens"
+    surface = "issue-agent"
+  }
+}

--- a/infra/opentofu/issue-agent-screenshot-storage/versions.tf
+++ b/infra/opentofu/issue-agent-screenshot-storage/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}


### PR DESCRIPTION
Draft infrastructure scaffold for Azure-hosted issue-agent screenshot previews.

This provisions:
- resource group
- public-read blob storage container
- user-assigned managed identity
- GitHub OIDC federated credentials
- Storage Blob Data Contributor assignment for uploads
- optional screenshot retention policy

Intended to replace the repo-committed screenshot preview workaround from #118/#119.

Open review questions:
- exact Azure region/resource group naming
- whether public blob access is acceptable vs SAS URLs
- retention window
- whether we want state backend committed now or configured externally
