### PR TITLE
Track Osty and replay attribution stats

### DIFF
--- a/.codex/skills/dev-work/SKILL.md
+++ b/.codex/skills/dev-work/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: dev-work
+description: SpireLens development workflow for code changes, stats work, Harmony patches, PR prep, and user-invoked "dev-work" sessions. Use when modifying this repo and needing the expected git, build, deploy, live-reload, validation, commit, push, PR, and merge flow.
+---
+
+# Dev Work
+
+## Core Rule
+
+Treat SpireLens work as branch-based, pushed, live-validated development. Do not leave the user paying manual validation tax that the repo tooling can handle.
+
+## Start
+
+1. Read `AGENTS.md`, then read the task-relevant docs named there.
+2. Make sure local `main` matches remote `origin/main`.
+   - Fetch first.
+   - Switch to local `main`.
+   - Pull fast-forward only.
+   - If main cannot be updated cleanly, stop and report the blocker.
+3. Branch from fresh `main`, using the `codex/` prefix unless the user asks otherwise.
+   - Prefer a worktree for substantial work or anything likely to overlap with existing dirty state.
+   - If staying in the current worktree, inspect dirty files and do not disturb unrelated user changes.
+
+## Implement
+
+1. Do the requested work. Read code before changing it.
+2. For new attribution or Harmony hooks, read `docs/sts2-runtime-primer.md`.
+3. For persisted fields, add schema fixtures and schema-loading assertions.
+4. Use focused commits on the feature branch. Do not be shy about commits.
+5. Push the feature branch after committing. Do not be shy about pushing feature-branch updates.
+
+## Validate After Each Pushed Iteration
+
+After commit and push, validate the exact pushed code path as far as local tooling allows:
+
+1. Run the relevant unit tests.
+   - Default: `dotnet test D:\repos\SpireLens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug`
+   - Add focused filters when useful, but do not replace the broad suite for risky shared changes.
+2. Build/deploy the mod.
+   - Core-only changes may use the core project/test build if it copies `SpireLens.Core.dll`.
+   - Loader or config-page changes need the root build/deploy.
+   - If deploy fails because STS2 locks `SpireLens.dll`, report that distinction; core hot-reload may still be deployable.
+3. Reload SpireLens through automation, not by asking the user to press F5.
+   - Prefer MCP tool `reload_spirelens_core` when available.
+   - Equivalent bridge call: `POST http://localhost:15526/api/v1/singleplayer` with `{"action":"dev_reload_spirelens_core"}`.
+4. Inspect `%APPDATA%\SlayTheSpire2\logs\godot.log`.
+   - Require `Core.Initialize complete`.
+   - Treat `Core.Initialize threw` as a failed validation.
+   - For Harmony changes, reflection-check target method names and parameter names before relying on reload.
+5. For UI/tooltip changes, use SpireLensMcp live tools/screenshots when practical.
+
+If validation fails, fix it, commit, push, and repeat the validation loop. Ask the user for help only when automated tooling is unavailable, the game state genuinely needs human setup, or the decision is product-level.
+
+## PR And Merge
+
+When the user asks to PR and merge:
+
+1. Ensure the branch is committed and pushed.
+2. Create the PR.
+3. Merge using the repo's normal merge path.
+4. Switch to `main` and pull latest `origin/main` after merge.
+5. Do not spend user attention on branch deletion; merged feature branches are auto-deleted.
+
+## Communication
+
+Be explicit about which phase you are in: branch setup, implementation, commit/push, validation, iteration, PR/merge. If a required validation step is skipped, say exactly why.

--- a/.codex/skills/dev-work/agents/openai.yaml
+++ b/.codex/skills/dev-work/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dev Work"
+  short_description: "SpireLens branch, push, and validation flow"
+  default_prompt: "Use $dev-work for this SpireLens change."

--- a/Config/BuildDisplayTimeZone.cs
+++ b/Config/BuildDisplayTimeZone.cs
@@ -1,0 +1,11 @@
+namespace SpireLens.Config;
+
+public enum BuildDisplayTimeZone
+{
+    Pacific,
+    Eastern,
+    Central,
+    Mountain,
+    UTC,
+    Local,
+}

--- a/Config/BuildMetadataFormatter.cs
+++ b/Config/BuildMetadataFormatter.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Globalization;
+
+namespace SpireLens.Config;
+
+internal static class BuildMetadataFormatter
+{
+    public static string FormatBuildDate(string buildTimestampUtc, BuildDisplayTimeZone selectedTimeZone)
+    {
+        if (!DateTimeOffset.TryParse(
+                buildTimestampUtc,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var utc))
+            return buildTimestampUtc;
+
+        if (!TryResolveTimeZone(selectedTimeZone, out var zone, out var label))
+            return utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+
+        var converted = TimeZoneInfo.ConvertTime(utc, zone);
+        return $"{converted:yyyy-MM-dd HH:mm:ss zzz} ({label})";
+    }
+
+    public static string GetTimeZoneId(BuildDisplayTimeZone selectedTimeZone)
+    {
+        return selectedTimeZone switch
+        {
+            BuildDisplayTimeZone.Pacific => "America/Los_Angeles",
+            BuildDisplayTimeZone.Eastern => "America/New_York",
+            BuildDisplayTimeZone.Central => "America/Chicago",
+            BuildDisplayTimeZone.Mountain => "America/Denver",
+            BuildDisplayTimeZone.UTC => "UTC",
+            BuildDisplayTimeZone.Local => TimeZoneInfo.Local.Id,
+            _ => "America/Los_Angeles",
+        };
+    }
+
+    private static bool TryResolveTimeZone(
+        BuildDisplayTimeZone selectedTimeZone,
+        out TimeZoneInfo zone,
+        out string label)
+    {
+        var candidates = selectedTimeZone switch
+        {
+            BuildDisplayTimeZone.Pacific => ("Pacific", new[] { "Pacific Standard Time", "America/Los_Angeles" }),
+            BuildDisplayTimeZone.Eastern => ("Eastern", new[] { "Eastern Standard Time", "America/New_York" }),
+            BuildDisplayTimeZone.Central => ("Central", new[] { "Central Standard Time", "America/Chicago" }),
+            BuildDisplayTimeZone.Mountain => ("Mountain", new[] { "Mountain Standard Time", "America/Denver" }),
+            BuildDisplayTimeZone.UTC => ("UTC", new[] { "UTC" }),
+            BuildDisplayTimeZone.Local => ("Local", new[] { TimeZoneInfo.Local.Id }),
+            _ => ("Pacific", new[] { "Pacific Standard Time", "America/Los_Angeles" }),
+        };
+
+        label = candidates.Item1;
+        foreach (var id in candidates.Item2)
+        {
+            try
+            {
+                zone = TimeZoneInfo.FindSystemTimeZoneById(id);
+                return true;
+            }
+            catch
+            {
+                // Try the next platform-specific id.
+            }
+        }
+
+        zone = TimeZoneInfo.Utc;
+        return false;
+    }
+}

--- a/Config/SpireLensConfig.cs
+++ b/Config/SpireLensConfig.cs
@@ -1,4 +1,5 @@
 using BaseLib.Config;
+using Godot;
 
 namespace SpireLens.Config;
 
@@ -17,6 +18,38 @@ public sealed class SpireLensConfig : SimpleModConfig
     [ConfigSection("Diagnostics")]
     public static bool EnableDebugLogging { get; set; }
 
+    [ConfigSection("Build")]
+    public static BuildDisplayTimeZone BuildTimeZone { get; set; } = BuildDisplayTimeZone.Pacific;
+
+    [ConfigIgnore]
+    public static string BuildVersion => BuildInfo.Version;
+
+    [ConfigIgnore]
+    public static string BuildSource => BuildInfo.Source;
+
+    [ConfigIgnore]
+    public static string BuildCommit => BuildInfo.CommitHash;
+
+    [ConfigIgnore]
+    public static string BuildDate => BuildMetadataFormatter.FormatBuildDate(
+        BuildInfo.BuildTimestampUtc,
+        BuildTimeZone);
+
+    [ConfigIgnore]
+    public static string BuildTimestampUtc => BuildInfo.BuildTimestampUtc;
+
     [ConfigHideInUI]
     public static bool LegacyPrefsMigrated { get; set; }
+
+    public override void SetupConfigUI(Control root)
+    {
+        base.SetupConfigUI(root);
+
+        root.AddChild(CreateSectionHeader("Build Info", false));
+        root.AddChild(CreateRawLabelControl($"Build version: {BuildVersion}", 18));
+        root.AddChild(CreateRawLabelControl($"Build source: {BuildSource}", 18));
+        root.AddChild(CreateRawLabelControl($"Commit: {BuildCommit}", 18));
+        root.AddChild(CreateRawLabelControl($"Build date: {BuildDate}", 18));
+        root.AddChild(CreateRawLabelControl($"Build timestamp UTC: {BuildTimestampUtc}", 18));
+    }
 }

--- a/Core/CardAggregatePooler.cs
+++ b/Core/CardAggregatePooler.cs
@@ -59,9 +59,13 @@ internal static class CardAggregatePooler
         target.TimesOstyHpAttackBonusApplied += source.TimesOstyHpAttackBonusApplied;
         target.TimesOstySummoned += source.TimesOstySummoned;
         target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
+        target.TimesReplayExtraPlanned += source.TimesReplayExtraPlanned;
         target.TimesReplayExtraPlayed += source.TimesReplayExtraPlayed;
+        target.TimesReplayAttackNoDamage += source.TimesReplayAttackNoDamage;
         MergeBlockedDrawReasonsInto(target.BlockedDrawReasons, source.BlockedDrawReasons);
