### PR TITLE
Make documentation links portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,16 +26,16 @@ When local filesystem access is helpful for drafting, validation, or temporary a
 ## Current Truths
 
 - Runtime is split into a stable loader and a hot-reloaded core.
-  - [Loader/LoaderMain.cs](D:/repos/SpireLens/Loader/LoaderMain.cs:14) owns the long-lived bootstrap and `F5` reload flow.
-  - [Core/CoreMain.cs](D:/repos/SpireLens/Core/CoreMain.cs:8) owns Harmony patch install/uninstall and re-entry on each reload.
+  - [Loader/LoaderMain.cs](Loader/LoaderMain.cs) owns the long-lived bootstrap and `F5` reload flow.
+  - [Core/CoreMain.cs](Core/CoreMain.cs) owns Harmony patch install/uninstall and re-entry on each reload.
 - Persistence is combat-boundary based.
-  - [Core/RunTracker.cs](D:/repos/SpireLens/Core/RunTracker.cs:18) buffers live combat data in `_pendingCombat`.
+  - [Core/RunTracker.cs](Core/RunTracker.cs) buffers live combat data in `_pendingCombat`.
   - Nothing is promoted to the permanent run file until combat ends.
   - Reload between combats / between floors is supported and expected.
   - Mid-combat restore is intentionally out of scope.
 - The data model is additive through schema `v14`.
-  - [Core/RunData.cs](D:/repos/SpireLens/Core/RunData.cs:13) is the source of truth for the current schema.
-  - [Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs](D:/repos/SpireLens/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs:1) and the checked-in fixtures pin what remains resumable.
+  - [Core/RunData.cs](Core/RunData.cs) is the source of truth for the current schema.
+  - [Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs](Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs) and the checked-in fixtures pin what remains resumable.
 - Card identity is per physical card when the card has stable deck identity.
   - Instance numbers never get reused within a run.
   - Combat-generated cards that do not meaningfully exist in the deck may use pooled summaries instead of fake deck-instance identities.
@@ -49,20 +49,20 @@ When local filesystem access is helpful for drafting, validation, or temporary a
 
 ## Start Here
 
-- Read [README.md](D:/repos/SpireLens/README.md:1) for the product-level overview.
+- Read [README.md](README.md) for the product-level overview.
 - Read [docs/pull-only-workflow.md](docs/pull-only-workflow.md) for the repo's GitHub-native workflow policy.
-- Read [docs/architecture.md](D:/repos/SpireLens/docs/architecture.md:1) for subsystem layout and data flow.
-- For tracking behavior, start in [Core/RunTracker.cs](D:/repos/SpireLens/Core/RunTracker.cs:18).
+- Read [docs/architecture.md](docs/architecture.md) for subsystem layout and data flow.
+- For tracking behavior, start in [Core/RunTracker.cs](Core/RunTracker.cs).
 - For tooltip/UI behavior, start in:
-  - [Core/Patches/ViewStatsInjectorPatch.cs](D:/repos/SpireLens/Core/Patches/ViewStatsInjectorPatch.cs:11)
-  - [Core/Patches/CardHoverTooltipPatch.cs](D:/repos/SpireLens/Core/Patches/CardHoverTooltipPatch.cs:11)
+  - [Core/Patches/ViewStatsInjectorPatch.cs](Core/Patches/ViewStatsInjectorPatch.cs)
+  - [Core/Patches/CardHoverTooltipPatch.cs](Core/Patches/CardHoverTooltipPatch.cs)
 
 ## When Changing Behavior
 
 - If you add persisted fields:
   - bump `RunData.CurrentSchemaVersion`
-  - add or update fixture files under [Fixtures/RunSchema](D:/repos/SpireLens/Fixtures/RunSchema/README.md:1)
-  - update [SchemaLoadingTests.cs](D:/repos/SpireLens/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs:1)
+  - add or update fixture files under [Fixtures/RunSchema](Fixtures/RunSchema/README.md)
+  - update [SchemaLoadingTests.cs](Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs)
 - If you change tooltip presentation:
   - preserve the compact-vs-full distinction
   - keep labels self-describing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered
 
 **Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, forge granted from cards, blocked-draw attribution, recurring summon-to-hand tracking, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
 
