### PR TITLE
fix: support both BeforeSideTurnEnd and BeforeTurnEnd target methods for Orichalcum patch

### DIFF
--- a/Core/Patches/OrichalcumBeforeTurnEndPatch.cs
+++ b/Core/Patches/OrichalcumBeforeTurnEndPatch.cs
@@ -17,7 +17,8 @@ public static class OrichalcumBeforeTurnEndPatch
     private static MethodBase? TargetMethod()
     {
         var t = AccessTools.TypeByName("MegaCrit.Sts2.Core.Models.Relics.Orichalcum");
-        return t == null ? null : AccessTools.Method(t, "BeforeTurnEnd");
+        if (t == null) return null;
+        return AccessTools.Method(t, "BeforeSideTurnEnd") ?? AccessTools.Method(t, "BeforeTurnEnd");
     }
 
     [HarmonyPrefix]


### PR DESCRIPTION
Updates OrichalcumBeforeTurnEndPatch.cs to target either the new BeforeSideTurnEnd method (renamed in game build v0.106.1) or fall back to the old BeforeTurnEnd method. This prevents startup patching errors on both newer and older game versions.