### PR TITLE
Add Letter Opener relic stats

### DIFF
--- a/Core/Patches/LetterOpenerAfterCardPlayedPatch.cs
+++ b/Core/Patches/LetterOpenerAfterCardPlayedPatch.cs
@@ -1,0 +1,34 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Letter Opener activates after every third Skill played in a turn. We count
+/// activations here and derive attempted damage from the number of hittable
+/// enemies at that moment.
+/// </summary>
+[HarmonyPatch(typeof(LetterOpener), nameof(LetterOpener.AfterCardPlayed))]
+public static class LetterOpenerAfterCardPlayedPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(LetterOpener __instance, CardPlay cardPlay)
+    {
+        try
+        {
+            if (__instance == null || cardPlay?.Card == null) return;
+            if (cardPlay.Card.Owner != __instance.Owner) return;
+            int threshold = Math.Max(1, __instance.DynamicVars.Cards.IntValue);
+            RunTracker.NoteLetterOpenerBeforeCardPlayed(
+                cardPlay,
+                __instance.SkillsPlayedThisTurn + 1,
+                threshold);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"LetterOpenerAfterCardPlayedPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Nodes.Relics;
+
+namespace SpireLens.Core.Patches;
+
+[HarmonyPatch]
+public static class RelicHoverShowPatch
+{
+    private const string LetterOpenerRelicId = "LETTER_OPENER";
+
+    public static IEnumerable<MethodBase> TargetMethods()
+    {
+        var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var basicFocus = typeof(NRelicBasicHolder).GetMethod("OnFocus", flags);
+        if (basicFocus != null) yield return basicFocus;
+
+        var inventoryFocus = typeof(NRelicInventoryHolder).GetMethod("OnFocus", flags);
+        if (inventoryFocus != null && inventoryFocus.DeclaringType != basicFocus?.DeclaringType)
+            yield return inventoryFocus;
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(object __instance)
+    {
+        try
+        {
+            RuntimeOptionsProvider.Refresh();
+            var tickbox = ViewStatsInjectorPatch.LastInjectedTickbox;
+            var viewStatsEnabled = tickbox?.IsTicked ?? RuntimeOptionsProvider.Current.ViewStatsToggleEnabled;
+            if (!viewStatsEnabled) return;
+
+            if (__instance is not Control holder) return;
+
+            var relicModel = GetRelicModel(holder);
+            var relicId = NormalizeRelicId(GetMemberText(GetMemberValue(relicModel, "Id")));
+            if (!string.Equals(relicId, LetterOpenerRelicId, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var aggregate = RunTracker.GetEffectiveRelicAggregate(relicId);
+            var body = BuildBodyBBCode(aggregate);
+            if (string.IsNullOrWhiteSpace(body)) return;
+
+            var title = GetMemberText(GetMemberValue(relicModel, "Title"));
+            if (string.IsNullOrWhiteSpace(title)) title = "Letter Opener";
+
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree == null) return;
+
+            StatsTooltip.Show(tree, holder, title, "SpireLens", body);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RelicHoverShow failed: {e.Message}");
+        }
+    }
+
+    private static string BuildBodyBBCode(RelicAggregate? aggregate)
+    {
+        if (aggregate == null || (aggregate.TimesActivated <= 0 && aggregate.TotalAttemptedDamage <= 0))
+            return "";
+
+        var sb = new StringBuilder();
+        Row3(sb, "Times activated", aggregate.TimesActivated.ToString(), "");
+        Row3(sb, "Attempted damage", aggregate.TotalAttemptedDamage.ToString(), "");
+        return sb.ToString();
+    }
+
+    private static void Row3(StringBuilder sb, string label, string value, string pct)
+    {
+        sb.Append("[table=3]");
+        sb.Append($"[cell expand=4 padding=0,0,12,0][color=#e0e0e0]{label}[/color][/cell]");
+        sb.Append($"[cell expand=1 padding=0,0,12,0][right][b]{value}[/b][/right][/cell]");
+        sb.Append($"[cell expand=1 padding=0,0,4,0][right][color=#b5b5b5]{pct}[/color][/right][/cell]");
+        sb.Append("[/table]\n");
+    }
+
+    private static object? GetRelicModel(object holder)
+    {
+        var relic = GetMemberValue(holder, "Relic");
+        return GetMemberValue(relic, "Model");
+    }
+
+    private static object? GetMemberValue(object? source, string memberName)
+    {
+        if (source == null) return null;
+
+        var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var type = source.GetType();
+        var property = type.GetProperty(memberName, flags);
+        if (property?.CanRead == true)
+        {
+            try { return property.GetValue(source); }
+            catch { }
+        }
+
+        var field = type.GetField(memberName, flags);
+        if (field != null)
+        {
+            try { return field.GetValue(source); }
+            catch { }
+        }
+
+        return null;
+    }
+
+    private static string? GetMemberText(object? value)
+    {
+        try
+        {
+            if (value == null) return null;
+            if (value is LocString locString) return locString.GetFormattedText();
+
+            var entry = GetMemberValue(value, "Entry");
+            if (entry != null) return entry.ToString();
+
+            return value.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string NormalizeRelicId(string? relicId)
+    {
+        var normalized = (relicId ?? "").Trim();
+        if (normalized.StartsWith("RELIC.", StringComparison.OrdinalIgnoreCase))
+            normalized = normalized["RELIC.".Length..];
+        return normalized.ToUpperInvariant();
+    }
+}
+
+[HarmonyPatch]
+public static class RelicHoverHidePatch
+{
+    public static IEnumerable<MethodBase> TargetMethods()
+    {
+        var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var basicUnfocus = typeof(NRelicBasicHolder).GetMethod("OnUnfocus", flags);
+        if (basicUnfocus != null) yield return basicUnfocus;
+
+        var inventoryUnfocus = typeof(NRelicInventoryHolder).GetMethod("OnUnfocus", flags);
+        if (inventoryUnfocus != null && inventoryUnfocus.DeclaringType != basicUnfocus?.DeclaringType)
+            yield return inventoryUnfocus;
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix()
+    {
+        try { StatsTooltip.Hide(); }
+        catch (Exception e) { CoreMain.Logger.Error($"RelicHoverHide failed: {e.Message}"); }
+    }
+}

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -10,7 +10,7 @@ namespace SpireLens.Core;
 /// </summary>
 public class RunData
 {
-    public const int CurrentSchemaVersion = 14;
+    public const int CurrentSchemaVersion = 15;
 
     // v1: aggregates keyed by card definition id (pooled across instances)
     // v2: aggregates keyed by per-instance id ("CARD.STRIKE_SILENT#1") —
@@ -55,6 +55,9 @@ public class RunData
     //      own runtime behavior can recur them to hand (starting with
     //      Make It So). Also additive; older v13 files remain resumable
     //      with the new field defaulting to 0.
+    // v15: add per-relic aggregates, starting with Letter Opener activation
+    //      count and attempted damage. Also additive; older v14 files remain
+    //      resumable with the new dictionary defaulting to empty.
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public string RunId { get; set; } = "";
     public string StartedAt { get; set; } = "";  // ISO-8601 UTC
@@ -80,6 +83,9 @@ public class RunData
 
     /// <summary>Per-card aggregates. Keyed by card definition ID (e.g. "STRIKE_KIN"). Upgraded and base versions share a key for now; upgrade breakout is a future issue.</summary>
     public Dictionary<string, CardAggregate> Aggregates { get; set; } = new();
+
+    /// <summary>Per-relic aggregates. Keyed by relic definition ID, e.g. "LETTER_OPENER".</summary>
+    public Dictionary<string, RelicAggregate> RelicAggregates { get; set; } = new();
 
     /// <summary>Full per-event log for later deep analysis. One entry per card play + one entry per damage-received-from-card.</summary>
     public List<CardEvent> Events { get; set; } = new();
@@ -304,6 +310,13 @@ public class BlockedDrawReasonAggregate
     public string ReasonId { get; set; } = "";
     public string DisplayName { get; set; } = "";
     public int Count { get; set; }
+}
+
+public class RelicAggregate
+{
+    public int TimesActivated { get; set; }
+    public int TotalAttemptedDamage { get; set; }
+    public int TotalTargets { get; set; }
 }
 
 /// <summary>

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -115,6 +115,7 @@ public static class RunStorage
             case 11:
             case 12:
             case 13:
+            case 14:
             case RunData.CurrentSchemaVersion:
             {
                 var data = DeserializeRunData(path);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -37,6 +37,8 @@ namespace SpireLens.Core;
 /// </summary>
 public static class RunTracker
 {
+    private const string LetterOpenerRelicId = "LETTER_OPENER";
+    private const int LetterOpenerDamagePerTarget = 5;
     private const string ShivDefinitionId = "CARD.SHIV";
     private const string SovereignBladeLegacyDefinitionToken = "SOVEREIGN_BLADE";
     private const string SovereignBladeLegacyDefinitionId = "CARD.SOVEREIGN_BLADE";
@@ -165,6 +167,28 @@ public static class RunTracker
             {
                 result ??= new CardAggregate();
                 MergeAggregateInto(result, pending);
+            }
+
+            return result;
+        }
+    }
+
+    public static RelicAggregate? GetEffectiveRelicAggregate(string relicId)
+    {
+        if (string.IsNullOrWhiteSpace(relicId)) return null;
+
+        lock (_lock)
+        {
+            var normalizedRelicId = NormalizeRelicId(relicId);
+            RelicAggregate? result = null;
+
+            if (_currentRun != null && _currentRun.RelicAggregates.TryGetValue(normalizedRelicId, out var committed))
+                result = CloneRelicAggregate(committed);
+
+            if (_pendingCombat != null && _pendingCombat.CombatRelicAggregates.TryGetValue(normalizedRelicId, out var pending))
+            {
+                result ??= new RelicAggregate();
+                MergeRelicAggregateInto(result, pending);
             }
 
             return result;
@@ -931,6 +955,11 @@ public static class RunTracker
                 var runAgg = GetOrCreateAggregate(_currentRun, cardId);
                 MergeAggregateInto(runAgg, combatAgg);
             }
+            foreach (var (relicId, combatAgg) in _pendingCombat.CombatRelicAggregates)
+            {
+                var runAgg = GetOrCreateRelicAggregate(_currentRun, relicId);
+                MergeRelicAggregateInto(runAgg, combatAgg);
+            }
             _currentRun.Events.AddRange(_pendingCombat.CombatEvents);
 
             // Refresh run-level metadata from the current game state (floor may have advanced).
@@ -1311,6 +1340,40 @@ public static class RunTracker
             {
                 CoreMain.LogDebug($"TryGetMakeItSoSkillCounter failed: {e.Message}");
                 return false;
+            }
+        }
+    }
+
+    public static void NoteLetterOpenerBeforeCardPlayed(
+        CardPlay cardPlay,
+        int skillsPlayedIncludingThis,
+        int activationThreshold)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (_pendingCombat == null) return;
+
+                var card = cardPlay?.Card;
+                if (card == null || card.Owner == null) return;
+                if (card.Type != CardType.Skill) return;
+
+                if (activationThreshold <= 0) return;
+                if (skillsPlayedIncludingThis <= 0 || skillsPlayedIncludingThis % activationThreshold != 0)
+                    return;
+
+                int targetCount = CountLetterOpenerTargets(card.CombatState);
+                if (targetCount <= 0) return;
+
+                var agg = GetOrCreateRelicAggregate(_pendingCombat, LetterOpenerRelicId);
+                agg.TimesActivated++;
+                agg.TotalTargets += targetCount;
+                agg.TotalAttemptedDamage += LetterOpenerDamagePerTarget * targetCount;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"NoteLetterOpenerBeforeCardPlayed failed: {e.Message}");
             }
         }
     }
@@ -3186,6 +3249,28 @@ public static class RunTracker
         return agg;
     }
 
+    private static RelicAggregate GetOrCreateRelicAggregate(PendingCombat pending, string relicId)
+    {
+        var normalizedRelicId = NormalizeRelicId(relicId);
+        if (!pending.CombatRelicAggregates.TryGetValue(normalizedRelicId, out var agg))
+        {
+            agg = new RelicAggregate();
+            pending.CombatRelicAggregates[normalizedRelicId] = agg;
+        }
+        return agg;
+    }
+
+    private static RelicAggregate GetOrCreateRelicAggregate(RunData run, string relicId)
+    {
+        var normalizedRelicId = NormalizeRelicId(relicId);
+        if (!run.RelicAggregates.TryGetValue(normalizedRelicId, out var agg))
+        {
+            agg = new RelicAggregate();
+            run.RelicAggregates[normalizedRelicId] = agg;
+        }
+        return agg;
+    }
+
     private static int GetMakeItSoThreshold(CardModel card)
     {
         if (card is not MakeItSo makeItSo) return 0;
@@ -3219,6 +3304,28 @@ public static class RunTracker
         {
             return 0;
         }
+    }
+
+    private static int CountLetterOpenerTargets(ICombatState? combatState)
+    {
+        if (combatState is not CombatState concreteCombatState) return 0;
+
+        try
+        {
+            return concreteCombatState.HittableEnemies.Count(creature => creature.IsAlive && creature.IsHittable);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static string NormalizeRelicId(string relicId)
+    {
+        var normalized = relicId.Trim();
+        if (normalized.StartsWith("RELIC.", StringComparison.OrdinalIgnoreCase))
+            normalized = normalized["RELIC.".Length..];
+        return normalized.ToUpperInvariant();
     }
 
     private static CardAggregate CloneAggregate(CardAggregate source)
@@ -3261,6 +3368,16 @@ public static class RunTracker
         return clone;
     }
 
+    private static RelicAggregate CloneRelicAggregate(RelicAggregate source)
+    {
+        return new RelicAggregate
+        {
+            TimesActivated = source.TimesActivated,
+            TotalAttemptedDamage = source.TotalAttemptedDamage,
+            TotalTargets = source.TotalTargets,
+        };
+    }
+
     private static void MergeAggregateInto(CardAggregate target, CardAggregate source)
     {
         target.Plays += source.Plays;
@@ -3290,6 +3407,13 @@ public static class RunTracker
         target.TimesSummonedToHand += source.TimesSummonedToHand;
         MergeBlockedDrawReasonsInto(target.BlockedDrawReasons, source.BlockedDrawReasons);
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
+    }
+
+    private static void MergeRelicAggregateInto(RelicAggregate target, RelicAggregate source)
+    {
+        target.TimesActivated += source.TimesActivated;
+        target.TotalAttemptedDamage += source.TotalAttemptedDamage;
+        target.TotalTargets += source.TotalTargets;
     }
 
     private static void MergeBlockedDrawReasonsInto(
@@ -3591,6 +3715,7 @@ public static class RunTracker
 internal class PendingCombat
 {
     public Dictionary<string, CardAggregate> CombatAggregates { get; } = new();
+    public Dictionary<string, RelicAggregate> CombatRelicAggregates { get; } = new();
     public List<CardEvent> CombatEvents { get; } = new();
     public List<BlockChunk> PlayerBlockLedger { get; } = new();
     public Dictionary<AbstractModel, PlayerPowerOwnershipShare> PlayerPowerOwnershipByModifier { get; }

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -47,17 +47,19 @@ These fixture files pin the on-disk run-file shapes that the mod has written.
   Legacy-but-resumable additive schema. Adds categorized blocked-draw reasons so draw cards can say
   why missing draws were prevented, alongside the v12 attempted/actual gap.
 - `v14-per-instance-make-it-so-run.json`
-  Current schema. Adds per-card summon-to-hand tracking for cards like
+  Legacy-but-resumable additive schema. Adds per-card summon-to-hand tracking for cards like
   `Make It So`, alongside the existing forge, blocked-draw, and per-instance
   attribution data.
+- `v15-relic-stats-run.json`
+  Current schema. Adds per-relic aggregates, starting with `LETTER_OPENER`
+  activation count and attempted damage.
 
 Why these exist:
 
 - schema work should be validated against real checked-in examples, not memory
 - `v1 -> v2` is not a lossless migration, so the old pooled shape needs to stay
   visible when changing loader behavior
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, `v7 -> v8`, `v8 -> v9`, `v9 -> v10`, `v10 -> v11`, `v11 -> v12`, and `v12 -> v13`) still need fixture coverage so
-- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, `v7 -> v8`, `v8 -> v9`, `v9 -> v10`, `v10 -> v11`, `v11 -> v12`, `v12 -> v13`, and `v13 -> v14`) still need fixture coverage so
+- additive follow-on schemas (like `v2 -> v3`, `v4 -> v5`, `v5 -> v6`, `v6 -> v7`, `v7 -> v8`, `v8 -> v9`, `v9 -> v10`, `v10 -> v11`, `v11 -> v12`, `v12 -> v13`, `v13 -> v14`, and `v14 -> v15`) still need fixture coverage so
   "old but resumable" behavior stays intentional
 - future tests can read these files directly without having to reconstruct old
   JSON by hand

--- a/Fixtures/RunSchema/v15-relic-stats-run.json
+++ b/Fixtures/RunSchema/v15-relic-stats-run.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 15,
+  "run_id": "fixture-v15-relic-stats",
+  "started_at": "2026-04-21T12:00:00Z",
+  "updated_at": "2026-04-21T12:07:00Z",
+  "ended_at": "2026-04-21T12:09:00Z",
+  "character": "REG",
+  "ascension": 10,
+  "floor_reached": 10,
+  "outcome": "win",
+  "game_start_time": 1713700800,
+  "aggregates": {
+    "CARD.REFINE_BLADE#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 1,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 9,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 1,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "applied_effects": {
+        "POWER.ENERGY_NEXT_TURN": {
+          "effect_id": "POWER.ENERGY_NEXT_TURN",
+          "display_name": "Energy Next Turn",
+          "icon_path": "res://images/atlases/power_atlas.sprites/energy_next_turn_power.tres",
+          "times_applied": 2,
+          "total_amount_applied": 2,
+          "times_blocked_by_artifact": 0,
+          "total_amount_blocked_by_artifact": 0,
+          "total_triggered_effective_damage": 0,
+          "total_triggered_overkill": 0,
+          "total_triggered_cards_draw_blocked": 0
+        }
+      },
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.MAKE_IT_SO#1": {
+      "plays": 1,
+      "total_intended": 12,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 12,
+      "kills": 1,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 3,
+      "times_discarded": 2,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 2,
+      "applied_effects": {},
+      "floor_added": 4,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "events": [
+    {
+      "t": "2026-04-21T12:01:00Z",
+      "type": "forge_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "forge_gained": 5,
+      "floor": 4
+    },
+    {
+      "t": "2026-04-21T12:01:00Z",
+      "type": "energy_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "energy_gained": 1,
+      "floor": 4
+    },
+    {
+      "t": "2026-04-21T12:04:00Z",
+      "type": "forge_gained",
+      "card_id": "CARD.REFINE_BLADE#1",
+      "forge_gained": 4,
+      "floor": 7
+    },
+    {
+      "t": "2026-04-21T12:06:00Z",
+      "type": "card_played",
+      "card_id": "CARD.MAKE_IT_SO#1",
+      "energy_spent": 2,
+      "floor": 8
+    }
+  ],
+  "instance_numbers_by_def": {
+    "CARD.REFINE_BLADE": [
+      1
+    ],
+    "CARD.MAKE_IT_SO": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.REFINE_BLADE": 1,
+    "CARD.MAKE_IT_SO": 1
+  },
+  "relic_aggregates": {
+    "LETTER_OPENER": {
+      "times_activated": 2,
+      "total_attempted_damage": 30,
+      "total_targets": 6
+    }
+  }
+}

--- a/Tests/SpireLens.Core.Tests/RelicTooltipTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicTooltipTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class RelicTooltipTests
+{
+    private static readonly MethodInfo BuildBodyBBCodeMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildBodyBBCode not found.");
+
+    [Fact]
+    public void BuildBodyBBCode_RendersLetterOpenerStats()
+    {
+        var aggregate = new RelicAggregate
+        {
+            TimesActivated = 2,
+            TotalAttemptedDamage = 30,
+            TotalTargets = 6,
+        };
+
+        var text = (string)(BuildBodyBBCodeMethod.Invoke(null, new object?[] { aggregate })
+            ?? throw new InvalidOperationException("BuildBodyBBCode returned null."));
+
+        Assert.Contains("Times activated", text);
+        Assert.Contains("[b]2[/b]", text);
+        Assert.Contains("Attempted damage", text);
+        Assert.Contains("[b]30[/b]", text);
+    }
+
+    [Fact]
+    public void BuildBodyBBCode_SkipsEmptyAggregate()
+    {
+        var text = (string)(BuildBodyBBCodeMethod.Invoke(null, new object?[] { new RelicAggregate() })
+            ?? throw new InvalidOperationException("BuildBodyBBCode returned null."));
+
+        Assert.Equal("", text);
+    }
+}

--- a/Tests/SpireLens.Core.Tests/RunTrackerAggregateTests.cs
+++ b/Tests/SpireLens.Core.Tests/RunTrackerAggregateTests.cs
@@ -14,6 +14,14 @@ public class RunTrackerAggregateTests
         typeof(RunTracker).GetMethod("MergeAggregateInto", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("MergeAggregateInto not found.");
 
+    private static readonly MethodInfo CloneRelicAggregateMethod =
+        typeof(RunTracker).GetMethod("CloneRelicAggregate", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("CloneRelicAggregate not found.");
+
+    private static readonly MethodInfo MergeRelicAggregateIntoMethod =
+        typeof(RunTracker).GetMethod("MergeRelicAggregateInto", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("MergeRelicAggregateInto not found.");
+
     [Fact]
     public void CloneAggregate_CopiesForgeGeneratedAndTimesSummonedToHand()
     {
@@ -48,5 +56,46 @@ public class RunTrackerAggregateTests
 
         Assert.Equal(3, target.TimesSummonedToHand);
         Assert.Equal(9m, target.TotalForgeGenerated);
+    }
+
+    [Fact]
+    public void CloneRelicAggregate_CopiesLetterOpenerFields()
+    {
+        var source = new RelicAggregate
+        {
+            TimesActivated = 2,
+            TotalAttemptedDamage = 30,
+            TotalTargets = 6,
+        };
+
+        var clone = (RelicAggregate)(CloneRelicAggregateMethod.Invoke(null, new object?[] { source })
+            ?? throw new InvalidOperationException("CloneRelicAggregate returned null."));
+
+        Assert.Equal(2, clone.TimesActivated);
+        Assert.Equal(30, clone.TotalAttemptedDamage);
+        Assert.Equal(6, clone.TotalTargets);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_AddsLetterOpenerFields()
+    {
+        var target = new RelicAggregate
+        {
+            TimesActivated = 1,
+            TotalAttemptedDamage = 10,
+            TotalTargets = 2,
+        };
+        var source = new RelicAggregate
+        {
+            TimesActivated = 2,
+            TotalAttemptedDamage = 30,
+            TotalTargets = 6,
+        };
+
+        _ = MergeRelicAggregateIntoMethod.Invoke(null, new object?[] { target, source });
+
+        Assert.Equal(3, target.TimesActivated);
+        Assert.Equal(40, target.TotalAttemptedDamage);
+        Assert.Equal(8, target.TotalTargets);
     }
 }

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -230,9 +230,25 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void HistoricalLoad_AcceptsCurrentV14Fixture()
+    public void HistoricalLoad_AcceptsLegacyV14Fixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("v14-per-instance-make-it-so-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.Equal(14, loaded!.SourceSchemaVersion);
+        Assert.True(loaded.IsLegacy);
+        Assert.True(loaded.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Contains("remains resumable", loaded.CompatibilityNote);
+        Assert.Equal(9m, loaded.Data.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
+        Assert.Equal(2, loaded.Data.Aggregates["CARD.MAKE_IT_SO#1"].TimesSummonedToHand);
+        Assert.Equal(4m, loaded.Data.Events[2].ForgeGained);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsCurrentV15Fixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v15-relic-stats-run.json"));
 
         Assert.NotNull(loaded);
         Assert.Equal(RunData.CurrentSchemaVersion, loaded!.SourceSchemaVersion);
@@ -242,7 +258,10 @@ public class SchemaLoadingTests
         Assert.Null(loaded.CompatibilityNote);
         Assert.Equal(9m, loaded.Data.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
         Assert.Equal(2, loaded.Data.Aggregates["CARD.MAKE_IT_SO#1"].TimesSummonedToHand);
-        Assert.Equal(4m, loaded.Data.Events[2].ForgeGained);
+        var relic = loaded.Data.RelicAggregates["LETTER_OPENER"];
+        Assert.Equal(2, relic.TimesActivated);
+        Assert.Equal(30, relic.TotalAttemptedDamage);
+        Assert.Equal(6, relic.TotalTargets);
     }
 
     [Fact]
@@ -414,15 +433,31 @@ public class SchemaLoadingTests
     }
 
     [Fact]
-    public void ResumableLoad_AcceptsCurrentV14Fixture()
+    public void ResumableLoad_AcceptsLegacyResumableV14Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v14-per-instance-make-it-so-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.Equal(14, resumed!.SchemaVersion);
+        Assert.Equal(9m, resumed.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
+        Assert.Equal(2, resumed.Aggregates["CARD.MAKE_IT_SO#1"].TimesSummonedToHand);
+        Assert.Equal(3, resumed.Aggregates["CARD.MAKE_IT_SO#1"].TimesDrawn);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsCurrentV15Fixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v15-relic-stats-run.json"));
 
         Assert.NotNull(resumed);
         Assert.Equal(RunData.CurrentSchemaVersion, resumed!.SchemaVersion);
         Assert.Equal(9m, resumed.Aggregates["CARD.REFINE_BLADE#1"].TotalForgeGenerated);
         Assert.Equal(2, resumed.Aggregates["CARD.MAKE_IT_SO#1"].TimesSummonedToHand);
         Assert.Equal(3, resumed.Aggregates["CARD.MAKE_IT_SO#1"].TimesDrawn);
+        var relic = resumed.RelicAggregates["LETTER_OPENER"];
+        Assert.Equal(2, relic.TimesActivated);
+        Assert.Equal(30, relic.TotalAttemptedDamage);
+        Assert.Equal(6, relic.TotalTargets);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add v15 per-relic aggregates and combat promotion for relic stats
- track Letter Opener activations and attempted damage from its own activation counter and current hittable enemies
- show Letter Opener stats on relic hover and add schema/tooltip aggregate tests

## Verification
- `dotnet test .\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug --no-restore`