-For codebase orientation, start with [AGENTS.md](D:/repos/SpireLens/AGENTS.md:1) and [docs/architecture.md](D:/repos/SpireLens/docs/architecture.md:1).
+For codebase orientation, start with [AGENTS.md](AGENTS.md) and [docs/architecture.md](docs/architecture.md).
 
 ## Development Workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,30 +9,30 @@ This codebase has two big goals:
 
 ### Loader
 
-- [Loader/LoaderMain.cs](D:/repos/SpireLens/Loader/LoaderMain.cs:14) is the stable bootstrap loaded once by the game's mod manager.
+- [Loader/LoaderMain.cs](../Loader/LoaderMain.cs) is the stable bootstrap loaded once by the game's mod manager.
 - It owns the `F5` workflow:
   - copy the Core DLL to a fresh temp path
   - load that copy
   - call `CoreMain.Initialize()`
   - on reload, call the previous `CoreMain.Shutdown()` first
 - It also owns the stable BaseLib boundary:
-  - [Config/SpireLensConfig.cs](D:/repos/SpireLens/Config/SpireLensConfig.cs:1) defines the BaseLib-backed mod settings UI
-  - [Loader/RuntimeOptionsBridge.cs](D:/repos/SpireLens/Loader/RuntimeOptionsBridge.cs:1) exposes a stable runtime-options bridge to the hot-reloaded Core
-  - [Api/SpireLensApiRegistry.cs](D:/repos/SpireLens/Api/SpireLensApiRegistry.cs:1) exposes a small public API surface other mods can call into
+  - [Config/SpireLensConfig.cs](../Config/SpireLensConfig.cs) defines the BaseLib-backed mod settings UI
+  - [Loader/RuntimeOptionsBridge.cs](../Loader/RuntimeOptionsBridge.cs) exposes a stable runtime-options bridge to the hot-reloaded Core
+  - [Api/SpireLensApiRegistry.cs](../Api/SpireLensApiRegistry.cs) exposes a small public API surface other mods can call into
 - The loader does not try to truly unload old contexts; it relies on explicit cleanup plus process-lifetime tolerance.
 
 ### Core
 
-- [Core/CoreMain.cs](D:/repos/SpireLens/Core/CoreMain.cs:8) is the hot-reloaded entry point.
+- [Core/CoreMain.cs](../Core/CoreMain.cs) is the hot-reloaded entry point.
 - It applies Harmony patches, wires tracker hooks, resumes active run state after reload, and tears all of that back down on `Shutdown()`.
 - The Core intentionally does not reference BaseLib directly anymore.
-- Loader-owned config is consumed through [Core/RuntimeOptions.cs](D:/repos/SpireLens/Core/RuntimeOptions.cs:1), which keeps the hot-reloaded assembly focused on domain logic instead of framework glue.
+- Loader-owned config is consumed through [Core/RuntimeOptions.cs](../Core/RuntimeOptions.cs), which keeps the hot-reloaded assembly focused on domain logic instead of framework glue.
 
 ## Data Flow
 
 ### Live Tracking
 
-- [Core/RunTracker.cs](D:/repos/SpireLens/Core/RunTracker.cs:18) is the heart of the mod.
+- [Core/RunTracker.cs](../Core/RunTracker.cs) is the heart of the mod.
 - Combat history entries and selected hook patches feed into the tracker.
 - During combat, observations accumulate in `_pendingCombat`.
 - On combat end, `_pendingCombat` is promoted into the committed run aggregates and saved.
@@ -45,14 +45,14 @@ This combat-boundary rule is important:
 
 ### Persistence
 
