### PR TITLE
build: upgrade BaseLib dependency to 3.1.8

### DIFF
--- a/SpireLens.csproj
+++ b/SpireLens.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.5.1" InitialTargets="CheckDependencyPaths">
+<Project Sdk="Godot.NET.Sdk/4.5.1" InitialTargets="CheckDependencyPaths">
     <Import Project=".\Sts2PathDiscovery.props"/>
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="3.0.9" PrivateAssets="All" GeneratePathProperty="true"/>
+        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="3.1.8" PrivateAssets="All" GeneratePathProperty="true"/>
         <PackageReference Include="Krafs.Publicizer" Version="2.3.0" PrivateAssets="All"/>
         <PackageReference Include="Alchyr.Sts2.ModAnalyzers" Version="0.1.9" />
         <!-- Mono.Cecil: rewrites the Core assembly's manifest name per load so


### PR DESCRIPTION
Upgrades the BaseLib PackageReference from 3.0.9 to 3.1.8. This ensures that dotnet build automatically deploys the compatible BaseLib version into the game's mods folder, preventing the HUD freezing issue on new machine setups.