+        MergeReplayExtraPlayReasonsInto(target.ReplayExtraPlayPlannedReasons, source.ReplayExtraPlayPlannedReasons);
         MergeReplayExtraPlayReasonsInto(target.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
+        MergeReplayExtraPlayReasonsInto(target.ReplayAttackNoDamageReasons, source.ReplayAttackNoDamageReasons);
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 

--- a/Core/CardAggregatePooler.cs
+++ b/Core/CardAggregatePooler.cs
@@ -54,7 +54,14 @@ internal static class CardAggregatePooler
         target.TimesCardsDrawn += source.TimesCardsDrawn;
         target.TimesCardsDrawAttempted += source.TimesCardsDrawAttempted;
         target.TimesCardsDrawBlocked += source.TimesCardsDrawBlocked;
+        target.TimesSummonedToHand += source.TimesSummonedToHand;
+        target.TotalOstyHpAttackBonus += source.TotalOstyHpAttackBonus;
+        target.TimesOstyHpAttackBonusApplied += source.TimesOstyHpAttackBonusApplied;
+        target.TimesOstySummoned += source.TimesOstySummoned;
+        target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
+        target.TimesReplayExtraPlayed += source.TimesReplayExtraPlayed;
         MergeBlockedDrawReasonsInto(target.BlockedDrawReasons, source.BlockedDrawReasons);
+        MergeReplayExtraPlayReasonsInto(target.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 
@@ -67,6 +74,28 @@ internal static class CardAggregatePooler
             if (!target.TryGetValue(kv.Key, out var reason))
             {
                 reason = new BlockedDrawReasonAggregate
+                {
+                    ReasonId = kv.Value.ReasonId,
+                    DisplayName = kv.Value.DisplayName,
+                };
+                target[kv.Key] = reason;
+            }
+
+            reason.Count += kv.Value.Count;
+            if (string.IsNullOrWhiteSpace(reason.DisplayName) && !string.IsNullOrWhiteSpace(kv.Value.DisplayName))
+                reason.DisplayName = kv.Value.DisplayName;
+        }
+    }
+
+    private static void MergeReplayExtraPlayReasonsInto(
+        Dictionary<string, ReplayExtraPlayReasonAggregate> target,
+        Dictionary<string, ReplayExtraPlayReasonAggregate> source)
+    {
+        foreach (var kv in source)
+        {
+            if (!target.TryGetValue(kv.Key, out var reason))
+            {
+                reason = new ReplayExtraPlayReasonAggregate
                 {
                     ReasonId = kv.Value.ReasonId,
                     DisplayName = kv.Value.DisplayName,

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -251,6 +251,9 @@ public static class CardHoverShowPatch
         }
 
         AppendMakeItSoStats(sb, cardModel, agg, compact: false);
+        AppendUnleashStats(sb, cardModel, agg, compact: false);
+        AppendOstySummonStats(sb, cardModel, agg, RunTracker.GetEffectiveMetaStats(), compact: false);
+        AppendReplayStats(sb, agg);
 
         bool hasDedicatedPoison = AppendDedicatedPoisonStats(sb, agg, compact: false);
         AppendAppliedEffects(sb, agg, compact: false, excludePoison: hasDedicatedPoison);
@@ -436,6 +439,9 @@ public static class CardHoverShowPatch
             Row3(sb, GetForgeStatLabel("gained"), FormatDecimal(agg.TotalForgeGenerated), "");
 
         AppendMakeItSoStats(sb, cardModel, agg, compact: true);
+        AppendUnleashStats(sb, cardModel, agg, compact: true);
+        AppendOstySummonStats(sb, cardModel, agg, RunTracker.GetEffectiveMetaStats(), compact: true);
+        AppendReplayStats(sb, agg);
 
         bool showDamage = isAttack || agg.TotalIntended > 0;
         if (showDamage)
@@ -480,6 +486,89 @@ public static class CardHoverShowPatch
         catch
         {
             return true;  // error → assume deck
+        }
+    }
+
+    private static void AppendUnleashStats(
+        StringBuilder sb,
+        MegaCrit.Sts2.Core.Models.CardModel card,
+        CardAggregate agg,
+        bool compact)
+    {
+        if (agg.TotalOstyHpAttackBonus <= 0) return;
+        if (card is not MegaCrit.Sts2.Core.Models.Cards.Unleash
+            && !IsCardId(card, "CARD.UNLEASH"))
+            return;
+
+        Row3(sb, "Osty HP damage", agg.TotalOstyHpAttackBonus.ToString(), "");
+        if (compact) return;
+
+        decimal avgBonus = agg.TimesOstyHpAttackBonusApplied > 0
+            ? (decimal)agg.TotalOstyHpAttackBonus / agg.TimesOstyHpAttackBonusApplied
+            : 0m;
+        Row3(sb, "avg Osty HP damage", FormatDecimal(avgBonus), "");
+    }
+
+    private static void AppendOstySummonStats(
+        StringBuilder sb,
+        MegaCrit.Sts2.Core.Models.CardModel card,
+        CardAggregate agg,
+        RunMetaStats metaStats,
+        bool compact)
+    {
+        agg ??= new CardAggregate();
+        metaStats ??= new RunMetaStats();
+
+        if (!IsOstySummonStatsHome(card, agg)) return;
+        if (agg.TotalOstyHpSummoned <= 0m && metaStats.TotalOstyDamageAbsorbed <= 0m) return;
+
+        if (agg.TotalOstyHpSummoned > 0m)
+            Row3(sb, "Osty HP summoned", FormatDecimal(agg.TotalOstyHpSummoned), "");
+
+        if (!compact && agg.TimesOstySummoned > 0)
+            Row3(sb, "Osty summons", agg.TimesOstySummoned.ToString(), "");
+
+        if (metaStats.TotalOstyDamageAbsorbed > 0m)
+            Row3(sb, "Osty dmg absorbed", FormatDecimal(metaStats.TotalOstyDamageAbsorbed), "");
+    }
+
+    private static bool IsOstySummonStatsHome(
+        MegaCrit.Sts2.Core.Models.CardModel card,
+        CardAggregate agg)
+    {
+        return agg.TimesOstySummoned > 0
+            || agg.TotalOstyHpSummoned > 0m
+            || card is SummonForth
+            || IsCardId(card, "CARD.SUMMON_FORTH");
+    }
+
+    private static bool IsCardId(MegaCrit.Sts2.Core.Models.CardModel? card, string id)
+    {
+        try
+        {
+            return card?.Id != null
+                && string.Equals(card.Id.ToString(), id, StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void AppendReplayStats(StringBuilder sb, CardAggregate agg)
+    {
+        if (agg.TimesReplayExtraPlayed <= 0) return;
+
+        Row3(sb, "Replay extra plays", agg.TimesReplayExtraPlayed.ToString(), "");
+        foreach (var reason in agg.ReplayExtraPlayReasons.Values
+                     .Where(r => r.Count > 0)
+                     .OrderByDescending(r => r.Count)
+                     .ThenBy(r => r.DisplayName))
+        {
+            var displayName = string.IsNullOrWhiteSpace(reason.DisplayName)
+                ? reason.ReasonId
+                : reason.DisplayName;
+            Row3(sb, $"Replay from {displayName}", reason.Count.ToString(), "");
         }
     }
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -520,16 +520,22 @@ public static class CardHoverShowPatch
         metaStats ??= new RunMetaStats();
 
         if (!IsOstySummonStatsHome(card, agg)) return;
-        if (agg.TotalOstyHpSummoned <= 0m && metaStats.TotalOstyDamageAbsorbed <= 0m) return;
+        if (agg.TotalOstyHpSummoned <= 0m
+            && metaStats.TotalOstyHpSummoned <= 0m
+            && metaStats.TotalOstyDamageAbsorbed <= 0m)
+            return;
 
         if (agg.TotalOstyHpSummoned > 0m)
-            Row3(sb, "Osty HP summoned", FormatDecimal(agg.TotalOstyHpSummoned), "");
+            Row3(sb, "Summon gained", FormatDecimal(agg.TotalOstyHpSummoned), "");
 
         if (!compact && agg.TimesOstySummoned > 0)
             Row3(sb, "Osty summons", agg.TimesOstySummoned.ToString(), "");
 
+        if (metaStats.TotalOstyHpSummoned > 0m)
+            Row3(sb, "All Osty total summon", FormatDecimal(metaStats.TotalOstyHpSummoned), "");
+
         if (metaStats.TotalOstyDamageAbsorbed > 0m)
-            Row3(sb, "Osty dmg absorbed", FormatDecimal(metaStats.TotalOstyDamageAbsorbed), "");
+            Row3(sb, "All Osty damage absorbed", FormatDecimal(metaStats.TotalOstyDamageAbsorbed), "");
     }
 
     private static bool IsOstySummonStatsHome(

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -563,9 +563,15 @@ public static class CardHoverShowPatch
 
     private static void AppendReplayStats(StringBuilder sb, CardAggregate agg)
     {
-        if (agg.TimesReplayExtraPlayed <= 0) return;
+        if (agg.TimesReplayExtraPlanned <= 0
+            && agg.TimesReplayExtraPlayed <= 0
+            && agg.TimesReplayAttackNoDamage <= 0)
+            return;
 
-        Row3(sb, "Replay extra plays", agg.TimesReplayExtraPlayed.ToString(), "");
+        if (agg.TimesReplayExtraPlanned > 0)
+            Row3(sb, "Replay planned/played", $"{agg.TimesReplayExtraPlanned}/{agg.TimesReplayExtraPlayed}", "");
+        else
+            Row3(sb, "Replay extra plays", agg.TimesReplayExtraPlayed.ToString(), "");
         foreach (var reason in agg.ReplayExtraPlayReasons.Values
                      .Where(r => r.Count > 0)
                      .OrderByDescending(r => r.Count)
@@ -575,6 +581,20 @@ public static class CardHoverShowPatch
                 ? reason.ReasonId
                 : reason.DisplayName;
             Row3(sb, $"Replay from {displayName}", reason.Count.ToString(), "");
+        }
+
+        if (agg.TimesReplayAttackNoDamage <= 0) return;
+
+        Row3(sb, "Replay no-damage attacks", agg.TimesReplayAttackNoDamage.ToString(), "");
+        foreach (var reason in agg.ReplayAttackNoDamageReasons.Values
+                     .Where(r => r.Count > 0)
+                     .OrderByDescending(r => r.Count)
+                     .ThenBy(r => r.DisplayName))
+        {
+            var displayName = string.IsNullOrWhiteSpace(reason.DisplayName)
+                ? reason.ReasonId
+                : reason.DisplayName;
+            Row3(sb, $"No damage from {displayName}", reason.Count.ToString(), "");
         }
     }
 

--- a/Core/Patches/GlamEnchantPlayCountPatch.cs
+++ b/Core/Patches/GlamEnchantPlayCountPatch.cs
@@ -1,0 +1,22 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models.Enchantments;
+
+namespace SpireLens.Core.Patches;
+
+[HarmonyPatch(typeof(Glam), nameof(Glam.EnchantPlayCount))]
+public static class GlamEnchantPlayCountPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(Glam __instance, int originalPlayCount, int __result)
+    {
+        try
+        {
+            RunTracker.NoteGlamReplayPlayCount(__instance, originalPlayCount, __result);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"Glam replay play-count attribution failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/HookAfterCurrentHpChangedPatch.cs
+++ b/Core/Patches/HookAfterCurrentHpChangedPatch.cs
@@ -6,9 +6,9 @@ using MegaCrit.Sts2.Core.Hooks;
 namespace SpireLens.Core.Patches;
 
 /// <summary>
-/// Captures actual HP restored for owner-specific healing attribution windows.
-/// Attempted healing is recorded at the owner callback; this hook records what
-/// the game actually applied after max-HP clamping or prevention.
+/// Captures observed HP deltas after the game applies clamping, prevention, or
+/// redirection. Positive deltas feed owner-specific healing attribution; Osty
+/// negative deltas feed summon-body absorbed-damage attribution.
 /// </summary>
 [HarmonyPatch(typeof(Hook), nameof(Hook.AfterCurrentHpChanged))]
 public static class HookAfterCurrentHpChangedPatch
@@ -18,8 +18,12 @@ public static class HookAfterCurrentHpChangedPatch
     {
         try
         {
-            if (creature == null || delta <= 0m) return;
-            RunTracker.RecordRelicHealingHpChanged(creature, delta);
+            if (creature == null || delta == 0m) return;
+
+            if (delta > 0m)
+                RunTracker.RecordRelicHealingHpChanged(creature, delta);
+            else
+                RunTracker.RecordOstyHpLost(creature, -delta);
         }
         catch (Exception e)
         {

--- a/Core/Patches/HookModifyCardPlayCountPatch.cs
+++ b/Core/Patches/HookModifyCardPlayCountPatch.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Cards;
+
+namespace SpireLens.Core.Patches;
+
+[HarmonyPatch(typeof(Hook), nameof(Hook.ModifyCardPlayCount))]
+public static class HookModifyCardPlayCountPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(
+        CardModel card,
+        int playCount,
+        ref List<AbstractModel> modifyingModels,
+        int __result)
+    {
+        try
+        {
+            RunTracker.NoteReplayPlayCountModifiers(card, playCount, __result, modifyingModels);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"Replay play-count modifier attribution failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/OstyCmdSummonPatch.cs
+++ b/Core/Patches/OstyCmdSummonPatch.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Captures successful Osty summons from the shared command path. The command
+/// carries its source model and returns the game-observed amount, so this
+/// avoids guessing from card text or play count.
+/// </summary>
+[HarmonyPatch(typeof(OstyCmd), nameof(OstyCmd.Summon))]
+public static class OstyCmdSummonPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(
+        ref Task<SummonResult> __result,
+        PlayerChoiceContext choiceContext,
+        Player summoner,
+        decimal amount,
+        AbstractModel source)
+    {
+        try
+        {
+            if (__result == null || summoner == null || source is not MegaCrit.Sts2.Core.Models.CardModel sourceCard)
+                return;
+
+            __result = ObserveSummonAsync(__result, summoner, sourceCard);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"OstyCmdSummonPatch.Postfix failed: {e.Message}");
+        }
+    }
+
+    private static async Task<SummonResult> ObserveSummonAsync(
+        Task<SummonResult> inner,
+        Player player,
+        MegaCrit.Sts2.Core.Models.CardModel sourceCard)
+    {
+        var result = await inner.ConfigureAwait(false);
+        try
+        {
+            if (result != null && result.Amount > 0m)
+                RunTracker.RecordOstySummoned(player, sourceCard, result.Creature, result.Amount);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"OstyCmdSummonPatch.ObserveSummonAsync failed: {e.Message}");
+        }
+
+        return result!;
+    }
+}

--- a/Core/Patches/UnleashOnPlayPatch.cs
+++ b/Core/Patches/UnleashOnPlayPatch.cs
@@ -1,0 +1,37 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models.Cards;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Captures Unleash's card-specific Osty HP scaling at the owner callback.
+/// The normal damage ledger still records observed damage from the resulting
+/// AttackCommand; this records how much of that attack payload came from
+/// Osty's current HP at play time.
+/// </summary>
+[HarmonyPatch(typeof(Unleash), "OnPlay")]
+public static class UnleashOnPlayPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Unleash __instance, CardPlay cardPlay)
+    {
+        try
+        {
+            if (cardPlay?.Target == null) return;
+
+            var osty = __instance.Owner?.Osty;
+            if (osty == null || !osty.IsAlive) return;
+
+            int ostyHpBonus = osty.CurrentHp;
+            if (ostyHpBonus <= 0) return;
+
+            RunTracker.RecordUnleashOstyHpAttackBonus(__instance, ostyHpBonus);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"UnleashOnPlayPatch.Prefix failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/ViewStatsInjectorPatch.cs
+++ b/Core/Patches/ViewStatsInjectorPatch.cs
@@ -190,6 +190,17 @@ public static class ViewStatsInjectorPatch
             CoreMain.Logger.Warn("ViewStatsInjector: label not found in clone");
         }
 
+        // Godot runs the clone's _Ready() during AddChild(). NTickbox._Ready()
+        // calls ConnectSignals(), which looks up %TickboxVisuals before our
+        // post-add field rewiring below. Duplicate() does not reliably preserve
+        // the unique-name owner relationship, so restore it before insertion.
+        if (innerTickbox != null)
+        {
+            var preAddVisuals = innerTickbox.GetNodeOrNull<Control>("TickboxVisuals");
+            if (preAddVisuals != null)
+                preAddVisuals.UniqueNameInOwner = true;
+        }
+
         // Insert into the same parent as the original (the DeckViewScreen).
         var parent = viewUpgradesContainer.GetParent();
         parent.AddChild(clone);

--- a/Core/Patches/ViewStatsInjectorPatch.cs
+++ b/Core/Patches/ViewStatsInjectorPatch.cs
@@ -196,6 +196,7 @@ public static class ViewStatsInjectorPatch
         // the unique-name owner relationship, so restore it before insertion.
         if (innerTickbox != null)
         {
+            SetOwnerRecursive(clone, clone);
             var preAddVisuals = innerTickbox.GetNodeOrNull<Control>("TickboxVisuals");
             if (preAddVisuals != null)
                 preAddVisuals.UniqueNameInOwner = true;
@@ -291,6 +292,16 @@ public static class ViewStatsInjectorPatch
         catch (Exception e)
         {
             CoreMain.Logger.Error($"DisplayCards re-render failed: {e.Message}");
+        }
+    }
+
+    private static void SetOwnerRecursive(Node node, Node owner)
+    {
+        for (int i = 0; i < node.GetChildCount(); i++)
+        {
+            var child = node.GetChild(i);
+            child.Owner = owner;
+            SetOwnerRecursive(child, owner);
         }
     }
 

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -275,6 +275,7 @@ public class CardAggregate
 
 public class RunMetaStats
 {
+    public decimal TotalOstyHpSummoned { get; set; }
     public decimal TotalOstyDamageAbsorbed { get; set; }
 }
 

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -228,8 +228,12 @@ public class CardAggregate
     // M3p: Extra plays caused by the game's replay/multi-play series. Total
     // Plays already includes these; this field tracks the subset where the
     // finished CardPlay was not the first play in its series.
+    public int TimesReplayExtraPlanned { get; set; }
+    public Dictionary<string, ReplayExtraPlayReasonAggregate> ReplayExtraPlayPlannedReasons { get; set; } = new();
     public int TimesReplayExtraPlayed { get; set; }
     public Dictionary<string, ReplayExtraPlayReasonAggregate> ReplayExtraPlayReasons { get; set; } = new();
+    public int TimesReplayAttackNoDamage { get; set; }
+    public Dictionary<string, ReplayExtraPlayReasonAggregate> ReplayAttackNoDamageReasons { get; set; } = new();
 
     // M4a: Effect / power application summary for this specific card
     // instance. First pass tracks ONLY that the card caused a power/effect

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -48,6 +48,13 @@ public class RunData
     public Dictionary<string, RelicAggregate> RelicAggregates { get; set; } = new();
 
     /// <summary>
+    /// Run-level facts surfaced on related cards when that card is the natural
+    /// place to inspect the mechanic, but the value is not caused by that
+    /// specific card instance.
+    /// </summary>
+    public RunMetaStats MetaStats { get; set; } = new();
+
+    /// <summary>
     /// Snapshot of per-instance number assignments, serialized so that hot
     /// reload mid-run can resume with the same numbers instead of losing
     /// the CardModel-ref → number mapping (which only lives in memory on
@@ -206,6 +213,24 @@ public class CardAggregate
     // of this number.
     public int TimesSummonedToHand { get; set; }
 
+    // M3n: Unleash-specific Osty HP scaling. Unleash adds Osty's current HP
+    // to its attack payload; these fields track that contribution separately
+    // from the normal observed damage totals.
+    public int TotalOstyHpAttackBonus { get; set; }
+    public int TimesOstyHpAttackBonusApplied { get; set; }
+
+    // M3o: Card-sourced successful Osty summons. These are direct card
+    // contributions: how often this card summoned/revived Osty and how much
+    // Osty HP the command actually added.
+    public int TimesOstySummoned { get; set; }
+    public decimal TotalOstyHpSummoned { get; set; }
+
+    // M3p: Extra plays caused by the game's replay/multi-play series. Total
+    // Plays already includes these; this field tracks the subset where the
+    // finished CardPlay was not the first play in its series.
+    public int TimesReplayExtraPlayed { get; set; }
+    public Dictionary<string, ReplayExtraPlayReasonAggregate> ReplayExtraPlayReasons { get; set; } = new();
+
     // M4a: Effect / power application summary for this specific card
     // instance. First pass tracks ONLY that the card caused a power/effect
     // to be applied, not what the downstream effect later did. Keyed by the
@@ -248,6 +273,11 @@ public class CardAggregate
     // M3c: Draw count attribution. Null until M3c.
 }
 
+public class RunMetaStats
+{
+    public decimal TotalOstyDamageAbsorbed { get; set; }
+}
+
 /// <summary>
 /// First-pass effect/power tracking credited back to a card instance.
 /// Keeps enough display metadata for tooltip rendering without forcing the
@@ -279,6 +309,13 @@ public class HealingLostReasonAggregate
     public string ReasonId { get; set; } = "";
     public string DisplayName { get; set; } = "";
     public decimal Amount { get; set; }
+}
+
+public class ReplayExtraPlayReasonAggregate
+{
+    public string ReasonId { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public int Count { get; set; }
 }
 
 /// <summary>

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -8,7 +8,9 @@ using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Entities.Powers;
 using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Hooks;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Enchantments;
 using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.Rooms;
@@ -92,6 +94,7 @@ public static class RunTracker
     // next added Strike gets the NEXT number, not a reused old one.
     private static readonly Dictionary<string, int> _defCounters = new();
     private static readonly HashSet<CardModel> _pendingMakeItSoSummons = new();
+    private static readonly Dictionary<CardModel, Queue<PendingReplayExtraPlaySource>> _pendingReplayExtraPlaySources = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Wire up game event subscriptions. Called by <see cref="CoreMain.Initialize"/>
@@ -173,6 +176,19 @@ public static class RunTracker
                 MergeAggregateInto(result, pending);
             }
 
+            return result;
+        }
+    }
+
+    public static RunMetaStats GetEffectiveMetaStats()
+    {
+        lock (_lock)
+        {
+            var result = new RunMetaStats();
+            if (_currentRun != null)
+                MergeMetaStatsInto(result, _currentRun.MetaStats);
+            if (_pendingCombat != null)
+                MergeMetaStatsInto(result, _pendingCombat.MetaStats);
             return result;
         }
     }
@@ -630,6 +646,7 @@ public static class RunTracker
         _pendingHappyFlowerEnergyAttribution = false;
         _pendingCloakClaspBlockAttribution = false;
         _pendingMakeItSoSummons.Clear();
+        _pendingReplayExtraPlaySources.Clear();
     }
 
     /// <summary>
@@ -965,6 +982,8 @@ public static class RunTracker
                 runRelicAgg.EnergyGenerated += pendingRelicAgg.EnergyGenerated;
             }
 
+            MergeMetaStatsInto(_currentRun.MetaStats, _pendingCombat.MetaStats);
+
             // Refresh run-level metadata from the current game state (floor may have advanced).
             var runState = RunManager.Instance.State;
             if (runState != null)
@@ -1107,6 +1126,12 @@ public static class RunTracker
 
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
             agg.Plays++;
+            if (IsReplayExtraPlay(cardPlay))
+            {
+                agg.TimesReplayExtraPlayed++;
+                var reason = ConsumeReplayExtraPlaySourceLocked(cardPlay.Card);
+                RecordReplayExtraPlayReason(agg, reason.ReasonId, reason.DisplayName);
+            }
             // Energy spent = actual energy paid this play, accounting for any
             // cost modifiers (Mummified Hand / similar making a card free
             // still counts 0 here, which is what we want — the card DIDN'T
@@ -1126,6 +1151,173 @@ public static class RunTracker
                 StarsSpent = cardPlay.Resources.StarsSpent,
             });
         }
