### PR TITLE
docs: add active environment mod configuration note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Per-run JSON files at `%APPDATA%/SlayTheSpire2/SpireLens/runs/<run-id>.json` (Go
 - Slay the Spire 2 (tested against v0.103.2)
 - [BaseLib](https://www.nexusmods.com/slaythespire2/mods/103) - required dependency
 
+> [!NOTE]
+> **Active Environment Reference (May 31, 2026)**
+>
+> The mod is verified working against **Slay the Spire 2 (v0.106.1)** on local dev setups with the following mod stack configuration:
+> - **BaseLib** (`v3.1.2`) — Modding utility dependency
+> - **SpireLens** (`v0.0.0` loader / `v1.0.0` core) — Per-card stats attribution mod
+> - **SpireLens MCP** (`v0.3.4`) — MCP bridge running on port `15526` (`http://localhost:15526/`)
+
 ## Install
 
 Drop the mod output into `<game install>/mods/` (including `SpireLens.dll`, `SpireLens.json`, and the `.pck` when present). Requires BaseLib.


### PR DESCRIPTION
Adds the verified mod stack and version details for Slay the Spire 2 v0.106.1 to the requirements section.