-- [Core/RunData.cs](D:/repos/SpireLens/Core/RunData.cs:6) defines the serialized run shape.
-- [Core/RunStorage.cs](D:/repos/SpireLens/Core/RunStorage.cs:9) handles load/save and resumability rules.
+- [Core/RunData.cs](../Core/RunData.cs) defines the serialized run shape.
+- [Core/RunStorage.cs](../Core/RunStorage.cs) handles load/save and resumability rules.
 - Schema changes are additive when possible. The current schema is `v14`.
 
 Historical compatibility is pinned by:
 
-- [Fixtures/RunSchema](D:/repos/SpireLens/Fixtures/RunSchema/README.md:1)
-- [Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs](D:/repos/SpireLens/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs:1)
+- [Fixtures/RunSchema](../Fixtures/RunSchema/README.md)
+- [Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs](../Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs)
 
 ## Attribution Model
 
@@ -81,10 +81,10 @@ When attribution is not naturally one-card-to-one-outcome, the code prefers:
 
 ## UI Surface
 
-- [Core/Patches/ViewStatsInjectorPatch.cs](D:/repos/SpireLens/Core/Patches/ViewStatsInjectorPatch.cs:11) injects the `View Stats` toggle into the deck view.
-- [Core/Patches/CardHoverTooltipPatch.cs](D:/repos/SpireLens/Core/Patches/CardHoverTooltipPatch.cs:11) builds compact and full tooltip bodies.
-- [Core/StatsTooltip.cs](D:/repos/SpireLens/Core/StatsTooltip.cs:1) renders the side tooltip panel.
-- [Config/SpireLensConfig.cs](D:/repos/SpireLens/Config/SpireLensConfig.cs:1) provides the persistent mod-settings UI for runtime display options.
+- [Core/Patches/ViewStatsInjectorPatch.cs](../Core/Patches/ViewStatsInjectorPatch.cs) injects the `View Stats` toggle into the deck view.
+- [Core/Patches/CardHoverTooltipPatch.cs](../Core/Patches/CardHoverTooltipPatch.cs) builds compact and full tooltip bodies.
+- [Core/StatsTooltip.cs](../Core/StatsTooltip.cs) renders the side tooltip panel.
+- [Config/SpireLensConfig.cs](../Config/SpireLensConfig.cs) provides the persistent mod-settings UI for runtime display options.
 
 Current UI conventions:
 
@@ -111,8 +111,8 @@ Use this checklist:
 
 1. decide whether the stat should be per-instance, pooled, or effect-oriented
 2. record the observed game outcome, not just the requested amount, if those can diverge
-3. update [RunData.cs](D:/repos/SpireLens/Core/RunData.cs:6) if persistence changes
-4. update fixtures under [Fixtures/RunSchema](D:/repos/SpireLens/Fixtures/RunSchema/README.md:1)
-5. update [SchemaLoadingTests.cs](D:/repos/SpireLens/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs:1)
-6. update tooltip rendering in [CardHoverTooltipPatch.cs](D:/repos/SpireLens/Core/Patches/CardHoverTooltipPatch.cs:11) if the stat is user-facing
+3. update [RunData.cs](../Core/RunData.cs) if persistence changes
+4. update fixtures under [Fixtures/RunSchema](../Fixtures/RunSchema/README.md)
+5. update [SchemaLoadingTests.cs](../Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs)
+6. update tooltip rendering in [CardHoverTooltipPatch.cs](../Core/Patches/CardHoverTooltipPatch.cs) if the stat is user-facing
 7. keep compact tooltip noise low


### PR DESCRIPTION
## Summary

- Replace workstation-specific Markdown links with repository-relative links in README, AGENTS, and architecture docs.
- Keep local checkout paths in command examples where they are intentionally user-environment-specific.

## Validation

- Compared `main...codex/portable-doc-links` through GitHub tools: branch is 3 commits ahead and only changes documentation.
- No local changes made.
- Tests not run; docs-only link cleanup.