+    }
+
+    internal static bool IsReplayExtraPlay(CardPlay cardPlay)
+    {
+        return cardPlay != null && cardPlay.PlayIndex > 0;
+    }
+
+    public static void NoteGlamReplayPlayCount(Glam glam, int baseCount, int finalCount)
+    {
+        if (glam?.Card == null) return;
+        int extra = Math.Max(0, finalCount - baseCount);
+        if (extra <= 0) return;
+
+        lock (_lock)
+        {
+            EnqueueReplayExtraPlaySourceLocked(glam.Card, "enchantment:GLAM", "Glam", extra);
+        }
+    }
+
+    public static void NoteReplayPlayCountModifiers(
+        CardModel card,
+        int baseCount,
+        int finalCount,
+        IEnumerable<AbstractModel>? modifyingModels)
+    {
+        if (card == null || modifyingModels == null) return;
+
+        int remaining = Math.Max(0, finalCount - baseCount);
+        if (remaining <= 0) return;
+
+        lock (_lock)
+        {
+            foreach (var modifier in modifyingModels)
+            {
+                if (modifier == null || remaining <= 0) break;
+                var source = ResolveReplayExtraPlaySource(modifier, remaining);
+                if (source.Count <= 0) continue;
+
+                int count = Math.Min(source.Count, remaining);
+                EnqueueReplayExtraPlaySourceLocked(card, source.ReasonId, source.DisplayName, count);
+                remaining -= count;
+            }
+        }
+    }
+
+    private static void EnqueueReplayExtraPlaySourceLocked(
+        CardModel card,
+        string reasonId,
+        string displayName,
+        int count)
+    {
+        if (card == null || count <= 0) return;
+
+        var key = Canonical(card);
+        if (!_pendingReplayExtraPlaySources.TryGetValue(key, out var queue))
+        {
+            queue = new Queue<PendingReplayExtraPlaySource>();
+            _pendingReplayExtraPlaySources[key] = queue;
+        }
+
+        queue.Enqueue(new PendingReplayExtraPlaySource
+        {
+            ReasonId = string.IsNullOrWhiteSpace(reasonId) ? "replay" : reasonId,
+            DisplayName = string.IsNullOrWhiteSpace(displayName) ? "Replay" : displayName,
+            Count = count,
+        });
+    }
+
+    private static (string ReasonId, string DisplayName) ConsumeReplayExtraPlaySourceLocked(CardModel? card)
+    {
+        if (card == null) return ("replay", "Replay");
+
+        var key = Canonical(card);
+        if (!_pendingReplayExtraPlaySources.TryGetValue(key, out var queue))
+            return ("replay", "Replay");
+
+        while (queue.Count > 0)
+        {
+            var source = queue.Peek();
+            if (source.Count <= 0)
+            {
+                queue.Dequeue();
+                continue;
+            }
+
+            source.Count--;
+            var result = (source.ReasonId, source.DisplayName);
+            if (source.Count <= 0)
+                queue.Dequeue();
+            if (queue.Count == 0)
+                _pendingReplayExtraPlaySources.Remove(key);
+            return result;
+        }
+
+        _pendingReplayExtraPlaySources.Remove(key);
+        return ("replay", "Replay");
+    }
+
+    private static PendingReplayExtraPlaySource ResolveReplayExtraPlaySource(AbstractModel modifier, int remaining)
+    {
+        if (modifier is PowerModel power)
+        {
+            var effectId = power.Id.ToString();
+            var count = modifier.GetType().Name == "TagTeamPower" && power.Amount > 0
+                ? Math.Min(power.Amount, remaining)
+                : 1;
+            return new PendingReplayExtraPlaySource
+            {
+                ReasonId = $"power:{effectId}",
+                DisplayName = GetPowerDisplayName(power),
+                Count = count,
+            };
+        }
+
+        if (modifier is EnchantmentModel enchantment)
+        {
+            var name = enchantment.GetType().Name;
+            return new PendingReplayExtraPlaySource
+            {
+                ReasonId = $"enchantment:{name}",
+                DisplayName = GetReadableTypeName(name),
+                Count = 1,
+            };
+        }
+
+        var typeName = modifier.GetType().Name;
+        return new PendingReplayExtraPlaySource
+        {
+            ReasonId = $"modifier:{modifier.GetType().FullName}",
+            DisplayName = GetReadableTypeName(typeName),
+            Count = 1,
+        };
+    }
+
+    private static void RecordReplayExtraPlayReason(CardAggregate agg, string reasonId, string displayName)
+    {
+        reasonId = string.IsNullOrWhiteSpace(reasonId) ? "replay" : reasonId;
+        displayName = string.IsNullOrWhiteSpace(displayName) ? "Replay" : displayName;
+
+        if (!agg.ReplayExtraPlayReasons.TryGetValue(reasonId, out var reason))
+        {
+            reason = new ReplayExtraPlayReasonAggregate
+            {
+                ReasonId = reasonId,
+                DisplayName = displayName,
+            };
+            agg.ReplayExtraPlayReasons[reasonId] = reason;
+        }
+
+        reason.Count++;
+        if (string.IsNullOrWhiteSpace(reason.DisplayName) && !string.IsNullOrWhiteSpace(displayName))
+            reason.DisplayName = displayName;
+    }
+
+    private static string GetReadableTypeName(string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName)) return "Replay";
+        var trimmed = typeName;
+        if (trimmed.EndsWith("Power", StringComparison.Ordinal))
+            trimmed = trimmed[..^"Power".Length];
+        if (trimmed.EndsWith("Enchantment", StringComparison.Ordinal))
+            trimmed = trimmed[..^"Enchantment".Length];
+
+        return string.Concat(trimmed.Select((ch, index) =>
+            index > 0 && char.IsUpper(ch) && !char.IsWhiteSpace(trimmed[index - 1])
+                ? " " + ch
+                : ch.ToString()));
     }
 
     private static void NoteCardPlayStarted(CardPlay cardPlay)
@@ -1558,6 +1750,81 @@ public static class RunTracker
             catch (Exception e)
             {
                 CoreMain.LogDebug($"RecordPocketwatchDraw failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Record Unleash's Osty-current-HP contribution to its attack payload.
+    /// This is card-specific intent metadata captured at the owner callback;
+    /// observed damage still flows through DamageReceivedEntry.
+    /// </summary>
+    public static void RecordUnleashOstyHpAttackBonus(CardModel card, int ostyHpBonus)
+    {
+        if (card == null || ostyHpBonus <= 0) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+                var instanceId = GetOrAssignInstanceId(card);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                agg.TotalOstyHpAttackBonus += ostyHpBonus;
+                agg.TimesOstyHpAttackBonusApplied++;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordUnleashOstyHpAttackBonus failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Record a successful card-sourced Osty summon/revive.
+    /// Called from <see cref="Patches.OstyCmdSummonPatch"/> after the async
+    /// summon command returns the game-observed amount.
+    /// </summary>
+    public static void RecordOstySummoned(Player player, CardModel sourceCard, Creature? ostyCreature, decimal amount)
+    {
+        if (player == null || sourceCard == null || amount <= 0m) return;
+        if (sourceCard.Owner != null && !ReferenceEquals(sourceCard.Owner, player)) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+                var instanceId = GetOrAssignInstanceId(sourceCard);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                agg.TimesOstySummoned++;
+                agg.TotalOstyHpSummoned += amount;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordOstySummoned failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Record HP lost by any Osty body as a run-level meta fact.
+    /// </summary>
+    public static void RecordOstyHpLost(Creature creature, decimal hpLost)
+    {
+        if (creature == null || hpLost <= 0m) return;
+        if (creature.Monster is not MegaCrit.Sts2.Core.Models.Monsters.Osty) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+                _pendingCombat.MetaStats.TotalOstyDamageAbsorbed += hpLost;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordOstyHpLost failed: {e.Message}");
             }
         }
     }
@@ -3877,6 +4144,11 @@ public static class RunTracker
             TimesCardsDrawAttempted = source.TimesCardsDrawAttempted,
             TimesCardsDrawBlocked = source.TimesCardsDrawBlocked,
             TimesSummonedToHand = source.TimesSummonedToHand,
+            TotalOstyHpAttackBonus = source.TotalOstyHpAttackBonus,
+            TimesOstyHpAttackBonusApplied = source.TimesOstyHpAttackBonusApplied,
+            TimesOstySummoned = source.TimesOstySummoned,
+            TotalOstyHpSummoned = source.TotalOstyHpSummoned,
+            TimesReplayExtraPlayed = source.TimesReplayExtraPlayed,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
@@ -3884,6 +4156,7 @@ public static class RunTracker
             RemovedSnapshot = source.RemovedSnapshot,
         };
         MergeBlockedDrawReasonsInto(clone.BlockedDrawReasons, source.BlockedDrawReasons);
+        MergeReplayExtraPlayReasonsInto(clone.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
         MergeAppliedEffectsInto(clone.AppliedEffects, source.AppliedEffects);
         return clone;
     }
@@ -3915,8 +4188,21 @@ public static class RunTracker
         target.TimesCardsDrawAttempted += source.TimesCardsDrawAttempted;
         target.TimesCardsDrawBlocked += source.TimesCardsDrawBlocked;
         target.TimesSummonedToHand += source.TimesSummonedToHand;
+        target.TotalOstyHpAttackBonus += source.TotalOstyHpAttackBonus;
+        target.TimesOstyHpAttackBonusApplied += source.TimesOstyHpAttackBonusApplied;
+        target.TimesOstySummoned += source.TimesOstySummoned;
+        target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
+        target.TimesReplayExtraPlayed += source.TimesReplayExtraPlayed;
         MergeBlockedDrawReasonsInto(target.BlockedDrawReasons, source.BlockedDrawReasons);
+        MergeReplayExtraPlayReasonsInto(target.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
+    }
+
+    private static void MergeMetaStatsInto(RunMetaStats target, RunMetaStats? source)
+    {
+        if (source == null) return;
+
+        target.TotalOstyDamageAbsorbed += source.TotalOstyDamageAbsorbed;
     }
 
     private static void MergeBlockedDrawReasonsInto(
@@ -3928,6 +4214,28 @@ public static class RunTracker
             if (!target.TryGetValue(kv.Key, out var reason))
             {
                 reason = new BlockedDrawReasonAggregate
+                {
+                    ReasonId = kv.Value.ReasonId,
+                    DisplayName = kv.Value.DisplayName,
+                };
+                target[kv.Key] = reason;
+            }
+
+            reason.Count += kv.Value.Count;
+            if (string.IsNullOrWhiteSpace(reason.DisplayName) && !string.IsNullOrWhiteSpace(kv.Value.DisplayName))
+                reason.DisplayName = kv.Value.DisplayName;
+        }
+    }
+
+    private static void MergeReplayExtraPlayReasonsInto(
+        Dictionary<string, ReplayExtraPlayReasonAggregate> target,
+        Dictionary<string, ReplayExtraPlayReasonAggregate> source)
+    {
+        foreach (var kv in source)
+        {
+            if (!target.TryGetValue(kv.Key, out var reason))
+            {
+                reason = new ReplayExtraPlayReasonAggregate
                 {
                     ReasonId = kv.Value.ReasonId,
                     DisplayName = kv.Value.DisplayName,
@@ -4231,6 +4539,7 @@ internal class PendingCombat
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Creature, PendingPoisonTick> PendingPoisonTicks { get; }
         = new(ReferenceEqualityComparer.Instance);
+    public RunMetaStats MetaStats { get; } = new();
     public int NextBlockSequence { get; set; }
 }
 
@@ -4255,6 +4564,13 @@ internal sealed class PendingDrawAttempt
 {
     public required Player Player { get; init; }
     public required CardModel SourceCard { get; init; }
+}
+
+internal sealed class PendingReplayExtraPlaySource
+{
+    public required string ReasonId { get; init; }
+    public required string DisplayName { get; init; }
+    public int Count { get; set; }
 }
 
 internal sealed class PendingRelicHealing

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1799,6 +1799,7 @@ public static class RunTracker
                 var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
                 agg.TimesOstySummoned++;
                 agg.TotalOstyHpSummoned += amount;
+                _pendingCombat.MetaStats.TotalOstyHpSummoned += amount;
             }
             catch (Exception e)
             {
@@ -4202,6 +4203,7 @@ public static class RunTracker
     {
         if (source == null) return;
 
+        target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
         target.TotalOstyDamageAbsorbed += source.TotalOstyDamageAbsorbed;
     }
 

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -95,6 +95,8 @@ public static class RunTracker
     private static readonly Dictionary<string, int> _defCounters = new();
     private static readonly HashSet<CardModel> _pendingMakeItSoSummons = new();
     private static readonly Dictionary<CardModel, Queue<PendingReplayExtraPlaySource>> _pendingReplayExtraPlaySources = new(ReferenceEqualityComparer.Instance);
+    private static readonly Dictionary<CardModel, bool> _pendingReplayExtraPlaySeriesStarted = new(ReferenceEqualityComparer.Instance);
+    private static readonly Dictionary<CardPlay, PendingReplayAttackOutcome> _pendingReplayAttackOutcomes = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Wire up game event subscriptions. Called by <see cref="CoreMain.Initialize"/>
@@ -647,6 +649,8 @@ public static class RunTracker
         _pendingCloakClaspBlockAttribution = false;
         _pendingMakeItSoSummons.Clear();
         _pendingReplayExtraPlaySources.Clear();
+        _pendingReplayExtraPlaySeriesStarted.Clear();
+        _pendingReplayAttackOutcomes.Clear();
     }
 
     /// <summary>
@@ -1130,7 +1134,11 @@ public static class RunTracker
             {
                 agg.TimesReplayExtraPlayed++;
                 var reason = ConsumeReplayExtraPlaySourceLocked(cardPlay.Card);
+                if (!reason.FromPlannedSource)
+                    RecordReplayExtraPlayPlannedReason(agg, reason.ReasonId, reason.DisplayName, 1);
                 RecordReplayExtraPlayReason(agg, reason.ReasonId, reason.DisplayName);
+                if (TryFinishReplayAttackNoDamageLocked(cardPlay))
+                    RecordReplayAttackNoDamageReason(agg, reason.ReasonId, reason.DisplayName);
             }
             // Energy spent = actual energy paid this play, accounting for any
             // cost modifiers (Mummified Hand / similar making a card free
@@ -1205,6 +1213,9 @@ public static class RunTracker
         if (card == null || count <= 0) return;
 
         var key = Canonical(card);
+        if (_pendingReplayExtraPlaySeriesStarted.Remove(key))
+            _pendingReplayExtraPlaySources.Remove(key);
+
         if (!_pendingReplayExtraPlaySources.TryGetValue(key, out var queue))
         {
             queue = new Queue<PendingReplayExtraPlaySource>();
@@ -1217,15 +1228,20 @@ public static class RunTracker
             DisplayName = string.IsNullOrWhiteSpace(displayName) ? "Replay" : displayName,
             Count = count,
         });
+
+        _pendingCombat ??= new PendingCombat();
+        var instanceId = GetOrAssignInstanceId(card);
+        var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+        RecordReplayExtraPlayPlannedReason(agg, reasonId, displayName, count);
     }
 
-    private static (string ReasonId, string DisplayName) ConsumeReplayExtraPlaySourceLocked(CardModel? card)
+    private static (string ReasonId, string DisplayName, bool FromPlannedSource) ConsumeReplayExtraPlaySourceLocked(CardModel? card)
     {
-        if (card == null) return ("replay", "Replay");
+        if (card == null) return ("replay", "Replay", false);
 
         var key = Canonical(card);
         if (!_pendingReplayExtraPlaySources.TryGetValue(key, out var queue))
-            return ("replay", "Replay");
+            return ("replay", "Replay", false);
 
         while (queue.Count > 0)
         {
@@ -1237,16 +1253,20 @@ public static class RunTracker
             }
 
             source.Count--;
-            var result = (source.ReasonId, source.DisplayName);
+            var result = (source.ReasonId, source.DisplayName, true);
             if (source.Count <= 0)
                 queue.Dequeue();
             if (queue.Count == 0)
+            {
                 _pendingReplayExtraPlaySources.Remove(key);
+                _pendingReplayExtraPlaySeriesStarted.Remove(key);
+            }
             return result;
         }
 
         _pendingReplayExtraPlaySources.Remove(key);
-        return ("replay", "Replay");
+        _pendingReplayExtraPlaySeriesStarted.Remove(key);
+        return ("replay", "Replay", false);
     }
 
     private static PendingReplayExtraPlaySource ResolveReplayExtraPlaySource(AbstractModel modifier, int remaining)
@@ -1287,20 +1307,43 @@ public static class RunTracker
 
     private static void RecordReplayExtraPlayReason(CardAggregate agg, string reasonId, string displayName)
     {
+        RecordReplayReason(agg.ReplayExtraPlayReasons, reasonId, displayName, 1);
+    }
+
+    private static void RecordReplayExtraPlayPlannedReason(CardAggregate agg, string reasonId, string displayName, int count)
+    {
+        if (count <= 0) return;
+        agg.TimesReplayExtraPlanned += count;
+        RecordReplayReason(agg.ReplayExtraPlayPlannedReasons, reasonId, displayName, count);
+    }
+
+    private static void RecordReplayAttackNoDamageReason(CardAggregate agg, string reasonId, string displayName)
+    {
+        agg.TimesReplayAttackNoDamage++;
+        RecordReplayReason(agg.ReplayAttackNoDamageReasons, reasonId, displayName, 1);
+    }
+
+    private static void RecordReplayReason(
+        Dictionary<string, ReplayExtraPlayReasonAggregate> reasons,
+        string reasonId,
+        string displayName,
+        int count)
+    {
+        if (count <= 0) return;
         reasonId = string.IsNullOrWhiteSpace(reasonId) ? "replay" : reasonId;
         displayName = string.IsNullOrWhiteSpace(displayName) ? "Replay" : displayName;
 
-        if (!agg.ReplayExtraPlayReasons.TryGetValue(reasonId, out var reason))
+        if (!reasons.TryGetValue(reasonId, out var reason))
         {
             reason = new ReplayExtraPlayReasonAggregate
             {
                 ReasonId = reasonId,
                 DisplayName = displayName,
             };
-            agg.ReplayExtraPlayReasons[reasonId] = reason;
+            reasons[reasonId] = reason;
         }
 
-        reason.Count++;
+        reason.Count += count;
         if (string.IsNullOrWhiteSpace(reason.DisplayName) && !string.IsNullOrWhiteSpace(displayName))
             reason.DisplayName = displayName;
     }
@@ -1325,6 +1368,15 @@ public static class RunTracker
         lock (_lock)
         {
             _currentPlayerCardPlay = cardPlay;
+            if (cardPlay?.Card != null)
+            {
+                var key = Canonical(cardPlay.Card);
+                if (cardPlay.PlayIndex == 0 && _pendingReplayExtraPlaySources.ContainsKey(key))
+                    _pendingReplayExtraPlaySeriesStarted[key] = true;
+
+                if (IsReplayExtraPlay(cardPlay) && cardPlay.Card.Type == CardType.Attack)
+                    _pendingReplayAttackOutcomes[cardPlay] = new PendingReplayAttackOutcome();
+            }
             _recentCompletedPlayerCardPlay = null;
             _recentCompletedPlayerCardPlayHistoryCount = 0;
             _pendingDrawSourceCard = null;
@@ -1343,6 +1395,13 @@ public static class RunTracker
                 && ReferenceEquals(Canonical(_currentPlayerCardPlay.Card), Canonical(cardPlay.Card)))
             {
                 _currentPlayerCardPlay = null;
+            }
+
+            if (cardPlay?.Card != null && cardPlay.IsLastInSeries)
+            {
+                var key = Canonical(cardPlay.Card);
+                _pendingReplayExtraPlaySources.Remove(key);
+                _pendingReplayExtraPlaySeriesStarted.Remove(key);
             }
 
             _recentCompletedPlayerCardPlay = cardPlay;
@@ -3936,6 +3995,7 @@ public static class RunTracker
             _pendingCombat ??= new PendingCombat();
             var instanceId = GetOrAssignInstanceId(entry.CardSource!);
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+            MarkReplayAttackDamageLocked(entry.CardSource!);
 
             if (entry.Receiver.IsPlayer)
             {
@@ -3974,6 +4034,25 @@ public static class RunTracker
                 Killed = result.WasTargetKilled,
             });
         }
+    }
+
+    private static void MarkReplayAttackDamageLocked(CardModel card)
+    {
+        if (_currentPlayerCardPlay?.Card == null) return;
+        if (!IsReplayExtraPlay(_currentPlayerCardPlay)) return;
+        if (!ReferenceEquals(Canonical(_currentPlayerCardPlay.Card), Canonical(card))) return;
+
+        if (_pendingReplayAttackOutcomes.TryGetValue(_currentPlayerCardPlay, out var outcome))
+            outcome.HasDamage = true;
+    }
+
+    private static bool TryFinishReplayAttackNoDamageLocked(CardPlay cardPlay)
+    {
+        if (!_pendingReplayAttackOutcomes.TryGetValue(cardPlay, out var outcome))
+            return false;
+
+        _pendingReplayAttackOutcomes.Remove(cardPlay);
+        return !outcome.HasDamage;
     }
 
     internal static (int IntendedDamage, int EffectiveDamage) ComputeEnemyDamageTotals(
@@ -4149,7 +4228,9 @@ public static class RunTracker
             TimesOstyHpAttackBonusApplied = source.TimesOstyHpAttackBonusApplied,
             TimesOstySummoned = source.TimesOstySummoned,
             TotalOstyHpSummoned = source.TotalOstyHpSummoned,
+            TimesReplayExtraPlanned = source.TimesReplayExtraPlanned,
             TimesReplayExtraPlayed = source.TimesReplayExtraPlayed,
+            TimesReplayAttackNoDamage = source.TimesReplayAttackNoDamage,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
@@ -4157,7 +4238,9 @@ public static class RunTracker
             RemovedSnapshot = source.RemovedSnapshot,
         };
         MergeBlockedDrawReasonsInto(clone.BlockedDrawReasons, source.BlockedDrawReasons);
+        MergeReplayExtraPlayReasonsInto(clone.ReplayExtraPlayPlannedReasons, source.ReplayExtraPlayPlannedReasons);
         MergeReplayExtraPlayReasonsInto(clone.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
+        MergeReplayExtraPlayReasonsInto(clone.ReplayAttackNoDamageReasons, source.ReplayAttackNoDamageReasons);
         MergeAppliedEffectsInto(clone.AppliedEffects, source.AppliedEffects);
         return clone;
     }
@@ -4193,9 +4276,13 @@ public static class RunTracker
         target.TimesOstyHpAttackBonusApplied += source.TimesOstyHpAttackBonusApplied;
         target.TimesOstySummoned += source.TimesOstySummoned;
         target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
+        target.TimesReplayExtraPlanned += source.TimesReplayExtraPlanned;
         target.TimesReplayExtraPlayed += source.TimesReplayExtraPlayed;
+        target.TimesReplayAttackNoDamage += source.TimesReplayAttackNoDamage;
         MergeBlockedDrawReasonsInto(target.BlockedDrawReasons, source.BlockedDrawReasons);
+        MergeReplayExtraPlayReasonsInto(target.ReplayExtraPlayPlannedReasons, source.ReplayExtraPlayPlannedReasons);
         MergeReplayExtraPlayReasonsInto(target.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
+        MergeReplayExtraPlayReasonsInto(target.ReplayAttackNoDamageReasons, source.ReplayAttackNoDamageReasons);
         MergeAppliedEffectsInto(target.AppliedEffects, source.AppliedEffects);
     }
 
@@ -4573,6 +4660,11 @@ internal sealed class PendingReplayExtraPlaySource
     public required string ReasonId { get; init; }
     public required string DisplayName { get; init; }
     public int Count { get; set; }
+}
+
+internal sealed class PendingReplayAttackOutcome
+{
+    public bool HasDamage { get; set; }
 }
 
 internal sealed class PendingRelicHealing

--- a/Core/RuntimeOptions.cs
+++ b/Core/RuntimeOptions.cs
@@ -12,6 +12,7 @@ public sealed class RuntimeOptions
     public bool ShowHandTooltips { get; set; } = true;
     public bool UseVerboseHandStats { get; set; }
     public bool EnableDebugLogging { get; set; }
+    public string BuildTimeZoneId { get; set; } = "America/Los_Angeles";
 }
 
 public static class RuntimeOptionsProvider

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -60,6 +60,18 @@ New fixtures added going forward do not need a `v*-` prefix.
 - `v20-bone-flute-run.json`
   Adds Bone Flute owned-Osty trigger tracking alongside actual block gained in
   relic aggregates.
+- `v21-unleash-osty-hp-run.json`
+  Adds Unleash-specific Osty current-HP attack bonus tracking to card
+  aggregates.
+- `v22-osty-summon-body-run.json`
+  Adds card-sourced Osty summon HP to card aggregates and run-level Osty
+  absorbed damage to meta stats.
+- `v23-replay-extra-plays-run.json`
+  Adds per-card replay extra-play tracking, where total plays still includes
+  all plays and this field counts the subset with nonzero play-series index.
+- `v24-replay-source-breakdown-run.json`
+  Adds per-card replay extra-play source breakdowns, preserving both the total
+  extra-play count and the observed source counts when the game exposes them.
 
 Why these exist:
 

--- a/Fixtures/RunSchema/v21-unleash-osty-hp-run.json
+++ b/Fixtures/RunSchema/v21-unleash-osty-hp-run.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 21,
+  "run_id": "fixture-v21-unleash-osty-hp",
+  "started_at": "2026-06-28T19:00:00Z",
+  "updated_at": "2026-06-28T19:12:00Z",
+  "ended_at": "2026-06-28T19:15:00Z",
+  "character": "NECROBINDER",
+  "ascension": 5,
+  "floor_reached": 9,
+  "outcome": "win",
+  "game_start_time": 1782673200,
+  "aggregates": {
+    "CARD.UNLEASH#1": {
+      "plays": 3,
+      "total_intended": 48,
+      "total_blocked": 6,
+      "total_overkill": 2,
+      "total_effective": 40,
+      "kills": 1,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 4,
+      "times_discarded": 1,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "total_osty_hp_attack_bonus": 30,
+      "times_osty_hp_attack_bonus_applied": 3,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "relic_aggregates": {},
+  "events": [],
+  "instance_numbers_by_def": {
+    "CARD.UNLEASH": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.UNLEASH": 1
+  }
+}

--- a/Fixtures/RunSchema/v22-osty-summon-body-run.json
+++ b/Fixtures/RunSchema/v22-osty-summon-body-run.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": 22,
+  "run_id": "fixture-v22-osty-summon-body",
+  "started_at": "2026-06-28T20:00:00Z",
+  "updated_at": "2026-06-28T20:12:00Z",
+  "ended_at": "2026-06-28T20:15:00Z",
+  "character": "NECROBINDER",
+  "ascension": 5,
+  "floor_reached": 10,
+  "outcome": "win",
+  "game_start_time": 1782676800,
+  "aggregates": {
+    "CARD.SUMMON_FORTH#1": {
+      "plays": 2,
+      "total_intended": 0,
+      "total_blocked": 0,
+      "total_overkill": 0,
+      "total_effective": 0,
+      "kills": 0,
+      "total_energy_spent": 2,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 3,
+      "times_discarded": 1,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "total_osty_hp_attack_bonus": 0,
+      "times_osty_hp_attack_bonus_applied": 0,
+      "times_osty_summoned": 2,
+      "total_osty_hp_summoned": 18,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    },
+    "CARD.UNLEASH#1": {
+      "plays": 3,
+      "total_intended": 48,
+      "total_blocked": 6,
+      "total_overkill": 2,
+      "total_effective": 40,
+      "kills": 1,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 4,
+      "times_discarded": 1,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "total_osty_hp_attack_bonus": 30,
+      "times_osty_hp_attack_bonus_applied": 3,
+      "times_osty_summoned": 0,
+      "total_osty_hp_summoned": 0,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "relic_aggregates": {},
+  "meta_stats": {
+    "total_osty_damage_absorbed": 11
+  },
+  "events": [],
+  "instance_numbers_by_def": {
+    "CARD.SUMMON_FORTH": [
+      1
+    ],
+    "CARD.UNLEASH": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.SUMMON_FORTH": 1,
+    "CARD.UNLEASH": 1
+  }
+}

--- a/Fixtures/RunSchema/v22-osty-summon-body-run.json
+++ b/Fixtures/RunSchema/v22-osty-summon-body-run.json
@@ -85,6 +85,7 @@
   },
   "relic_aggregates": {},
   "meta_stats": {
+    "total_osty_hp_summoned": 18,
     "total_osty_damage_absorbed": 11
   },
   "events": [],

--- a/Fixtures/RunSchema/v23-replay-extra-plays-run.json
+++ b/Fixtures/RunSchema/v23-replay-extra-plays-run.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 23,
+  "run_id": "fixture-v23-replay-extra-plays",
+  "started_at": "2026-06-28T21:00:00Z",
+  "updated_at": "2026-06-28T21:12:00Z",
+  "ended_at": "2026-06-28T21:15:00Z",
+  "character": "IRONCLAD",
+  "ascension": 5,
+  "floor_reached": 11,
+  "outcome": "win",
+  "game_start_time": 1782680400,
+  "aggregates": {
+    "CARD.STRIKE_KIN#1": {
+      "plays": 5,
+      "total_intended": 30,
+      "total_blocked": 4,
+      "total_overkill": 1,
+      "total_effective": 25,
+      "kills": 1,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 4,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "total_osty_hp_attack_bonus": 0,
+      "times_osty_hp_attack_bonus_applied": 0,
+      "times_osty_summoned": 0,
+      "total_osty_hp_summoned": 0,
+      "times_replay_extra_played": 2,
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "relic_aggregates": {},
+  "meta_stats": {},
+  "events": [],
+  "instance_numbers_by_def": {
+    "CARD.STRIKE_KIN": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.STRIKE_KIN": 1
+  }
+}

--- a/Fixtures/RunSchema/v24-replay-source-breakdown-run.json
+++ b/Fixtures/RunSchema/v24-replay-source-breakdown-run.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 24,
+  "run_id": "fixture-v24-replay-source-breakdown",
+  "started_at": "2026-06-28T22:00:00Z",
+  "updated_at": "2026-06-28T22:12:00Z",
+  "ended_at": "2026-06-28T22:15:00Z",
+  "character": "IRONCLAD",
+  "ascension": 5,
+  "floor_reached": 12,
+  "outcome": "win",
+  "game_start_time": 1782684000,
+  "aggregates": {
+    "CARD.STRIKE_KIN#1": {
+      "plays": 6,
+      "total_intended": 36,
+      "total_blocked": 4,
+      "total_overkill": 1,
+      "total_effective": 31,
+      "kills": 1,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 4,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "total_osty_hp_attack_bonus": 0,
+      "times_osty_hp_attack_bonus_applied": 0,
+      "times_osty_summoned": 0,
+      "total_osty_hp_summoned": 0,
+      "times_replay_extra_played": 3,
+      "replay_extra_play_reasons": {
+        "replay": {
+          "reason_id": "replay",
+          "display_name": "Replay",
+          "count": 1
+        },
+        "power:POWER.BURST": {
+          "reason_id": "power:POWER.BURST",
+          "display_name": "Burst",
+          "count": 2
+        }
+      },
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "relic_aggregates": {},
+  "meta_stats": {},
+  "events": [],
+  "instance_numbers_by_def": {
+    "CARD.STRIKE_KIN": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.STRIKE_KIN": 1
+  }
+}

--- a/Fixtures/RunSchema/v25-replay-outcomes-run.json
+++ b/Fixtures/RunSchema/v25-replay-outcomes-run.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 25,
+  "run_id": "fixture-v25-replay-outcomes",
+  "started_at": "2026-06-28T23:00:00Z",
+  "updated_at": "2026-06-28T23:12:00Z",
+  "ended_at": "2026-06-28T23:15:00Z",
+  "character": "IRONCLAD",
+  "ascension": 5,
+  "floor_reached": 12,
+  "outcome": "win",
+  "game_start_time": 1782687600,
+  "aggregates": {
+    "CARD.STRIKE_KIN#1": {
+      "plays": 6,
+      "total_intended": 36,
+      "total_blocked": 4,
+      "total_overkill": 1,
+      "total_effective": 31,
+      "kills": 1,
+      "total_energy_spent": 3,
+      "total_energy_generated": 0,
+      "total_stars_spent": 0,
+      "total_stars_generated": 0,
+      "total_forge_generated": 0,
+      "total_block_gained": 0,
+      "total_block_effective": 0,
+      "total_block_wasted": 0,
+      "times_drawn": 4,
+      "times_discarded": 0,
+      "times_placed_on_top_from_hand": 0,
+      "times_placed_on_top_from_discard": 0,
+      "times_exhausted_other_cards": 0,
+      "times_exhausted": 0,
+      "total_hp_lost": 0,
+      "times_cards_drawn": 0,
+      "times_cards_draw_attempted": 0,
+      "times_cards_draw_blocked": 0,
+      "blocked_draw_reasons": {},
+      "times_summoned_to_hand": 0,
+      "total_osty_hp_attack_bonus": 0,
+      "times_osty_hp_attack_bonus_applied": 0,
+      "times_osty_summoned": 0,
+      "total_osty_hp_summoned": 0,
+      "times_replay_extra_planned": 4,
+      "replay_extra_play_planned_reasons": {
+        "replay": {
+          "reason_id": "replay",
+          "display_name": "Replay",
+          "count": 1
+        },
+        "power:POWER.BURST": {
+          "reason_id": "power:POWER.BURST",
+          "display_name": "Burst",
+          "count": 3
+        }
+      },
+      "times_replay_extra_played": 3,
+      "replay_extra_play_reasons": {
+        "replay": {
+          "reason_id": "replay",
+          "display_name": "Replay",
+          "count": 1
+        },
+        "power:POWER.BURST": {
+          "reason_id": "power:POWER.BURST",
+          "display_name": "Burst",
+          "count": 2
+        }
+      },
+      "times_replay_attack_no_damage": 1,
+      "replay_attack_no_damage_reasons": {
+        "power:POWER.BURST": {
+          "reason_id": "power:POWER.BURST",
+          "display_name": "Burst",
+          "count": 1
+        }
+      },
+      "applied_effects": {},
+      "floor_added": 1,
+      "initial_upgrade_level": 0,
+      "removed": false
+    }
+  },
+  "relic_aggregates": {},
+  "meta_stats": {},
+  "events": [],
+  "instance_numbers_by_def": {
+    "CARD.STRIKE_KIN": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.STRIKE_KIN": 1
+  }
+}

--- a/Loader/RuntimeOptionsBridge.cs
+++ b/Loader/RuntimeOptionsBridge.cs
@@ -15,6 +15,7 @@ public sealed class RuntimeOptionsSnapshot
     public bool ShowHandTooltips { get; set; } = true;
     public bool UseVerboseHandStats { get; set; }
     public bool EnableDebugLogging { get; set; }
+    public string BuildTimeZoneId { get; set; } = "America/Los_Angeles";
 }
 
 public static class RuntimeOptionsBridge
@@ -60,6 +61,7 @@ public static class RuntimeOptionsBridge
             ShowHandTooltips = SpireLensConfig.ShowHandTooltips,
             UseVerboseHandStats = SpireLensConfig.UseVerboseHandStats,
             EnableDebugLogging = SpireLensConfig.EnableDebugLogging,
+            BuildTimeZoneId = BuildMetadataFormatter.GetTimeZoneId(SpireLensConfig.BuildTimeZone),
         };
     }
 

--- a/SpireLens.csproj
+++ b/SpireLens.csproj
@@ -86,6 +86,41 @@
                 Condition="('$(Sts2DataDir)' == '' or !Exists('$(Sts2DataDir)')) and !Exists('$(Sts2LibDir)/sts2.dll')" />
     </Target>
 
+    <Target Name="GenerateSpireLensBuildInfo" BeforeTargets="CoreCompile">
+        <PropertyGroup>
+            <SpireLensBuildTimestampUtc>$([System.DateTime]::UtcNow.ToString("O"))</SpireLensBuildTimestampUtc>
+            <SpireLensBuildSource>Local</SpireLensBuildSource>
+        </PropertyGroup>
+        <Exec Command="git rev-parse --short=12 HEAD" ConsoleToMSBuild="true" IgnoreExitCode="true">
+            <Output TaskParameter="ConsoleOutput" ItemName="_SpireLensGitCommitOutput" />
+        </Exec>
+        <PropertyGroup>
+            <SpireLensGitCommitHash>@(_SpireLensGitCommitOutput)</SpireLensGitCommitHash>
+            <SpireLensGitCommitHash Condition="'$(SpireLensGitCommitHash)' == ''">unknown</SpireLensGitCommitHash>
+            <SpireLensBuildSource Condition="'$(GITHUB_ACTIONS)' == 'true'">GitHub</SpireLensBuildSource>
+            <SpireLensBuildVersion>$(SpireLensGitCommitHash)</SpireLensBuildVersion>
+            <SpireLensBuildVersion Condition="'$(GITHUB_ACTIONS)' == 'true' and '$(GITHUB_REF_NAME)' != ''">$(GITHUB_REF_NAME)</SpireLensBuildVersion>
+        </PropertyGroup>
+        <ItemGroup>
+            <Compile Include="$(IntermediateOutputPath)BuildInfo.g.cs" />
+            <_SpireLensBuildInfoLines Include="// &lt;auto-generated /&gt;" />
+            <_SpireLensBuildInfoLines Include="namespace SpireLens.Config" />
+            <_SpireLensBuildInfoLines Include="{" />
+            <_SpireLensBuildInfoLines Include="internal static class BuildInfo" />
+            <_SpireLensBuildInfoLines Include="{" />
+            <_SpireLensBuildInfoLines Include="    public const string Version = &quot;$(SpireLensBuildVersion)&quot;%3B" />
+            <_SpireLensBuildInfoLines Include="    public const string CommitHash = &quot;$(SpireLensGitCommitHash)&quot;%3B" />
+            <_SpireLensBuildInfoLines Include="    public const string Source = &quot;$(SpireLensBuildSource)&quot;%3B" />
+            <_SpireLensBuildInfoLines Include="    public const string BuildTimestampUtc = &quot;$(SpireLensBuildTimestampUtc)&quot;%3B" />
+            <_SpireLensBuildInfoLines Include="}" />
+            <_SpireLensBuildInfoLines Include="}" />
+        </ItemGroup>
+        <WriteLinesToFile
+            File="$(IntermediateOutputPath)BuildInfo.g.cs"
+            Lines="@(_SpireLensBuildInfoLines)"
+            Overwrite="true" />
+    </Target>
+
     <Target Name="CopyToModsFolderOnBuild" AfterTargets="PostBuildEvent" Condition="'$(SkipModsDeploy)' != 'true'">
         <Message Text="Copying .dll, manifest, and dependencies to mods folder." Importance="high" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModsPath)$(MSBuildProjectName)/" />

--- a/Tests/SpireLens.Core.Tests/CardAggregatePoolerTests.cs
+++ b/Tests/SpireLens.Core.Tests/CardAggregatePoolerTests.cs
@@ -16,6 +16,11 @@ public class CardAggregatePoolerTests
             TimesExhausted = 1,
             TimesCardsDrawAttempted = 3,
             TimesCardsDrawBlocked = 2,
+            TotalOstyHpAttackBonus = 7,
+            TimesOstyHpAttackBonusApplied = 1,
+            TimesOstySummoned = 1,
+            TotalOstyHpSummoned = 8m,
+            TimesReplayExtraPlayed = 1,
         };
         first.AppliedEffects["POWER.ARTIFACT"] = new AppliedEffectAggregate
         {
@@ -31,6 +36,12 @@ public class CardAggregatePoolerTests
             DisplayName = "No Draw",
             Count = 2,
         };
+        first.ReplayExtraPlayReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 1,
+        };
 
         var second = new CardAggregate
         {
@@ -40,6 +51,11 @@ public class CardAggregatePoolerTests
             TimesExhausted = 2,
             TimesCardsDrawAttempted = 1,
             TimesCardsDrawBlocked = 1,
+            TotalOstyHpAttackBonus = 11,
+            TimesOstyHpAttackBonusApplied = 2,
+            TimesOstySummoned = 2,
+            TotalOstyHpSummoned = 12m,
+            TimesReplayExtraPlayed = 3,
         };
         second.AppliedEffects["POWER.VULNERABLE"] = new AppliedEffectAggregate
         {
@@ -53,6 +69,12 @@ public class CardAggregatePoolerTests
             ReasonId = "full_hand",
             DisplayName = "Hand full",
             Count = 1,
+        };
+        second.ReplayExtraPlayReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 3,
         };
 
         var otherDefinition = new CardAggregate
@@ -78,6 +100,13 @@ public class CardAggregatePoolerTests
         Assert.Equal(3, pooled.TimesExhausted);
         Assert.Equal(4, pooled.TimesCardsDrawAttempted);
         Assert.Equal(3, pooled.TimesCardsDrawBlocked);
+        Assert.Equal(18, pooled.TotalOstyHpAttackBonus);
+        Assert.Equal(3, pooled.TimesOstyHpAttackBonusApplied);
+        Assert.Equal(3, pooled.TimesOstySummoned);
+        Assert.Equal(20m, pooled.TotalOstyHpSummoned);
+        Assert.Equal(4, pooled.TimesReplayExtraPlayed);
+        Assert.Equal(1, pooled.ReplayExtraPlayReasons["replay"].Count);
+        Assert.Equal(3, pooled.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
         Assert.Equal(2, pooled.BlockedDrawReasons["effect:POWER.NO_DRAW"].Count);
         Assert.Equal(1, pooled.BlockedDrawReasons["full_hand"].Count);
 

--- a/Tests/SpireLens.Core.Tests/CardAggregatePoolerTests.cs
+++ b/Tests/SpireLens.Core.Tests/CardAggregatePoolerTests.cs
@@ -20,7 +20,9 @@ public class CardAggregatePoolerTests
             TimesOstyHpAttackBonusApplied = 1,
             TimesOstySummoned = 1,
             TotalOstyHpSummoned = 8m,
+            TimesReplayExtraPlanned = 2,
             TimesReplayExtraPlayed = 1,
+            TimesReplayAttackNoDamage = 1,
         };
         first.AppliedEffects["POWER.ARTIFACT"] = new AppliedEffectAggregate
         {
@@ -42,6 +44,18 @@ public class CardAggregatePoolerTests
             DisplayName = "Replay",
             Count = 1,
         };
+        first.ReplayExtraPlayPlannedReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 2,
+        };
+        first.ReplayAttackNoDamageReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 1,
+        };
 
         var second = new CardAggregate
         {
@@ -55,7 +69,9 @@ public class CardAggregatePoolerTests
             TimesOstyHpAttackBonusApplied = 2,
             TimesOstySummoned = 2,
             TotalOstyHpSummoned = 12m,
+            TimesReplayExtraPlanned = 3,
             TimesReplayExtraPlayed = 3,
+            TimesReplayAttackNoDamage = 2,
         };
         second.AppliedEffects["POWER.VULNERABLE"] = new AppliedEffectAggregate
         {
@@ -75,6 +91,18 @@ public class CardAggregatePoolerTests
             ReasonId = "power:POWER.BURST",
             DisplayName = "Burst",
             Count = 3,
+        };
+        second.ReplayExtraPlayPlannedReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 3,
+        };
+        second.ReplayAttackNoDamageReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 2,
         };
 
         var otherDefinition = new CardAggregate
@@ -104,9 +132,15 @@ public class CardAggregatePoolerTests
         Assert.Equal(3, pooled.TimesOstyHpAttackBonusApplied);
         Assert.Equal(3, pooled.TimesOstySummoned);
         Assert.Equal(20m, pooled.TotalOstyHpSummoned);
+        Assert.Equal(5, pooled.TimesReplayExtraPlanned);
         Assert.Equal(4, pooled.TimesReplayExtraPlayed);
+        Assert.Equal(3, pooled.TimesReplayAttackNoDamage);
+        Assert.Equal(2, pooled.ReplayExtraPlayPlannedReasons["replay"].Count);
+        Assert.Equal(3, pooled.ReplayExtraPlayPlannedReasons["power:POWER.BURST"].Count);
         Assert.Equal(1, pooled.ReplayExtraPlayReasons["replay"].Count);
         Assert.Equal(3, pooled.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal(1, pooled.ReplayAttackNoDamageReasons["replay"].Count);
+        Assert.Equal(2, pooled.ReplayAttackNoDamageReasons["power:POWER.BURST"].Count);
         Assert.Equal(2, pooled.BlockedDrawReasons["effect:POWER.NO_DRAW"].Count);
         Assert.Equal(1, pooled.BlockedDrawReasons["full_hand"].Count);
 

--- a/Tests/SpireLens.Core.Tests/OstySummonStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/OstySummonStatsTests.cs
@@ -30,6 +30,7 @@ public class OstySummonStatsTests
 
         Assert.Equal(0, agg.TimesOstySummoned);
         Assert.Equal(0m, agg.TotalOstyHpSummoned);
+        Assert.Equal(0m, meta.TotalOstyHpSummoned);
         Assert.Equal(0m, meta.TotalOstyDamageAbsorbed);
     }
 
@@ -42,6 +43,7 @@ public class OstySummonStatsTests
             TimesOstySummoned = 2,
             TotalOstyHpSummoned = 18m,
         };
+        run.MetaStats.TotalOstyHpSummoned = 25m;
         run.MetaStats.TotalOstyDamageAbsorbed = 11m;
 
         var json = JsonSerializer.Serialize(run, SerializerOptions);
@@ -56,6 +58,7 @@ public class OstySummonStatsTests
         var agg = restored!.Aggregates["CARD.SUMMON_FORTH#1"];
         Assert.Equal(2, agg.TimesOstySummoned);
         Assert.Equal(18m, agg.TotalOstyHpSummoned);
+        Assert.Equal(25m, restored.MetaStats.TotalOstyHpSummoned);
         Assert.Equal(11m, restored.MetaStats.TotalOstyDamageAbsorbed);
     }
 
@@ -68,16 +71,18 @@ public class OstySummonStatsTests
             TimesOstySummoned = 2,
             TotalOstyHpSummoned = 18m,
         };
-        var meta = new RunMetaStats { TotalOstyDamageAbsorbed = 11m };
+        var meta = new RunMetaStats { TotalOstyHpSummoned = 25m, TotalOstyDamageAbsorbed = 11m };
 
         _ = AppendOstySummonStatsMethod.Invoke(null, new object?[] { sb, new SummonForth(), agg, meta, false });
         var body = sb.ToString();
 
-        Assert.Contains("Osty HP summoned", body);
+        Assert.Contains("Summon gained", body);
         Assert.Contains("[b]18[/b]", body);
         Assert.Contains("Osty summons", body);
         Assert.Contains("[b]2[/b]", body);
-        Assert.Contains("Osty dmg absorbed", body);
+        Assert.Contains("All Osty total summon", body);
+        Assert.Contains("[b]25[/b]", body);
+        Assert.Contains("All Osty damage absorbed", body);
         Assert.Contains("[b]11[/b]", body);
     }
 
@@ -90,13 +95,14 @@ public class OstySummonStatsTests
             TimesOstySummoned = 2,
             TotalOstyHpSummoned = 18m,
         };
-        var meta = new RunMetaStats { TotalOstyDamageAbsorbed = 11m };
+        var meta = new RunMetaStats { TotalOstyHpSummoned = 25m, TotalOstyDamageAbsorbed = 11m };
 
         _ = AppendOstySummonStatsMethod.Invoke(null, new object?[] { sb, new SummonForth(), agg, meta, true });
         var body = sb.ToString();
 
-        Assert.Contains("Osty HP summoned", body);
-        Assert.Contains("Osty dmg absorbed", body);
+        Assert.Contains("Summon gained", body);
+        Assert.Contains("All Osty total summon", body);
+        Assert.Contains("All Osty damage absorbed", body);
         Assert.DoesNotContain("Osty summons", body);
     }
 
@@ -104,13 +110,14 @@ public class OstySummonStatsTests
     public void Tooltip_OstySummonStats_MetaDamageCanShowOnUnplayedSummonCard()
     {
         var sb = new StringBuilder();
-        var meta = new RunMetaStats { TotalOstyDamageAbsorbed = 11m };
+        var meta = new RunMetaStats { TotalOstyHpSummoned = 25m, TotalOstyDamageAbsorbed = 11m };
 
         _ = AppendOstySummonStatsMethod.Invoke(null, new object?[] { sb, new SummonForth(), new CardAggregate(), meta, false });
         var body = sb.ToString();
 
-        Assert.DoesNotContain("Osty HP summoned", body);
-        Assert.Contains("Osty dmg absorbed", body);
+        Assert.DoesNotContain("Summon gained", body);
+        Assert.Contains("All Osty total summon", body);
+        Assert.Contains("All Osty damage absorbed", body);
         Assert.Contains("[b]11[/b]", body);
     }
 }

--- a/Tests/SpireLens.Core.Tests/OstySummonStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/OstySummonStatsTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Models.Cards;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class OstySummonStatsTests
+{
+    private static readonly MethodInfo AppendOstySummonStatsMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendOstySummonStats", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendOstySummonStats not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void OstySummonFields_DefaultToZero()
+    {
+        var agg = new CardAggregate();
+        var meta = new RunMetaStats();
+
+        Assert.Equal(0, agg.TimesOstySummoned);
+        Assert.Equal(0m, agg.TotalOstyHpSummoned);
+        Assert.Equal(0m, meta.TotalOstyDamageAbsorbed);
+    }
+
+    [Fact]
+    public void OstySummonFields_JsonRoundtrip_PreserveCardAndMetaFields()
+    {
+        var run = new RunData();
+        run.Aggregates["CARD.SUMMON_FORTH#1"] = new CardAggregate
+        {
+            TimesOstySummoned = 2,
+            TotalOstyHpSummoned = 18m,
+        };
+        run.MetaStats.TotalOstyDamageAbsorbed = 11m;
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("times_osty_summoned", json);
+        Assert.Contains("total_osty_hp_summoned", json);
+        Assert.Contains("total_osty_damage_absorbed", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var agg = restored!.Aggregates["CARD.SUMMON_FORTH#1"];
+        Assert.Equal(2, agg.TimesOstySummoned);
+        Assert.Equal(18m, agg.TotalOstyHpSummoned);
+        Assert.Equal(11m, restored.MetaStats.TotalOstyDamageAbsorbed);
+    }
+
+    [Fact]
+    public void Tooltip_OstySummonStats_FullViewShowsCardSummonsAndMetaAbsorbedDamage()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate
+        {
+            TimesOstySummoned = 2,
+            TotalOstyHpSummoned = 18m,
+        };
+        var meta = new RunMetaStats { TotalOstyDamageAbsorbed = 11m };
+
+        _ = AppendOstySummonStatsMethod.Invoke(null, new object?[] { sb, new SummonForth(), agg, meta, false });
+        var body = sb.ToString();
+
+        Assert.Contains("Osty HP summoned", body);
+        Assert.Contains("[b]18[/b]", body);
+        Assert.Contains("Osty summons", body);
+        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("Osty dmg absorbed", body);
+        Assert.Contains("[b]11[/b]", body);
+    }
+
+    [Fact]
+    public void Tooltip_OstySummonStats_CompactSkipsSummonCount()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate
+        {
+            TimesOstySummoned = 2,
+            TotalOstyHpSummoned = 18m,
+        };
+        var meta = new RunMetaStats { TotalOstyDamageAbsorbed = 11m };
+
+        _ = AppendOstySummonStatsMethod.Invoke(null, new object?[] { sb, new SummonForth(), agg, meta, true });
+        var body = sb.ToString();
+
+        Assert.Contains("Osty HP summoned", body);
+        Assert.Contains("Osty dmg absorbed", body);
+        Assert.DoesNotContain("Osty summons", body);
+    }
+
+    [Fact]
+    public void Tooltip_OstySummonStats_MetaDamageCanShowOnUnplayedSummonCard()
+    {
+        var sb = new StringBuilder();
+        var meta = new RunMetaStats { TotalOstyDamageAbsorbed = 11m };
+
+        _ = AppendOstySummonStatsMethod.Invoke(null, new object?[] { sb, new SummonForth(), new CardAggregate(), meta, false });
+        var body = sb.ToString();
+
+        Assert.DoesNotContain("Osty HP summoned", body);
+        Assert.Contains("Osty dmg absorbed", body);
+        Assert.Contains("[b]11[/b]", body);
+    }
+}

--- a/Tests/SpireLens.Core.Tests/ReplayStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/ReplayStatsTests.cs
@@ -27,8 +27,12 @@ public class ReplayStatsTests
     {
         var agg = new CardAggregate();
 
+        Assert.Equal(0, agg.TimesReplayExtraPlanned);
         Assert.Equal(0, agg.TimesReplayExtraPlayed);
+        Assert.Equal(0, agg.TimesReplayAttackNoDamage);
+        Assert.Empty(agg.ReplayExtraPlayPlannedReasons);
         Assert.Empty(agg.ReplayExtraPlayReasons);
+        Assert.Empty(agg.ReplayAttackNoDamageReasons);
     }
 
     [Fact]
@@ -38,8 +42,17 @@ public class ReplayStatsTests
         run.Aggregates["CARD.STRIKE_KIN#1"] = new CardAggregate
         {
             Plays = 5,
+            TimesReplayExtraPlanned = 3,
             TimesReplayExtraPlayed = 2,
+            TimesReplayAttackNoDamage = 1,
         };
+        run.Aggregates["CARD.STRIKE_KIN#1"].ReplayExtraPlayPlannedReasons["power:POWER.BURST"] =
+            new ReplayExtraPlayReasonAggregate
+            {
+                ReasonId = "power:POWER.BURST",
+                DisplayName = "Burst",
+                Count = 3,
+            };
         run.Aggregates["CARD.STRIKE_KIN#1"].ReplayExtraPlayReasons["power:POWER.BURST"] =
             new ReplayExtraPlayReasonAggregate
             {
@@ -47,19 +60,34 @@ public class ReplayStatsTests
                 DisplayName = "Burst",
                 Count = 2,
             };
+        run.Aggregates["CARD.STRIKE_KIN#1"].ReplayAttackNoDamageReasons["power:POWER.BURST"] =
+            new ReplayExtraPlayReasonAggregate
+            {
+                ReasonId = "power:POWER.BURST",
+                DisplayName = "Burst",
+                Count = 1,
+            };
 
         var json = JsonSerializer.Serialize(run, SerializerOptions);
 
+        Assert.Contains("times_replay_extra_planned", json);
+        Assert.Contains("replay_extra_play_planned_reasons", json);
         Assert.Contains("times_replay_extra_played", json);
         Assert.Contains("replay_extra_play_reasons", json);
+        Assert.Contains("times_replay_attack_no_damage", json);
+        Assert.Contains("replay_attack_no_damage_reasons", json);
 
         var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
 
         Assert.NotNull(restored);
         var agg = restored!.Aggregates["CARD.STRIKE_KIN#1"];
         Assert.Equal(5, agg.Plays);
+        Assert.Equal(3, agg.TimesReplayExtraPlanned);
         Assert.Equal(2, agg.TimesReplayExtraPlayed);
+        Assert.Equal(1, agg.TimesReplayAttackNoDamage);
+        Assert.Equal(3, agg.ReplayExtraPlayPlannedReasons["power:POWER.BURST"].Count);
         Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal(1, agg.ReplayAttackNoDamageReasons["power:POWER.BURST"].Count);
         Assert.Equal("Burst", agg.ReplayExtraPlayReasons["power:POWER.BURST"].DisplayName);
     }
 
@@ -74,7 +102,12 @@ public class ReplayStatsTests
     public void Tooltip_ReplayStats_ShowsExtraPlays()
     {
         var sb = new StringBuilder();
-        var agg = new CardAggregate { TimesReplayExtraPlayed = 2 };
+        var agg = new CardAggregate
+        {
+            TimesReplayExtraPlanned = 3,
+            TimesReplayExtraPlayed = 2,
+            TimesReplayAttackNoDamage = 1,
+        };
         agg.ReplayExtraPlayReasons["replay"] = new ReplayExtraPlayReasonAggregate
         {
             ReasonId = "replay",
@@ -87,14 +120,22 @@ public class ReplayStatsTests
             DisplayName = "Burst",
             Count = 1,
         };
+        agg.ReplayAttackNoDamageReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 1,
+        };
 
         _ = AppendReplayStatsMethod.Invoke(null, new object?[] { sb, agg });
         var body = sb.ToString();
 
-        Assert.Contains("Replay extra plays", body);
-        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("Replay planned/played", body);
+        Assert.Contains("[b]3/2[/b]", body);
         Assert.Contains("Replay from Replay", body);
         Assert.Contains("Replay from Burst", body);
+        Assert.Contains("Replay no-damage attacks", body);
+        Assert.Contains("No damage from Burst", body);
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/ReplayStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/ReplayStatsTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class ReplayStatsTests
+{
+    private static readonly MethodInfo AppendReplayStatsMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendReplayStats", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendReplayStats not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void CardAggregate_ReplayExtraPlays_DefaultsToZero()
+    {
+        var agg = new CardAggregate();
+
+        Assert.Equal(0, agg.TimesReplayExtraPlayed);
+        Assert.Empty(agg.ReplayExtraPlayReasons);
+    }
+
+    [Fact]
+    public void CardAggregate_ReplayExtraPlays_JsonRoundtrip_PreservesField()
+    {
+        var run = new RunData();
+        run.Aggregates["CARD.STRIKE_KIN#1"] = new CardAggregate
+        {
+            Plays = 5,
+            TimesReplayExtraPlayed = 2,
+        };
+        run.Aggregates["CARD.STRIKE_KIN#1"].ReplayExtraPlayReasons["power:POWER.BURST"] =
+            new ReplayExtraPlayReasonAggregate
+            {
+                ReasonId = "power:POWER.BURST",
+                DisplayName = "Burst",
+                Count = 2,
+            };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("times_replay_extra_played", json);
+        Assert.Contains("replay_extra_play_reasons", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var agg = restored!.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(5, agg.Plays);
+        Assert.Equal(2, agg.TimesReplayExtraPlayed);
+        Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal("Burst", agg.ReplayExtraPlayReasons["power:POWER.BURST"].DisplayName);
+    }
+
+    [Fact]
+    public void IsReplayExtraPlay_UsesNonzeroPlayIndex()
+    {
+        Assert.False(RunTracker.IsReplayExtraPlay(CreateCardPlay(playIndex: 0, playCount: 2)));
+        Assert.True(RunTracker.IsReplayExtraPlay(CreateCardPlay(playIndex: 1, playCount: 2)));
+    }
+
+    [Fact]
+    public void Tooltip_ReplayStats_ShowsExtraPlays()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate { TimesReplayExtraPlayed = 2 };
+        agg.ReplayExtraPlayReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 1,
+        };
+        agg.ReplayExtraPlayReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 1,
+        };
+
+        _ = AppendReplayStatsMethod.Invoke(null, new object?[] { sb, agg });
+        var body = sb.ToString();
+
+        Assert.Contains("Replay extra plays", body);
+        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("Replay from Replay", body);
+        Assert.Contains("Replay from Burst", body);
+    }
+
+    [Fact]
+    public void Tooltip_ReplayStats_HidesWhenZero()
+    {
+        var sb = new StringBuilder();
+
+        _ = AppendReplayStatsMethod.Invoke(null, new object?[] { sb, new CardAggregate() });
+
+        Assert.Equal("", sb.ToString());
+    }
+
+    private static CardPlay CreateCardPlay(int playIndex, int playCount)
+    {
+        var cardPlay = (CardPlay)Activator.CreateInstance(typeof(CardPlay), nonPublic: true)!;
+        typeof(CardPlay).GetProperty(nameof(CardPlay.PlayIndex))!.SetValue(cardPlay, playIndex);
+        typeof(CardPlay).GetProperty(nameof(CardPlay.PlayCount))!.SetValue(cardPlay, playCount);
+        return cardPlay;
+    }
+}

--- a/Tests/SpireLens.Core.Tests/RunTrackerAggregateTests.cs
+++ b/Tests/SpireLens.Core.Tests/RunTrackerAggregateTests.cs
@@ -25,13 +25,27 @@ public class RunTrackerAggregateTests
             TimesOstyHpAttackBonusApplied = 3,
             TimesOstySummoned = 2,
             TotalOstyHpSummoned = 18m,
+            TimesReplayExtraPlanned = 5,
             TimesReplayExtraPlayed = 4,
+            TimesReplayAttackNoDamage = 2,
+        };
+        source.ReplayExtraPlayPlannedReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 5,
         };
         source.ReplayExtraPlayReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
         {
             ReasonId = "power:POWER.BURST",
             DisplayName = "Burst",
             Count = 4,
+        };
+        source.ReplayAttackNoDamageReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 2,
         };
 
         var clone = (CardAggregate)(CloneAggregateMethod.Invoke(null, new object?[] { source })
@@ -43,8 +57,12 @@ public class RunTrackerAggregateTests
         Assert.Equal(3, clone.TimesOstyHpAttackBonusApplied);
         Assert.Equal(2, clone.TimesOstySummoned);
         Assert.Equal(18m, clone.TotalOstyHpSummoned);
+        Assert.Equal(5, clone.TimesReplayExtraPlanned);
         Assert.Equal(4, clone.TimesReplayExtraPlayed);
+        Assert.Equal(2, clone.TimesReplayAttackNoDamage);
+        Assert.Equal(5, clone.ReplayExtraPlayPlannedReasons["power:POWER.BURST"].Count);
         Assert.Equal(4, clone.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal(2, clone.ReplayAttackNoDamageReasons["power:POWER.BURST"].Count);
         Assert.Equal("Burst", clone.ReplayExtraPlayReasons["power:POWER.BURST"].DisplayName);
     }
 
@@ -59,9 +77,23 @@ public class RunTrackerAggregateTests
             TimesOstyHpAttackBonusApplied = 1,
             TimesOstySummoned = 1,
             TotalOstyHpSummoned = 10m,
+            TimesReplayExtraPlanned = 2,
             TimesReplayExtraPlayed = 1,
+            TimesReplayAttackNoDamage = 1,
+        };
+        target.ReplayExtraPlayPlannedReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 2,
         };
         target.ReplayExtraPlayReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 1,
+        };
+        target.ReplayAttackNoDamageReasons["replay"] = new ReplayExtraPlayReasonAggregate
         {
             ReasonId = "replay",
             DisplayName = "Replay",
@@ -75,13 +107,27 @@ public class RunTrackerAggregateTests
             TimesOstyHpAttackBonusApplied = 2,
             TimesOstySummoned = 2,
             TotalOstyHpSummoned = 15m,
+            TimesReplayExtraPlanned = 3,
             TimesReplayExtraPlayed = 3,
+            TimesReplayAttackNoDamage = 2,
+        };
+        source.ReplayExtraPlayPlannedReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 3,
         };
         source.ReplayExtraPlayReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
         {
             ReasonId = "power:POWER.BURST",
             DisplayName = "Burst",
             Count = 3,
+        };
+        source.ReplayAttackNoDamageReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 2,
         };
 
         _ = MergeAggregateIntoMethod.Invoke(null, new object?[] { target, source });
@@ -92,8 +138,14 @@ public class RunTrackerAggregateTests
         Assert.Equal(3, target.TimesOstyHpAttackBonusApplied);
         Assert.Equal(3, target.TimesOstySummoned);
         Assert.Equal(25m, target.TotalOstyHpSummoned);
+        Assert.Equal(5, target.TimesReplayExtraPlanned);
         Assert.Equal(4, target.TimesReplayExtraPlayed);
+        Assert.Equal(3, target.TimesReplayAttackNoDamage);
+        Assert.Equal(2, target.ReplayExtraPlayPlannedReasons["replay"].Count);
+        Assert.Equal(3, target.ReplayExtraPlayPlannedReasons["power:POWER.BURST"].Count);
         Assert.Equal(1, target.ReplayExtraPlayReasons["replay"].Count);
         Assert.Equal(3, target.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal(1, target.ReplayAttackNoDamageReasons["replay"].Count);
+        Assert.Equal(2, target.ReplayAttackNoDamageReasons["power:POWER.BURST"].Count);
     }
 }

--- a/Tests/SpireLens.Core.Tests/RunTrackerAggregateTests.cs
+++ b/Tests/SpireLens.Core.Tests/RunTrackerAggregateTests.cs
@@ -15,12 +15,23 @@ public class RunTrackerAggregateTests
         ?? throw new InvalidOperationException("MergeAggregateInto not found.");
 
     [Fact]
-    public void CloneAggregate_CopiesForgeGeneratedAndTimesSummonedToHand()
+    public void CloneAggregate_CopiesForgeGeneratedTimesSummonedAndOstyStats()
     {
         var source = new CardAggregate
         {
             TimesSummonedToHand = 2,
             TotalForgeGenerated = 9m,
+            TotalOstyHpAttackBonus = 21,
+            TimesOstyHpAttackBonusApplied = 3,
+            TimesOstySummoned = 2,
+            TotalOstyHpSummoned = 18m,
+            TimesReplayExtraPlayed = 4,
+        };
+        source.ReplayExtraPlayReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 4,
         };
 
         var clone = (CardAggregate)(CloneAggregateMethod.Invoke(null, new object?[] { source })
@@ -28,25 +39,61 @@ public class RunTrackerAggregateTests
 
         Assert.Equal(2, clone.TimesSummonedToHand);
         Assert.Equal(9m, clone.TotalForgeGenerated);
+        Assert.Equal(21, clone.TotalOstyHpAttackBonus);
+        Assert.Equal(3, clone.TimesOstyHpAttackBonusApplied);
+        Assert.Equal(2, clone.TimesOstySummoned);
+        Assert.Equal(18m, clone.TotalOstyHpSummoned);
+        Assert.Equal(4, clone.TimesReplayExtraPlayed);
+        Assert.Equal(4, clone.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal("Burst", clone.ReplayExtraPlayReasons["power:POWER.BURST"].DisplayName);
     }
 
     [Fact]
-    public void MergeAggregateInto_AddsForgeGeneratedAndTimesSummonedToHand()
+    public void MergeAggregateInto_AddsForgeGeneratedTimesSummonedAndOstyStats()
     {
         var target = new CardAggregate
         {
             TimesSummonedToHand = 1,
             TotalForgeGenerated = 5m,
+            TotalOstyHpAttackBonus = 8,
+            TimesOstyHpAttackBonusApplied = 1,
+            TimesOstySummoned = 1,
+            TotalOstyHpSummoned = 10m,
+            TimesReplayExtraPlayed = 1,
+        };
+        target.ReplayExtraPlayReasons["replay"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "replay",
+            DisplayName = "Replay",
+            Count = 1,
         };
         var source = new CardAggregate
         {
             TimesSummonedToHand = 2,
             TotalForgeGenerated = 4m,
+            TotalOstyHpAttackBonus = 13,
+            TimesOstyHpAttackBonusApplied = 2,
+            TimesOstySummoned = 2,
+            TotalOstyHpSummoned = 15m,
+            TimesReplayExtraPlayed = 3,
+        };
+        source.ReplayExtraPlayReasons["power:POWER.BURST"] = new ReplayExtraPlayReasonAggregate
+        {
+            ReasonId = "power:POWER.BURST",
+            DisplayName = "Burst",
+            Count = 3,
         };
 
         _ = MergeAggregateIntoMethod.Invoke(null, new object?[] { target, source });
 
         Assert.Equal(3, target.TimesSummonedToHand);
         Assert.Equal(9m, target.TotalForgeGenerated);
+        Assert.Equal(21, target.TotalOstyHpAttackBonus);
+        Assert.Equal(3, target.TimesOstyHpAttackBonusApplied);
+        Assert.Equal(3, target.TimesOstySummoned);
+        Assert.Equal(25m, target.TotalOstyHpSummoned);
+        Assert.Equal(4, target.TimesReplayExtraPlayed);
+        Assert.Equal(1, target.ReplayExtraPlayReasons["replay"].Count);
+        Assert.Equal(3, target.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
     }
 }

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -291,6 +291,67 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsV21UnleashOstyHpFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v21-unleash-osty-hp-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Null(loaded.CompatibilityNote);
+        var agg = loaded.Data.Aggregates["CARD.UNLEASH#1"];
+        Assert.Equal(30, agg.TotalOstyHpAttackBonus);
+        Assert.Equal(3, agg.TimesOstyHpAttackBonusApplied);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsV22OstySummonBodyFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v22-osty-summon-body-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Null(loaded.CompatibilityNote);
+        var summonAgg = loaded.Data.Aggregates["CARD.SUMMON_FORTH#1"];
+        Assert.Equal(2, summonAgg.TimesOstySummoned);
+        Assert.Equal(18m, summonAgg.TotalOstyHpSummoned);
+        Assert.Equal(11m, loaded.Data.MetaStats.TotalOstyDamageAbsorbed);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsV23ReplayExtraPlaysFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v23-replay-extra-plays-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Null(loaded.CompatibilityNote);
+        var agg = loaded.Data.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(5, agg.Plays);
+        Assert.Equal(2, agg.TimesReplayExtraPlayed);
+    }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsV24ReplaySourceBreakdownFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v24-replay-source-breakdown-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Null(loaded.CompatibilityNote);
+        var agg = loaded.Data.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(6, agg.Plays);
+        Assert.Equal(3, agg.TimesReplayExtraPlayed);
+        Assert.Equal(1, agg.ReplayExtraPlayReasons["replay"].Count);
+        Assert.Equal("Replay", agg.ReplayExtraPlayReasons["replay"].DisplayName);
+        Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal("Burst", agg.ReplayExtraPlayReasons["power:POWER.BURST"].DisplayName);
+    }
+
+    [Fact]
     public void ResumableLoad_RejectsLegacyV1Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v1-pooled-run.json"));
@@ -557,5 +618,52 @@ public class SchemaLoadingTests
         Assert.NotNull(resumed);
         var relicAgg = resumed!.RelicAggregates["RELIC.CLOAK_CLASP"];
         Assert.Equal(21, relicAgg.AdditionalBlockGained);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsV21UnleashOstyHpFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v21-unleash-osty-hp-run.json"));
+
+        Assert.NotNull(resumed);
+        var agg = resumed!.Aggregates["CARD.UNLEASH#1"];
+        Assert.Equal(30, agg.TotalOstyHpAttackBonus);
+        Assert.Equal(3, agg.TimesOstyHpAttackBonusApplied);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsV22OstySummonBodyFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v22-osty-summon-body-run.json"));
+
+        Assert.NotNull(resumed);
+        var summonAgg = resumed!.Aggregates["CARD.SUMMON_FORTH#1"];
+        Assert.Equal(2, summonAgg.TimesOstySummoned);
+        Assert.Equal(18m, summonAgg.TotalOstyHpSummoned);
+        Assert.Equal(11m, resumed.MetaStats.TotalOstyDamageAbsorbed);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsV23ReplayExtraPlaysFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v23-replay-extra-plays-run.json"));
+
+        Assert.NotNull(resumed);
+        var agg = resumed!.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(5, agg.Plays);
+        Assert.Equal(2, agg.TimesReplayExtraPlayed);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsV24ReplaySourceBreakdownFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v24-replay-source-breakdown-run.json"));
+
+        Assert.NotNull(resumed);
+        var agg = resumed!.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(6, agg.Plays);
+        Assert.Equal(3, agg.TimesReplayExtraPlayed);
+        Assert.Equal(1, agg.ReplayExtraPlayReasons["replay"].Count);
+        Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
     }
 }

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -316,6 +316,7 @@ public class SchemaLoadingTests
         var summonAgg = loaded.Data.Aggregates["CARD.SUMMON_FORTH#1"];
         Assert.Equal(2, summonAgg.TimesOstySummoned);
         Assert.Equal(18m, summonAgg.TotalOstyHpSummoned);
+        Assert.Equal(18m, loaded.Data.MetaStats.TotalOstyHpSummoned);
         Assert.Equal(11m, loaded.Data.MetaStats.TotalOstyDamageAbsorbed);
     }
 
@@ -640,6 +641,7 @@ public class SchemaLoadingTests
         var summonAgg = resumed!.Aggregates["CARD.SUMMON_FORTH#1"];
         Assert.Equal(2, summonAgg.TimesOstySummoned);
         Assert.Equal(18m, summonAgg.TotalOstyHpSummoned);
+        Assert.Equal(18m, resumed.MetaStats.TotalOstyHpSummoned);
         Assert.Equal(11m, resumed.MetaStats.TotalOstyDamageAbsorbed);
     }
 

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -353,6 +353,26 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsV25ReplayOutcomesFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("v25-replay-outcomes-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        Assert.True(loaded.HasPerInstanceIdentity);
+        Assert.Null(loaded.CompatibilityNote);
+        var agg = loaded.Data.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(6, agg.Plays);
+        Assert.Equal(4, agg.TimesReplayExtraPlanned);
+        Assert.Equal(3, agg.TimesReplayExtraPlayed);
+        Assert.Equal(1, agg.TimesReplayAttackNoDamage);
+        Assert.Equal(1, agg.ReplayExtraPlayPlannedReasons["replay"].Count);
+        Assert.Equal(3, agg.ReplayExtraPlayPlannedReasons["power:POWER.BURST"].Count);
+        Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal(1, agg.ReplayAttackNoDamageReasons["power:POWER.BURST"].Count);
+    }
+
+    [Fact]
     public void ResumableLoad_RejectsLegacyV1Fixture()
     {
         var resumed = RunStorage.LoadResumable(FixturePath("v1-pooled-run.json"));
@@ -667,5 +687,21 @@ public class SchemaLoadingTests
         Assert.Equal(3, agg.TimesReplayExtraPlayed);
         Assert.Equal(1, agg.ReplayExtraPlayReasons["replay"].Count);
         Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsV25ReplayOutcomesFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("v25-replay-outcomes-run.json"));
+
+        Assert.NotNull(resumed);
+        var agg = resumed!.Aggregates["CARD.STRIKE_KIN#1"];
+        Assert.Equal(6, agg.Plays);
+        Assert.Equal(4, agg.TimesReplayExtraPlanned);
+        Assert.Equal(3, agg.TimesReplayExtraPlayed);
+        Assert.Equal(1, agg.TimesReplayAttackNoDamage);
+        Assert.Equal(3, agg.ReplayExtraPlayPlannedReasons["power:POWER.BURST"].Count);
+        Assert.Equal(2, agg.ReplayExtraPlayReasons["power:POWER.BURST"].Count);
+        Assert.Equal(1, agg.ReplayAttackNoDamageReasons["power:POWER.BURST"].Count);
     }
 }

--- a/Tests/SpireLens.Core.Tests/UnleashStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/UnleashStatsTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Models.Cards;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class UnleashStatsTests
+{
+    private static readonly MethodInfo AppendUnleashStatsMethod =
+        typeof(CardHoverShowPatch).GetMethod("AppendUnleashStats", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("AppendUnleashStats not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void CardAggregate_UnleashFields_DefaultToZero()
+    {
+        var agg = new CardAggregate();
+
+        Assert.Equal(0, agg.TotalOstyHpAttackBonus);
+        Assert.Equal(0, agg.TimesOstyHpAttackBonusApplied);
+    }
+
+    [Fact]
+    public void CardAggregate_UnleashFields_JsonRoundtrip_PreserveFields()
+    {
+        var run = new RunData();
+        run.Aggregates["CARD.UNLEASH#1"] = new CardAggregate
+        {
+            TotalOstyHpAttackBonus = 27,
+            TimesOstyHpAttackBonusApplied = 3,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("total_osty_hp_attack_bonus", json);
+        Assert.Contains("times_osty_hp_attack_bonus_applied", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var agg = restored!.Aggregates["CARD.UNLEASH#1"];
+        Assert.Equal(27, agg.TotalOstyHpAttackBonus);
+        Assert.Equal(3, agg.TimesOstyHpAttackBonusApplied);
+    }
+
+    [Fact]
+    public void Tooltip_UnleashStats_ShowTotalAndAverage()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate
+        {
+            TotalOstyHpAttackBonus = 25,
+            TimesOstyHpAttackBonusApplied = 2,
+        };
+
+        _ = AppendUnleashStatsMethod.Invoke(null, new object?[] { sb, new Unleash(), agg, false });
+        var body = sb.ToString();
+
+        Assert.Contains("Osty HP damage", body);
+        Assert.Contains("[b]25[/b]", body);
+        Assert.Contains("avg Osty HP damage", body);
+        Assert.Contains("[b]12.5[/b]", body);
+    }
+
+    [Fact]
+    public void Tooltip_UnleashStats_CompactShowsTotalOnly()
+    {
+        var sb = new StringBuilder();
+        var agg = new CardAggregate
+        {
+            TotalOstyHpAttackBonus = 18,
+            TimesOstyHpAttackBonusApplied = 1,
+        };
+
+        _ = AppendUnleashStatsMethod.Invoke(null, new object?[] { sb, new Unleash(), agg, true });
+        var body = sb.ToString();
+
+        Assert.Contains("Osty HP damage", body);
+        Assert.Contains("[b]18[/b]", body);
+        Assert.DoesNotContain("avg Osty HP damage", body);
+    }
+}

--- a/docs/adr/0003-meta-stats-on-related-surfaces.md
+++ b/docs/adr/0003-meta-stats-on-related-surfaces.md
@@ -1,0 +1,52 @@
+# 0003. Surface Meta-Stats On Related Cards Without Claiming Per-Card Ownership
+
+Date: 2026-06-28
+
+Status: Accepted
+
+## Context
+
+Some stats are useful when shown on a card, but are not facts caused by that
+specific physical card instance. SpireLens already has examples of this pattern:
+supplemental deck-view cards like Shiv and Sovereign Blade summarize all usage
+of that generated or synthetic card family rather than one stable deck copy.
+
+Necrobinder's Osty stats need the same distinction. A card that summons Osty can
+own the HP it actually added through `OstyCmd.Summon`. Later damage absorbed by
+Osty is different: it describes the overall Osty body across the run, not the
+last card that happened to summon or revive it.
+
+## Decision
+
+Use meta-stats for run-level mechanic facts that have a natural card UI home but
+are not per-card attribution facts.
+
+Rules:
+
+1. Store the value outside the per-card aggregate when the stat covers all
+   instances or all occurrences of a mechanic.
+2. Surface the value on related cards or supplemental cards when that is where a
+   player naturally looks for the mechanic.
+3. Keep card-owned contribution stats separate from meta-stats.
+4. Tooltip wording should avoid implying that the hovered card caused the meta
+   value.
+
+For Osty:
+
+- `TimesOstySummoned` and `TotalOstyHpSummoned` belong to the source card that
+  successfully called `OstyCmd.Summon`.
+- `TotalOstyDamageAbsorbed` belongs to run-level meta stats and may be surfaced
+  on Osty summon cards as a related mechanic stat.
+- Unleash's Osty HP damage bonus remains on Unleash because Unleash itself uses
+  Osty's current HP at play time.
+
+## Consequences
+
+This avoids inventing false ownership ledgers. A card can still show a rich
+story about its mechanic family, but the persisted shape and tooltip labels keep
+the difference between "this card caused this" and "this related mechanic did
+this across the run."
+
+Future stats should explicitly choose among per-card aggregate, effect/relic
+aggregate, supplemental pooled card aggregate, and run-level meta stat before
+adding fields.

--- a/docs/adr/0003-meta-stats-on-related-surfaces.md
+++ b/docs/adr/0003-meta-stats-on-related-surfaces.md
@@ -35,8 +35,12 @@ For Osty:
 
 - `TimesOstySummoned` and `TotalOstyHpSummoned` belong to the source card that
   successfully called `OstyCmd.Summon`.
-- `TotalOstyDamageAbsorbed` belongs to run-level meta stats and may be surfaced
-  on Osty summon cards as a related mechanic stat.
+- `RunMetaStats.TotalOstyHpSummoned` and `TotalOstyDamageAbsorbed` belong to
+  run-level meta stats and may be surfaced on Osty summon cards as related
+  mechanic stats.
+- Label card-owned summon HP as a local contribution, such as `Summon gained`.
+  Label run-level values with an `All Osty ...` prefix so the hovered card does
+  not appear to own them.
 - Unleash's Osty HP damage bonus remains on Unleash because Unleash itself uses
   Osty's current HP at play time.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ This combat-boundary rule is important:
 
 - [Core/RunData.cs](../Core/RunData.cs) defines the serialized run shape.
 - [Core/RunStorage.cs](../Core/RunStorage.cs) handles load/save and resumability rules.
-- Schema changes are additive when possible. The current schema is `v16`.
+- Schema changes are additive when possible. The current schema fixture is `v23`.
 
 Historical compatibility is pinned by:
 
@@ -70,6 +70,7 @@ Examples already implemented:
 - observed cards drawn from draw effects
 - blocked draw attempts, categorized blocked reasons, and effect-side downstream blocked counts
 - successful self-summons to hand for recurring cards like Make It So
+- Osty summon HP, current-body absorbed damage, and Unleash's Osty-HP payoff damage
 - effect applications credited back to the source card
 - Artifact-blocked debuffs
 - downstream poison damage and poison overkill
@@ -79,6 +80,8 @@ When attribution is not naturally one-card-to-one-outcome, the code prefers:
 
 - observed outcomes over listed intent
 - pooled summaries for combat-generated cards when they do not have stable deck identity
+- run-level meta-stats surfaced on related cards when the value describes all
+  instances or occurrences of a mechanic rather than one card's own effect
 - explicitly heuristic handling instead of pretending certainty
 
 ## UI Surface
@@ -112,7 +115,7 @@ That distinction matters for both tooltip wording and data integrity.
 Use this checklist:
 
 1. read [docs/sts2-runtime-primer.md](sts2-runtime-primer.md) for hook timing and attribution traps
-2. decide whether the stat should be per-instance, pooled, effect-oriented, or relic-oriented
+2. decide whether the stat should be per-instance, pooled, meta-stat, effect-oriented, or relic-oriented
 3. record the observed game outcome, not just the requested amount, if those can diverge
 4. update [RunData.cs](../Core/RunData.cs) if persistence changes
 5. update fixtures under [Fixtures/RunSchema](../Fixtures/RunSchema/README.md)

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -143,6 +143,22 @@ A card play has at least three useful phases for stats:
 
 `CardPlay.Resources.EnergySpent` and star spend are the source of truth for actual cost paid, not printed card cost. This captures cost reduction, free plays, X-cost behavior, and modifiers.
 
+`CardPlay.PlayIndex` and `CardPlay.PlayCount` describe a play series. Total
+card plays should still count every `CardPlayFinishedEntry`; replay extra plays
+are the subset where `PlayIndex > 0`. This preserves the normal "played N"
+stat while revealing how often Replay/Glam-like mechanics caused additional
+plays.
+
+Replay source attribution is a two-phase pattern. Capture play-count modifiers
+when the game calculates the series, then spend those pending sources only when
+an actual extra `CardPlayFinishedEntry` arrives. `Hook.ModifyCardPlayCount`
+exposes power/model contributors such as Burst, Echo Form, One Two Punch,
+Duplication, Signal Boost, and Tag Team. `Glam.EnchantPlayCount` covers the
+card-enchantment Replay path. If an extra play has no captured source, count it
+as plain `Replay`; this is the fallback for card-native/base replay counts and
+other effects that mutate the card's replay count before the hook can expose a
+source.
+
 For source context, `RunTracker` keeps notions like current player card play, recently completed player card play, pending draw source, pending effect source, and history counts. These are deliberately temporal and should be handled carefully. When adding a stat, ask:
 
 - Is the source card still current at the outcome hook?
@@ -175,6 +191,23 @@ Effective damage is the user-facing total damage because it is the HP actually r
 Known trap: an attack can play and produce no damage event, for example if the target is already dead/not fully removed or if no damage is actually received. Tooltip code treats a played attack with zero intended damage as a real but zero-damage case rather than inventing damage.
 
 Player self-damage is tracked as HP lost from playing a card and uses observed unblocked damage after reductions. That is the real cost, not the text value.
+
+## Osty Body Attribution
+
+Necrobinder has both investment cards that create or maintain Osty and payoff
+cards that spend the resulting board state. Track those as different signals.
+
+- Patch `OstyCmd.Summon`, not individual card text, for successful card-sourced
+  Osty summons. The command carries the source model and returns the
+  game-observed summon amount.
+- Attribute the summon amount to the source card. That is the card's own
+  contribution.
+- Attribute Osty HP lost through `Hook.AfterCurrentHpChanged` negative deltas
+  on any Osty creature into run-level meta stats. Do not assign all later Osty
+  damage absorbed to the card that happened to summon most recently.
+- Keep payoff tracking separate. For example, Unleash's Osty-current-HP attack
+  bonus belongs on Unleash, while HP summoned belongs on the summon card, and
+  total Osty damage absorbed is a meta stat surfaced on related summon cards.
 
 ## Block Attribution
 

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -159,6 +159,16 @@ as plain `Replay`; this is the fallback for card-native/base replay counts and
 other effects that mutate the card's replay count before the hook can expose a
 source.
 
+Replay shortfalls and no-outcome replays are not the same thing. `PlayCardAction`
+can cancel before `OnPlayWrapper` starts if `CanPlay` or `IsValidTarget` fails;
+that produces no `CardPlayStartedEntry`, no `CardPlayFinishedEntry`, and no
+resource spend. Once `OnPlayWrapper` starts, the game loops through the generated
+`playCount`, emits started/finished history for each iteration, and lets the
+card's own async `OnPlay` body run its commands. A later replay can therefore be
+a real finished card play while a command such as `AttackCommand` finds no valid
+target and produces no damage entries. Track planned replay extras, finished
+replay extras, and command-specific no-outcome buckets separately.
+
 For source context, `RunTracker` keeps notions like current player card play, recently completed player card play, pending draw source, pending effect source, and history counts. These are deliberately temporal and should be handled carefully. When adding a stat, ask:
 
 - Is the source card still current at the outcome hook?

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -201,13 +201,16 @@ cards that spend the resulting board state. Track those as different signals.
   Osty summons. The command carries the source model and returns the
   game-observed summon amount.
 - Attribute the summon amount to the source card. That is the card's own
-  contribution.
+  contribution. Tooltip label: `Summon gained`.
+- Also add successful summon amount to run-level Osty meta stats. Tooltip
+  label: `All Osty total summon`.
 - Attribute Osty HP lost through `Hook.AfterCurrentHpChanged` negative deltas
   on any Osty creature into run-level meta stats. Do not assign all later Osty
-  damage absorbed to the card that happened to summon most recently.
+  damage absorbed to the card that happened to summon most recently. Tooltip
+  label: `All Osty damage absorbed`.
 - Keep payoff tracking separate. For example, Unleash's Osty-current-HP attack
   bonus belongs on Unleash, while HP summoned belongs on the summon card, and
-  total Osty damage absorbed is a meta stat surfaced on related summon cards.
+  all-Osty totals are meta stats surfaced on related summon cards.
 
 ## Block Attribution
 


### PR DESCRIPTION
## Summary
- Track Unleash Osty HP attack bonus and aggregate Osty summon/body meta stats.
- Add replay source attribution, planned-vs-finished replay outcomes, and no-damage replay attack tracking.
- Surface build metadata and update attribution/runtime docs and schema fixtures.

## Validation
- dotnet test D:\repos\SpireLens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug
- Automated SpireLens core hot reload via local bridge; godot.log showed Core.Initialize complete.