### PR TITLE
Add .NET quality CI (run C# tests on PRs)

### DIFF
--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -30,9 +30,14 @@ jobs:
 
       # SkipModsDeploy: the Core build otherwise copies its output into the game
       # mods/ folder, which does not exist on the runner.
+      # RequiresLiveGame tests render tooltips that resolve real game icon
+      # assets, which the checked-in sts2.dll stub does not carry — they pass
+      # only against a live game install (the laptop verification phase), so
+      # they are excluded from the headless gate. See #257 for decoupling them.
       - name: dotnet test (against checked-in reference stubs)
         run: >
           dotnet test Tests/SpireLens.Core.Tests/SpireLens.Core.Tests.csproj
           -c Release
           -p:SkipModsDeploy=true
+          --filter "Category!=RequiresLiveGame"
           --logger "console;verbosity=normal"

--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -1,0 +1,48 @@
+name: .NET Quality
+
+# Runs the C# unit-test suite (Tests/SpireLens.Core.Tests) on every PR touching
+# the mod code, so the project's deterministic quality gate no longer depends on
+# the gaming laptop being awake. Builds headless against the checked-in
+# lib/{0Harmony,GodotSharp,sts2}.dll reference stubs — on a runner with no game
+# install, Sts2DataDir does not exist so the csproj falls back to lib/.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Core/**'
+      - 'Loader/**'
+      - 'Api/**'
+      - 'Config/**'
+      - 'Tests/**'
+      - 'lib/**'
+      - '**/*.csproj'
+      - '**/*.props'
+      - '.github/workflows/dotnet-quality.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dotnet:
+    name: build / test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      # SkipModsDeploy: the Core build otherwise copies its output into the game
+      # mods/ folder, which does not exist on the runner.
+      - name: dotnet test (against checked-in reference stubs)
+        run: >
+          dotnet test Tests/SpireLens.Core.Tests/SpireLens.Core.Tests.csproj
+          -c Release
+          -p:SkipModsDeploy=true
+          --logger "console;verbosity=normal"

--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -9,16 +9,6 @@ name: .NET Quality
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'Core/**'
-      - 'Loader/**'
-      - 'Api/**'
-      - 'Config/**'
-      - 'Tests/**'
-      - 'lib/**'
-      - '**/*.csproj'
-      - '**/*.props'
-      - '.github/workflows/dotnet-quality.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ When inspecting `mods/`, treat any non-(SpireLens|BaseLib|SpireLensMcp) entry as
   - [Core/CoreMain.cs](D:/repos/SpireLens/Core/CoreMain.cs:8) owns Harmony patch install/uninstall and re-entry on each reload.
 - Persistence is combat-boundary based.
   - [Core/RunTracker.cs](D:/repos/SpireLens/Core/RunTracker.cs:18) buffers live combat data in `_pendingCombat`.
-  - Nothing is promoted to the permanent run file until combat ends.
+  - Nothing is promoted to the permanent run file until combat ends — with one deliberate exception: a LOST run's end also promotes, because on a loss `RunManager.OnEnded` fires synchronously from the killing action and the fatal combat's `CombatEnded` only fires afterwards, too late for the buffer. Abandon-mid-combat still discards the buffer.
+  - The game re-fires `RunStarted` with the same `_startTime` on every main-menu Continue; `OnRunStarted` resumes/adopts the existing run record (matched by `game_start_time`) instead of minting a new one.
   - Reload between combats / between floors is supported and expected.
   - Mid-combat restore is intentionally out of scope.
 - The persisted shape evolves additively without an explicit version number.

--- a/Core/CoreMain.cs
+++ b/Core/CoreMain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using HarmonyLib;
 using SpireLens.Core.Patches;
 using MegaCrit.Sts2.Core.Logging;
@@ -82,7 +83,30 @@ public static class CoreMain
         Logger.Info($"Core.Initialize starting (harmony_id={_harmonyId}, debug={DebugLogging})");
 
         _harmony = new Harmony(_harmonyId);
-        _harmony.PatchAll();
+
+        // Install each patch class in its own try/catch instead of a bare
+        // PatchAll. A single failing patch — e.g. one whose target game method
+        // a Slay the Spire 2 update renamed or changed — would otherwise abort
+        // PatchAll and silently take down EVERY other patch (all tracking).
+        // Per-class isolation degrades gracefully: the broken hook is skipped
+        // and logged, the rest keep working. Classes whose TargetMethod(s)
+        // resolve to nothing are simply no-ops.
+        int patchedClasses = 0, failedClasses = 0;
+        foreach (var type in AccessTools.GetTypesFromAssembly(Assembly.GetExecutingAssembly()))
+        {
+            try
+            {
+                var processor = _harmony.CreateClassProcessor(type);
+                var methods = processor.Patch();
+                if (methods != null && methods.Count > 0) patchedClasses++;
+            }
+            catch (Exception e)
+            {
+                failedClasses++;
+                Logger.Error($"Patch install failed for {type.FullName}: {e}");
+            }
+        }
+        Logger.Info($"Patch install: {patchedClasses} classes patched, {failedClasses} failed/skipped.");
 
         // Diagnostic: enumerate every Harmony-patched method so we can
         // confirm from the log whether a given hook (especially

--- a/Core/Patches/CloakClaspBeforeTurnEndPatch.cs
+++ b/Core/Patches/CloakClaspBeforeTurnEndPatch.cs
@@ -41,10 +41,20 @@ public static class CloakClaspBeforeTurnEndPatch
 /// <summary>
 /// Clears the Cloak Clasp attribution window after the player's end-of-turn
 /// hook sequence. Mirrors the later-boundary cleanup pattern used by Orichalcum.
+///
+/// Bound via a runtime <c>TargetMethods()</c> lookup rather than
+/// <c>nameof(Hook.AfterTurnEnd)</c> so a Slay the Spire 2 update that renames or
+/// removes the hook skips this patch instead of breaking the build.
 /// </summary>
-[HarmonyPatch(typeof(Hook), nameof(Hook.AfterTurnEnd))]
+[HarmonyPatch]
 public static class HookAfterTurnEndCloakClaspCleanupPatch
 {
+    private static System.Collections.Generic.IEnumerable<MethodBase> TargetMethods()
+    {
+        var m = AccessTools.Method(typeof(Hook), "AfterTurnEnd");
+        if (m != null) yield return m;
+    }
+
     [HarmonyPrefix]
     public static void Prefix(CombatSide side)
     {

--- a/Core/Patches/HookAfterDamageGivenPatch.cs
+++ b/Core/Patches/HookAfterDamageGivenPatch.cs
@@ -1,0 +1,45 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Captures damage the game suppresses from combat history on combat-ending
+/// killing blows.
+///
+/// <c>CreatureCmd.Damage</c> applies HP loss and only then emits the
+/// combat-history entry behind an <c>IsInProgress &amp;&amp; !IsEnding</c>
+/// gate — the hit that kills the last living enemy flips <c>IsEnding</c> and
+/// suppresses its own <c>DamageReceivedEntry</c>, so the master
+/// <see cref="CombatHistoryAddPatch"/> hook never sees it.
+///
+/// <c>Hook.AfterDamageGiven</c> still fires for that hit — the game dispatches
+/// it directly, documented as "it fires from the same damage event that ends
+/// combat (the killing hit), so it must still resolve for that hit" — carrying
+/// the same result/dealer/cardSource the entry would have carried, and it runs
+/// BEFORE <c>Kill()</c> triggers CombatEnded, so the recorded damage still
+/// lands in the pending combat and is promoted normally.
+/// </summary>
+[HarmonyPatch(typeof(Hook), nameof(Hook.AfterDamageGiven))]
+public static class HookAfterDamageGivenPatch
+{
+    // Prefix (not postfix): the hook is async, and we only need its arguments;
+    // a prefix runs synchronously at dispatch time, before any listener model
+    // can react to the hit.
+    [HarmonyPrefix]
+    public static void Prefix(ICombatState combatState, Creature? dealer, DamageResult results, CardModel? cardSource)
+    {
+        try
+        {
+            RunTracker.RecordCombatEndingSuppressedDamage(combatState, dealer, results, cardSource);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"HookAfterDamageGivenPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/OrichalcumBeforeTurnEndPatch.cs
+++ b/Core/Patches/OrichalcumBeforeTurnEndPatch.cs
@@ -75,10 +75,22 @@ public static class OrichalcumBeforeTurnEndPatch
 /// end-of-turn hook sequence. Orichalcum's async hook can gain block after
 /// the relic method has returned its task, so cleanup cannot live in the
 /// relic postfix itself.
+///
+/// Bound via a runtime <c>TargetMethods()</c> lookup rather than
+/// <c>nameof(Hook.AfterTurnEnd)</c>: a Slay the Spire 2 update can rename or
+/// remove the hook, and a compile-time reference would break the whole build
+/// (and, under bare PatchAll, take down every other patch). When the method is
+/// absent the class simply yields nothing and Harmony skips it.
 /// </summary>
-[HarmonyPatch(typeof(Hook), nameof(Hook.AfterTurnEnd))]
+[HarmonyPatch]
 public static class HookAfterTurnEndOrichalcumCleanupPatch
 {
+    private static System.Collections.Generic.IEnumerable<MethodBase> TargetMethods()
+    {
+        var m = AccessTools.Method(typeof(Hook), "AfterTurnEnd");
+        if (m != null) yield return m;
+    }
+
     [HarmonyPrefix]
     public static void Prefix(CombatSide side)
     {

--- a/Core/Patches/RunHistoryUtilitiesCreateEntryPatch.cs
+++ b/Core/Patches/RunHistoryUtilitiesCreateEntryPatch.cs
@@ -1,3 +1,4 @@
+using System;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Runs;
 
@@ -31,11 +32,22 @@ public static class RunHistoryUtilitiesCreateEntryPatch
     [HarmonyPostfix]
     public static void Postfix(bool victory, bool isAbandoned)
     {
-        string outcome;
-        if (isAbandoned) outcome = "abandoned";
-        else if (victory) outcome = "win";
-        else outcome = "loss";
+        // Guard the terminal run-end funnel: an unhandled throw here would
+        // propagate into RunManager.OnEnded / NMainMenu.AbandonRun and could
+        // skip the game's own run cleanup. Always-on Error log (not LogDebug)
+        // so a broken run-end is visible without a debug flag.
+        try
+        {
+            string outcome;
+            if (isAbandoned) outcome = "abandoned";
+            else if (victory) outcome = "win";
+            else outcome = "loss";
 
-        RunTracker.OnRunEnded(outcome);
+            RunTracker.OnRunEnded(outcome);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RunHistoryUtilitiesCreateEntryPatch.Postfix failed: {e}");
+        }
     }
 }

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ public static class RunStorage
     {
         public long? GameStartTime { get; set; }
         public string RunId { get; set; } = "";
+        public string? Outcome { get; set; }
     }
 
     private static readonly JsonSerializerOptions Options = new()
@@ -194,7 +196,18 @@ public static class RunStorage
     /// Returns null if no match or if the directory doesn't exist yet.
     /// Malformed / unreadable files are skipped, not fatal.
     /// </summary>
-    public static RunData? FindByGameStartTime(long gameStartTime, out bool foundUnsupportedMatch)
+    // How many of the newest run files FindByGameStartTime probes before
+    // giving up. The in-progress run it looks for is by construction among
+    // the most recently written files — only one run is ever active and its
+    // file is rewritten on every save — so a bounded probe keeps the miss
+    // case (fresh run start, no match anywhere) from reading and JSON-parsing
+    // months of accumulated run files on the main thread.
+    private const int MaxFindHeaderProbes = 25;
+
+    public static RunData? FindByGameStartTime(
+        long gameStartTime,
+        out bool foundUnsupportedMatch,
+        bool requireInProgress = false)
     {
         foundUnsupportedMatch = false;
         try
@@ -202,16 +215,35 @@ public static class RunStorage
             if (!Directory.Exists(RunsDir)) return null;
 
             // Sort newest-first so if multiple files match (shouldn't happen
-            // but defensive), we pick the most recent.
-            var files = Directory.GetFiles(RunsDir, "*.json");
-            Array.Sort(files, (a, b) => File.GetLastWriteTimeUtc(b).CompareTo(File.GetLastWriteTimeUtc(a)));
+            // but defensive), we pick the most recent. Sort keys are
+            // precomputed — GetLastWriteTimeUtc inside a comparator would
+            // stat each file O(log N) times.
+            var byNewest = Directory.GetFiles(RunsDir, "*.json")
+                .Select(p => (Path: p, Mtime: File.GetLastWriteTimeUtc(p)))
+                .OrderByDescending(f => f.Mtime)
+                .Select(f => f.Path);
 
-            foreach (var path in files)
+            int probed = 0;
+            foreach (var path in byNewest)
             {
+                if (probed++ >= MaxFindHeaderProbes)
+                {
+                    CoreMain.LogDebug(
+                        $"FindByGameStartTime: no match for {gameStartTime} in the {MaxFindHeaderProbes} newest run files; stopping scan");
+                    break;
+                }
                 try
                 {
                     var header = ReadHeader(path);
                     if (header?.GameStartTime != gameStartTime) continue;
+
+                    // Filter at scan level, not post-hoc: a finished record
+                    // (e.g. a hot reload on the game-over screen) must not
+                    // shadow an older in-progress one for the same run.
+                    // Null outcome (very old files) is treated as unknown
+                    // and allowed through; LoadForResume gates the shape.
+                    if (requireInProgress && header.Outcome != null
+                        && header.Outcome != "in_progress") continue;
 
                     var data = LoadForResume(path);
                     if (data != null) return data;

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -36,26 +36,56 @@ public static class RunStorage
     /// <summary>Resolved absolute path to runs/ directory. Created on first save.</summary>
     public static string RunsDir => ProjectSettings.GlobalizePath("user://SpireLens/runs/");
 
+    // Single-writer chain: every save is a continuation of the previous one,
+    // so writes to the same run file apply in the exact order SaveAsync was
+    // called (which, since callers hold RunTracker's lock and serialize the
+    // snapshot on the calling thread, equals logical order). This replaces the
+    // old fire-and-forget Task.Run, where two rapid saves of the same file
+    // (OnCombatEnded then OnRunEnded on a won/lost run) raced: FileShare
+    // collisions dropped a save, or pool scheduling let a stale in_progress
+    // snapshot overwrite the final outcome=win/loss one.
+    private static readonly object _writeChainGate = new();
+    private static Task _writeChain = Task.CompletedTask;
+
     /// <summary>Serialize and write the run data to disk without blocking the caller.</summary>
     public static void SaveAsync(RunData data)
     {
-        // Snapshot-serialize on the calling thread so we don't race with further mutations.
-        // (RunTracker holds the lock when it calls this; safe here.)
+        // Snapshot-serialize AND resolve paths on the calling thread (the game
+        // thread, under RunTracker's lock): ProjectSettings.GlobalizePath and
+        // the RunData mutations are not safe to touch from a pool thread,
+        // especially during engine teardown.
         string json = JsonSerializer.Serialize(data, Options);
-        string path = Path.Combine(RunsDir, data.RunId + ".json");
+        string dir = RunsDir;
+        string path = Path.Combine(dir, data.RunId + ".json");
 
-        Task.Run(() =>
+        lock (_writeChainGate)
         {
-            try
-            {
-                Directory.CreateDirectory(RunsDir);
-                File.WriteAllText(path, json);
-            }
-            catch (Exception e)
-            {
-                CoreMain.Logger.Error($"RunStorage.SaveAsync failed: {e}");
-            }
-        });
+            _writeChain = _writeChain.ContinueWith(
+                _ => WriteFileAtomic(dir, path, json),
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+        }
+    }
+
+    // Atomic write: full content to a temp file, then replace. A crash mid-write
+    // leaves the old file intact (or an orphan .tmp that the "*.json" scans
+    // ignore) instead of a truncated .json that LoadKnownSchemaFile silently
+    // skips — which would lose the whole run. Swallows its own exceptions so
+    // one failed write can't fault the shared chain and stall every later save.
+    private static void WriteFileAtomic(string dir, string path, string json)
+    {
+        try
+        {
+            Directory.CreateDirectory(dir);
+            string tmp = path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RunStorage.SaveAsync failed: {e}");
+        }
     }
 
     private static RunFileHeader? ReadHeader(string path)

--- a/Core/RunStorage.cs
+++ b/Core/RunStorage.cs
@@ -26,11 +26,23 @@ public static class RunStorage
         public string? Outcome { get; set; }
     }
 
-    private static readonly JsonSerializerOptions Options = new()
+    /// <summary>
+    /// The single canonical serializer options for run files. Internal so tests
+    /// consume the exact production configuration instead of hand-copied
+    /// duplicates (which drift — the same parallel-list hazard as merge lists),
+    /// and so the public API layer can serialize in the on-disk shape.
+    ///
+    /// <c>IncludeFields</c> is required: the game's <c>SerializableCard</c>
+    /// (persisted as a removed-card snapshot) stores its data in public FIELDS,
+    /// not properties, so without this a removed card's props/enchantment
+    /// serialize as <c>{}</c> and rehydrate empty — silent data loss.
+    /// </summary>
+    internal static readonly JsonSerializerOptions Options = new()
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        IncludeFields = true,
     };
 
     /// <summary>Resolved absolute path to runs/ directory. Created on first save.</summary>

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -4980,7 +4980,14 @@ public static class RunTracker
                 || ownership.Count == 0)
                 return false;
 
-            decimal totalAttempted = entry.Result.BlockedDamage + entry.Result.UnblockedDamage;
+            // Route through the one canonical damage convention: intended =
+            // blocked + unblocked + overkill (the true tick size), effective =
+            // unblocked (HP actually lost — overkill is disjoint). Omitting
+            // overkill previously made the normalize step scale ownership down
+            // on kills and the unarmed-fallback amount-match drop lethal ticks.
+            var tickTotals = ComputeEnemyDamageTotals(
+                entry.Result.BlockedDamage, entry.Result.UnblockedDamage, entry.Result.OverkillDamage);
+            decimal totalAttempted = tickTotals.IntendedDamage;
             if (totalAttempted <= 0m) return false;
 
             bool armedTick = false;
@@ -5009,7 +5016,10 @@ public static class RunTracker
                     share.Amount *= normalize;
             }
 
-            decimal effectiveDamage = Math.Max(0m, entry.Result.UnblockedDamage - entry.Result.OverkillDamage);
+            // Effective = HP actually lost (tickTotals.EffectiveDamage =
+            // UnblockedDamage). The old `unblocked - overkill` double-counted
+            // overkill and zeroed every killing tick's effective damage.
+            decimal effectiveDamage = Math.Max(0m, (decimal)tickTotals.EffectiveDamage);
             decimal overkillDamage = Math.Max(0m, entry.Result.OverkillDamage);
 
             foreach (var share in ownership.Values.ToList())
@@ -5139,6 +5149,13 @@ public static class RunTracker
 
     private static void RecordEnemyDamage(DamageReceivedEntry entry)
     {
+        // Only damage dealt TO the player counts as enemy damage. Without this
+        // guard, a summon body (Osty is a Creature with Monster set but
+        // IsPlayer=false) absorbing an enemy hit via DieForYou is counted as
+        // damage-to-player and doubles DamageInstances per redirect, and Osty's
+        // OWN attacks on enemies mint a phantom MONSTER.OSTY enemy aggregate.
+        // Matches RecordPlayerBlockedDamage and the primer's enemy-damage spec.
+        if (!entry.Receiver.IsPlayer) return;
         if (entry.Dealer == null || entry.Dealer.IsPlayer || entry.Dealer.Monster == null) return;
 
         int blocked = Math.Max(0, entry.Result.BlockedDamage);
@@ -5201,9 +5218,16 @@ public static class RunTracker
             }
 
             int actualRemaining = Math.Max(0, creature.Block);
+            // Unarmed fallback is 0, not the whole ledger: the game fires
+            // AfterBlockCleared even when a retain effect (Barricade/Blur/Sturdy
+            // Clamp) PREVENTED the clear, so wasting all tracked block would
+            // mislabel retained block as wasted and strip its card attribution.
+            // Reconcile below wastes exactly max(0, tracked - actual), which is
+            // correct whether block truly cleared (actual→0 wastes all) or was
+            // retained (actual unchanged wastes nothing).
             int removed = _pendingPlayerBlockClearArmed
                 ? Math.Max(0, _pendingPlayerBlockClearAmount - actualRemaining)
-                : TotalTrackedPlayerBlockLocked();
+                : 0;
 
             AttributeUnusedBlockLocked(removed);
             ReconcilePlayerBlockLedgerLocked(creature);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1337,7 +1337,7 @@ public static class RunTracker
     /// the mid-combat tooltip overlay so the two can't drift. Add new relic
     /// stat fields HERE, once.
     /// </summary>
-    private static void MergeRelicAggregateInto(RelicAggregate target, RelicAggregate source)
+    internal static void MergeRelicAggregateInto(RelicAggregate target, RelicAggregate source)
     {
         target.Activations += source.Activations;
         target.EnemiesAffected += source.EnemiesAffected;
@@ -3123,35 +3123,10 @@ public static class RunTracker
 
             if (_currentRun != null && _currentRun.RelicAggregates.TryGetValue(relicId, out var committed))
             {
-                result = new RelicAggregate
-                {
-                    Activations = committed.Activations,
-                    EnemiesAffected = committed.EnemiesAffected,
-                    VulnerableApplied = committed.VulnerableApplied,
-                    WeakApplied = committed.WeakApplied,
-                    AdditionalCardsDrawn = committed.AdditionalCardsDrawn,
-                    AdditionalBlockGained = committed.AdditionalBlockGained,
-                    BlockedTriggers = committed.BlockedTriggers,
-                    StrengthAdded = committed.StrengthAdded,
-                    PlatingAdded = committed.PlatingAdded,
-                    CardsUpgraded = committed.CardsUpgraded,
-                    BoneFluteTriggers = committed.BoneFluteTriggers,
-                    TotalOstyHpSummoned = committed.TotalOstyHpSummoned,
-                    TotalHealingAttempted = committed.TotalHealingAttempted,
-                    TotalHealingRestored = committed.TotalHealingRestored,
-                    TotalHealingLost = committed.TotalHealingLost,
-                    DoomDeathTriggers = committed.DoomDeathTriggers,
-                    DoomKills = committed.DoomKills,
-                    EnergyGenerated = committed.EnergyGenerated,
-                    PotionsGained = committed.PotionsGained,
-                    CommonPotionsGained = committed.CommonPotionsGained,
-                    UncommonPotionsGained = committed.UncommonPotionsGained,
-                    RarePotionsGained = committed.RarePotionsGained,
-                    PotionsSkipped = committed.PotionsSkipped,
-                    CardRewardsAffected = committed.CardRewardsAffected,
-                    CardRewardCategories = CloneCardRewardCategories(committed.CardRewardCategories),
-                };
-                MergeHealingLostReasonsInto(result, committed);
+                // new + Merge instead of a parallel 26-field clone — one
+                // RelicAggregate field list lives in MergeRelicAggregateInto.
+                result = new RelicAggregate();
+                MergeRelicAggregateInto(result, committed);
             }
 
             if (_pendingCombat != null && _pendingCombat.RelicAggregates.TryGetValue(relicId, out var pending))
@@ -3245,28 +3220,16 @@ public static class RunTracker
         cardAgg.Count++;
     }
 
-    private static EnemyAggregate CloneEnemyAggregate(EnemyAggregate source)
+    // new + Merge (target starts empty, so Merge copies identity and
+    // accumulates every stat) — one EnemyAggregate field list to maintain.
+    internal static EnemyAggregate CloneEnemyAggregate(EnemyAggregate source)
     {
-        var clone = new EnemyAggregate
-        {
-            EnemyId = source.EnemyId,
-            DisplayName = source.DisplayName,
-            DamageInstances = source.DamageInstances,
-            DamageAttempted = source.DamageAttempted,
-            DamageDealt = source.DamageDealt,
-            DamageBlocked = source.DamageBlocked,
-            StatusCardsAdded = source.StatusCardsAdded,
-            StatusCardsAddedToHand = source.StatusCardsAddedToHand,
-            StatusCardsAddedToDraw = source.StatusCardsAddedToDraw,
-            StatusCardsAddedToDiscard = source.StatusCardsAddedToDiscard,
-            StatusCardsAddedToDeck = source.StatusCardsAddedToDeck,
-        };
-
-        MergeEnemyStatusCardBreakdownInto(clone, source);
+        var clone = new EnemyAggregate();
+        MergeEnemyAggregateInto(clone, source);
         return clone;
     }
 
-    private static void MergeEnemyAggregateInto(EnemyAggregate target, EnemyAggregate source)
+    internal static void MergeEnemyAggregateInto(EnemyAggregate target, EnemyAggregate source)
     {
         if (string.IsNullOrWhiteSpace(target.EnemyId))
             target.EnemyId = source.EnemyId;
@@ -3418,14 +3381,6 @@ public static class RunTracker
                 reason.DisplayName,
                 reason.Amount);
         }
-    }
-
-    private static Dictionary<string, CardRewardCategoryAggregate> CloneCardRewardCategories(
-        Dictionary<string, CardRewardCategoryAggregate> source)
-    {
-        var result = new Dictionary<string, CardRewardCategoryAggregate>();
-        MergeCardRewardCategories(result, source);
-        return result;
     }
 
     private static void MergeCardRewardCategories(
@@ -5629,58 +5584,25 @@ public static class RunTracker
         }
     }
 
-    private static CardAggregate CloneAggregate(CardAggregate source)
+    // Clone = copy the per-instance lineage/identity fields (which a merge
+    // intentionally does NOT accumulate), then delegate every accumulating
+    // field to MergeAggregateInto so there is ONE field list to maintain.
+    // RemovedSnapshot is shared by reference (an immutable removal snapshot).
+    internal static CardAggregate CloneAggregate(CardAggregate source)
     {
         var clone = new CardAggregate
         {
-            CombatsInDeck = source.CombatsInDeck,
-            Plays = source.Plays,
-            TotalIntended = source.TotalIntended,
-            TotalBlocked = source.TotalBlocked,
-            TotalOverkill = source.TotalOverkill,
-            TotalEffective = source.TotalEffective,
-            Kills = source.Kills,
-            TotalEnergySpent = source.TotalEnergySpent,
-            TotalEnergyGenerated = source.TotalEnergyGenerated,
-            TotalStarsSpent = source.TotalStarsSpent,
-            TotalStarsGenerated = source.TotalStarsGenerated,
-            TotalForgeGenerated = source.TotalForgeGenerated,
-            TotalBlockGained = source.TotalBlockGained,
-            TotalBlockEffective = source.TotalBlockEffective,
-            TotalBlockWasted = source.TotalBlockWasted,
-            TimesDrawn = source.TimesDrawn,
-            TimesDiscarded = source.TimesDiscarded,
-            TimesPlacedOnTopFromHand = source.TimesPlacedOnTopFromHand,
-            TimesPlacedOnTopFromDiscard = source.TimesPlacedOnTopFromDiscard,
-            TimesExhaustedOtherCards = source.TimesExhaustedOtherCards,
-            TimesExhausted = source.TimesExhausted,
-            TotalHpLost = source.TotalHpLost,
-            TimesCardsDrawn = source.TimesCardsDrawn,
-            TimesCardsDrawAttempted = source.TimesCardsDrawAttempted,
-            TimesCardsDrawBlocked = source.TimesCardsDrawBlocked,
-            TimesSummonedToHand = source.TimesSummonedToHand,
-            TotalOstyHpAttackBonus = source.TotalOstyHpAttackBonus,
-            TimesOstyHpAttackBonusApplied = source.TimesOstyHpAttackBonusApplied,
-            TimesOstySummoned = source.TimesOstySummoned,
-            TotalOstyHpSummoned = source.TotalOstyHpSummoned,
-            TimesReplayExtraPlanned = source.TimesReplayExtraPlanned,
-            TimesReplayExtraPlayed = source.TimesReplayExtraPlayed,
-            TimesReplayAttackNoDamage = source.TimesReplayAttackNoDamage,
             FloorAdded = source.FloorAdded,
             InitialUpgradeLevel = source.InitialUpgradeLevel,
             Removed = source.Removed,
             RemovedAtFloor = source.RemovedAtFloor,
             RemovedSnapshot = source.RemovedSnapshot,
         };
-        MergeBlockedDrawReasonsInto(clone.BlockedDrawReasons, source.BlockedDrawReasons);
-        MergeReplayExtraPlayReasonsInto(clone.ReplayExtraPlayPlannedReasons, source.ReplayExtraPlayPlannedReasons);
-        MergeReplayExtraPlayReasonsInto(clone.ReplayExtraPlayReasons, source.ReplayExtraPlayReasons);
-        MergeReplayExtraPlayReasonsInto(clone.ReplayAttackNoDamageReasons, source.ReplayAttackNoDamageReasons);
-        MergeAppliedEffectsInto(clone.AppliedEffects, source.AppliedEffects);
+        MergeAggregateInto(clone, source);
         return clone;
     }
 
-    private static void MergeAggregateInto(CardAggregate target, CardAggregate source)
+    internal static void MergeAggregateInto(CardAggregate target, CardAggregate source)
     {
         target.CombatsInDeck += source.CombatsInDeck;
         target.Plays += source.Plays;

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -106,6 +106,21 @@ public static class RunTracker
     private static readonly Dictionary<CardModel, bool> _pendingReplayExtraPlaySeriesStarted = new(ReferenceEqualityComparer.Instance);
     private static readonly Dictionary<CardPlay, PendingReplayAttackOutcome> _pendingReplayAttackOutcomes = new(ReferenceEqualityComparer.Instance);
 
+    // DamageResult objects already seen through a real DamageReceivedEntry
+    // this combat. Lets the combat-ending capture (HookAfterDamageGivenPatch →
+    // RecordCombatEndingSuppressedDamage) tell a hit whose history entry the
+    // game suppressed apart from one it recorded normally. Reference-keyed —
+    // the game allocates a distinct DamageResult per hit.
+    private static readonly HashSet<DamageResult> _observedDamageResults = new(ReferenceEqualityComparer.Instance);
+
+    // Saved instance numbers still waiting for the deck to (re)populate after
+    // a resume/adoption. Continue-loads don't guarantee whether RunStarted
+    // fires before or after CardPile.AddInternal repopulates the deck; numbers
+    // the adoption deck walk couldn't bind yet are claimed here in arrival
+    // (deck) order by CardEnterDeckPatch instead of minting fresh numbers
+    // that would orphan the saved stats.
+    private static readonly Dictionary<string, Queue<int>> _pendingRankRestores = new();
+
     /// <summary>
     /// Wire up game event subscriptions. Called by <see cref="CoreMain.Initialize"/>
     /// on first load and each hot-reload. Safe to call before CombatManager/RunManager
@@ -348,6 +363,21 @@ public static class RunTracker
         return false;
     }
 
+    /// <summary>
+    /// Clear the synthetic deck-view card caches and availability flags.
+    /// Single home for the per-run deck-view reset — used by fresh run start,
+    /// run end, and run adoption (which recomputes availability right after
+    /// via the Refresh*AvailabilityLocked pair).
+    /// </summary>
+    private static void ResetDeckViewCachesLocked()
+    {
+        _shivAvailableThisRun = false;
+        _shivDeckViewCard = null;
+        _sovereignBladeAvailableThisRun = false;
+        _sovereignBladeDeckViewCard = null;
+        _sovereignBladeDefinitionIdThisRun = null;
+    }
+
     private static void RefreshShivAvailabilityLocked()
     {
         _shivAvailableThisRun = HasShivDataLocked();
@@ -492,6 +522,22 @@ public static class RunTracker
         if (_instanceNumbers.TryGetValue(key, out var existing)) return existing;
 
         var defId = key.Id.ToString();
+
+        // A resume/adoption may run before the game repopulates the deck.
+        // Saved numbers the adoption deck walk couldn't bind wait in
+        // _pendingRankRestores and are claimed here in arrival (deck) order,
+        // so the reload boundary doesn't mint fresh numbers that would
+        // orphan the saved stats. Cleared at combat setup, so combat-time
+        // ephemeral cards can't steal a waiting number.
+        if (_pendingRankRestores.TryGetValue(defId, out var waiting) && waiting.Count > 0)
+        {
+            var restored = waiting.Dequeue();
+            if (waiting.Count == 0) _pendingRankRestores.Remove(defId);
+            _instanceNumbers[key] = restored;
+            StampArrival(key, restored);
+            return restored;
+        }
+
         _defCounters.TryGetValue(defId, out var n);
         n++;
         _defCounters[defId] = n;
@@ -604,23 +650,43 @@ public static class RunTracker
         try
         {
             var player = RunManager.Instance.State?.Players.FirstOrDefault();
-            if (player?.Deck == null) return result;
-            foreach (var card in player.Deck.Cards)
+            if (player?.Deck != null)
             {
-                var key = Canonical(card);
-                if (!_instanceNumbers.TryGetValue(key, out var n)) continue;
-                var defId = key.Id.ToString();
-                if (!result.TryGetValue(defId, out var list))
+                foreach (var card in player.Deck.Cards)
                 {
-                    list = new List<int>();
-                    result[defId] = list;
+                    var key = Canonical(card);
+                    if (!_instanceNumbers.TryGetValue(key, out var n)) continue;
+                    var defId = key.Id.ToString();
+                    if (!result.TryGetValue(defId, out var list))
+                    {
+                        list = new List<int>();
+                        result[defId] = list;
+                    }
+                    list.Add(n);
                 }
-                list.Add(n);
             }
         }
         catch (Exception e)
         {
             CoreMain.LogDebug($"CaptureInstanceNumbersByDeckRank failed: {e.Message}");
+        }
+
+        // Numbers still queued for late deck population are part of the
+        // mapping too: deck arrivals claim the queue front in deck order, so
+        // the remaining queue is exactly the deck-rank suffix after whatever
+        // the walk above saw. Without this, a save during adoption (repair or
+        // ghost-prune) on a not-yet-repopulated deck would overwrite the
+        // on-disk snapshot with just the visible prefix — and a crash before
+        // the next save would permanently orphan every queued card's stats.
+        foreach (var kv in _pendingRankRestores)
+        {
+            if (kv.Value.Count == 0) continue;
+            if (!result.TryGetValue(kv.Key, out var list))
+            {
+                list = new List<int>();
+                result[kv.Key] = list;
+            }
+            list.AddRange(kv.Value);
         }
         return result;
     }
@@ -634,8 +700,22 @@ public static class RunTracker
     private static void SaveCurrentRun()
     {
         if (_currentRun == null) return;
-        _currentRun.InstanceNumbersByDef = CaptureInstanceNumbersByDeckRank();
-        _currentRun.DefCounters = new Dictionary<string, int>(_defCounters);
+
+        // Never capture identity from a deck that belongs to a DIFFERENT game
+        // run. During a new-run embark or continue-load, CardEnterDeckPatch
+        // can repopulate the deck before RunStarted re-points _currentRun —
+        // recapturing here would overwrite the old run's last good snapshot
+        // and counters with the new run's deck state. Freeze identity in that
+        // window; the aggregates themselves still save.
+        long liveGameStartTime = 0;
+        try { liveGameStartTime = RunManager.Instance._startTime; }
+        catch { /* no live run state — keep the frozen snapshot */ }
+        if (_currentRun.GameStartTime == null || _currentRun.GameStartTime == liveGameStartTime)
+        {
+            _currentRun.InstanceNumbersByDef = CaptureInstanceNumbersByDeckRank();
+            _currentRun.DefCounters = new Dictionary<string, int>(_defCounters);
+        }
+
         RunStorage.SaveAsync(_currentRun);
     }
 
@@ -662,6 +742,16 @@ public static class RunTracker
         _pendingReplayExtraPlaySources.Clear();
         _pendingReplayExtraPlaySeriesStarted.Clear();
         _pendingReplayAttackOutcomes.Clear();
+        _observedDamageResults.Clear();
+        if (_pendingRankRestores.Count > 0)
+        {
+            // Leftover queued numbers mean saved cards never re-arrived via
+            // CardEnterDeckPatch before combat — their aggregates stay
+            // unbound. Should be empty here; log so a rebind gap is visible.
+            var leftovers = string.Join(", ", _pendingRankRestores.Select(kv => $"{kv.Key}x{kv.Value.Count}"));
+            CoreMain.Logger.Info($"ResetCombatContextState: discarding unclaimed rank restores: {leftovers}");
+            _pendingRankRestores.Clear();
+        }
     }
 
     /// <summary>
@@ -703,7 +793,10 @@ public static class RunTracker
                     return;
                 }
 
-                var saved = RunStorage.FindByGameStartTime(gameStartTime, out var foundUnsupportedMatch);
+                // requireInProgress: a hot reload on the game-over screen still
+                // has live RunState and _startTime — adopting the just-
+                // finalized record would resurrect a finished run.
+                var saved = RunStorage.FindByGameStartTime(gameStartTime, out var foundUnsupportedMatch, requireInProgress: true);
                 if (saved == null)
                 {
                     if (foundUnsupportedMatch)
@@ -721,116 +814,7 @@ public static class RunTracker
                     return;
                 }
 
-                _currentRun = saved;
-                bool repairedDamageAggregates = RepairOffensiveDamageAggregatesFromEvents(_currentRun);
-                _pendingCombat = null;
-                _instanceNumbers.Clear();
-                _defCounters.Clear();
-                _shivDeckViewCard = null;
-                _sovereignBladeDeckViewCard = null;
-                _sovereignBladeDefinitionIdThisRun = null;
-
-                // Restore monotonic counters first so any lazy-assign after
-                // this picks up the next unused number (not a conflict).
-                if (saved.DefCounters != null)
-                {
-                    foreach (var kv in saved.DefCounters) _defCounters[kv.Key] = kv.Value;
-                }
-
-                // Rebuild the ref → number map by walking the live deck in
-                // its current order. For each card, count its rank among
-                // same-def cards and look up the saved number at that rank.
-                //
-                // Removal-safe: if the player Smith'd Strike #3, the saved
-                // list for STRIKE is [1, 2, 4, 5] — rank 0 → #1, rank 1 →
-                // #2, rank 2 → #4 (the old #4, correctly), rank 3 → #5.
-                var player = runState.Players.FirstOrDefault();
-                int restored = 0, unmatched = 0;
-                if (player?.Deck != null && saved.InstanceNumbersByDef != null)
-                {
-                    var rankCounters = new Dictionary<string, int>();
-                    foreach (var card in player.Deck.Cards)
-                    {
-                        var key = Canonical(card);
-                        var defId = key.Id.ToString();
-                        rankCounters.TryGetValue(defId, out var rank);
-                        rankCounters[defId] = rank + 1;
-
-                        if (saved.InstanceNumbersByDef.TryGetValue(defId, out var list) && rank < list.Count)
-                        {
-                            _instanceNumbers[key] = list[rank];
-                            restored++;
-                        }
-                        else
-                        {
-                            // Card in deck that wasn't in the saved snapshot — probably
-                            // added between the last save and the hot reload. Lazy-assign
-                            // via counter (which is already restored above).
-                            GetOrAssignNumber(key);
-                            unmatched++;
-                        }
-                    }
-                }
-
-                // Reconstruct refs for REMOVED cards. These aren't in
-                // player.Deck.Cards anymore, so the deck walk above didn't
-                // find them. But they still need entries in _instanceNumbers
-                // so GetRemovedCards() can surface them for the deck-view
-                // injection.
-                //
-                // State-accurate reconstruction: we snapshot the card's
-                // full SerializableCard state at removal time (upgrade
-                // level, enchantment, etc.) and use CardModel.FromSerializable
-                // to rebuild a ref matching the removed card's state.
-                // If no snapshot exists (aggregate from a pre-snapshot
-                // build), fall back to a canonical ref via ModelDb.
-                int reconstructedRemoved = 0;
-                if (_currentRun.Aggregates != null)
-                {
-                    foreach (var kv in _currentRun.Aggregates)
-                    {
-                        if (!kv.Value.Removed) continue;
-                        var hashIdx = kv.Key.LastIndexOf('#');
-                        if (hashIdx < 0) continue;
-                        if (!int.TryParse(kv.Key.Substring(hashIdx + 1), out var num)) continue;
-                        var defIdStr = kv.Key.Substring(0, hashIdx);
-                        try
-                        {
-                            CardModel reconstructed;
-                            if (kv.Value.RemovedSnapshot != null)
-                            {
-                                reconstructed = CardModel.FromSerializable(kv.Value.RemovedSnapshot);
-                            }
-                            else
-                            {
-                                var modelId = MegaCrit.Sts2.Core.Models.ModelId.Deserialize(defIdStr);
-                                reconstructed = MegaCrit.Sts2.Core.Models.ModelDb.GetById<CardModel>(modelId).ToMutable();
-                            }
-                            _instanceNumbers[reconstructed] = num;
-                            reconstructedRemoved++;
-                        }
-                        catch (Exception e)
-                        {
-                            CoreMain.LogDebug($"TryResumeActiveRun: couldn't reconstruct {kv.Key}: {e.Message}");
-                        }
-                    }
-                }
-
-                CoreMain.Logger.Info(
-                    $"TryResumeActiveRun: resumed run_id={_currentRun.RunId} " +
-                    $"game_start_time={gameStartTime} aggregates={_currentRun.Aggregates?.Count ?? 0} " +
-                    $"reconstructed_removed={reconstructedRemoved} " +
-                    $"restored_numbers={restored} unmatched_in_deck={unmatched}");
-
-                RefreshShivAvailabilityLocked();
-                RefreshSovereignBladeAvailabilityLocked();
-
-                if (repairedDamageAggregates)
-                {
-                    CoreMain.Logger.Info(
-                        $"TryResumeActiveRun: repaired offensive damage aggregates for run_id={_currentRun.RunId}");
-                    SaveCurrentRun();
-                }
+                AdoptRunLocked(saved, runState, "TryResumeActiveRun", repairAggregates: true);
             }
             catch (Exception e)
             {
@@ -839,17 +823,314 @@ public static class RunTracker
         }
     }
 
+    /// <summary>
+    /// Make <paramref name="run"/> the tracked current run and rebind per-card
+    /// identity to the CURRENT CardModel refs. Shared by hot-reload resume
+    /// (<see cref="TryResumeActiveRun"/>), main-menu Continue re-fires of
+    /// RunStarted (same run object kept in memory), and Continue-after-game-
+    /// restart adoption from disk.
+    ///
+    /// The deck walk maps live refs to saved numbers by (def, deck-rank);
+    /// snapshot numbers the walk couldn't bind (deck not yet repopulated on
+    /// some continue-load orderings) wait in <see cref="_pendingRankRestores"/>
+    /// for CardEnterDeckPatch arrivals. Ghost aggregates minted by
+    /// CardEnterDeckPatch firing BEFORE RunStarted on continue-loads are
+    /// pruned afterward.
+    /// </summary>
+    private static void AdoptRunLocked(RunData run, RunState? runState, string context, bool repairAggregates)
+    {
+        _currentRun = run;
+        // Old builds stamped EndedAt on every Continue re-fire; an in-progress
+        // run is live again the moment we adopt it. Guarded on outcome so a
+        // defensive future caller can't resurrect a genuinely finished record
+        // (every current caller already filters to in_progress).
+        if (run.Outcome == "in_progress")
+            run.EndedAt = null;
+
+        bool repairedDamageAggregates = repairAggregates && RepairOffensiveDamageAggregatesFromEvents(run);
+
+        _pendingCombat = null;
+        ResetCombatContextState();
+        _instanceNumbers.Clear();
+        _defCounters.Clear();
+        ResetDeckViewCachesLocked();
+
+        // Restore monotonic counters first so any lazy-assign after
+        // this picks up the next unused number (not a conflict).
+        if (run.DefCounters != null)
+        {
+            foreach (var kv in run.DefCounters) _defCounters[kv.Key] = kv.Value;
+        }
+
+        // Seed every saved instance number, in deck-rank order, into the
+        // pending-restore queues, then walk the live deck through the normal
+        // GetOrAssignNumber path: each deck card claims its def's next queued
+        // number in arrival order — the same (def, rank) binding the snapshot
+        // was captured with. Removal-safe: if the player Smith'd Strike #3,
+        // the saved list for STRIKE is [1, 2, 4, 5] and deck order claims
+        // #1, #2, #4, #5. Whatever the walk can't bind (deck not yet
+        // repopulated on some continue-load orderings) stays queued for
+        // CardEnterDeckPatch arrivals; deck cards beyond the snapshot fall
+        // through to the restored counters. One binding mechanism regardless
+        // of whether the deck populates before or after this runs.
+        int seeded = 0;
+        if (run.InstanceNumbersByDef != null)
+        {
+            foreach (var kv in run.InstanceNumbersByDef)
+            {
+                if (kv.Value.Count == 0) continue;
+                _pendingRankRestores[kv.Key] = new Queue<int>(kv.Value);
+                seeded += kv.Value.Count;
+            }
+        }
+
+        int deckCards = 0;
+        var player = runState?.Players.FirstOrDefault();
+        if (player?.Deck != null)
+        {
+            foreach (var card in player.Deck.Cards)
+            {
+                deckCards++;
+                GetOrAssignNumber(card);
+            }
+        }
+        int stillWaiting = _pendingRankRestores.Values.Sum(q => q.Count);
+        int restored = seeded - stillWaiting;
+        int unmatched = deckCards - restored;
+
+        // If the deck was already (re)populated when we adopted, leftover
+        // queued numbers aren't late-population waiters — they're snapshot
+        // entries the game's own save no longer contains (e.g. a crash rolled
+        // the save back past a card acquisition). Keeping them queued would
+        // let the next same-def acquisition claim a dead card's number and
+        // silently inherit its stats. Drop them; their aggregates stay in the
+        // file as history (the ≤-saved-counter rule shields them from the
+        // ghost prune below).
+        if (deckCards > 0 && stillWaiting > 0)
+        {
+            var dropped = string.Join(", ", _pendingRankRestores.Select(kv => $"{kv.Key}x{kv.Value.Count}"));
+            CoreMain.Logger.Info($"{context}: dropping stale rank restores not present in the live deck: {dropped}");
+            _pendingRankRestores.Clear();
+        }
+
+        // Reconstruct refs for REMOVED cards. These aren't in
+        // player.Deck.Cards anymore, so the deck walk above didn't
+        // find them. But they still need entries in _instanceNumbers
+        // so GetRemovedCards() can surface them for the deck-view
+        // injection.
+        //
+        // State-accurate reconstruction: we snapshot the card's
+        // full SerializableCard state at removal time (upgrade
+        // level, enchantment, etc.) and use CardModel.FromSerializable
+        // to rebuild a ref matching the removed card's state.
+        // If no snapshot exists (aggregate from a pre-snapshot
+        // build), fall back to a canonical ref via ModelDb.
+        int reconstructedRemoved = 0;
+        if (run.Aggregates != null)
+        {
+            foreach (var kv in run.Aggregates)
+            {
+                if (!kv.Value.Removed) continue;
+                if (!TryParseAggregateKey(kv.Key, out var defIdStr, out var num)) continue;
+                try
+                {
+                    CardModel reconstructed;
+                    if (kv.Value.RemovedSnapshot != null)
+                    {
+                        reconstructed = CardModel.FromSerializable(kv.Value.RemovedSnapshot);
+                    }
+                    else
+                    {
+                        var modelId = MegaCrit.Sts2.Core.Models.ModelId.Deserialize(defIdStr);
+                        reconstructed = MegaCrit.Sts2.Core.Models.ModelDb.GetById<CardModel>(modelId).ToMutable();
+                    }
+                    _instanceNumbers[reconstructed] = num;
+                    reconstructedRemoved++;
+                }
+                catch (Exception e)
+                {
+                    CoreMain.LogDebug($"{context}: couldn't reconstruct {kv.Key}: {e.Message}");
+                }
+            }
+        }
+
+        int prunedGhosts = PruneGhostAggregates(run, run.DefCounters, BuildLiveInstanceIdSetLocked());
+
+        CoreMain.Logger.Info(
+            $"{context}: resumed run_id={run.RunId} " +
+            $"game_start_time={run.GameStartTime} aggregates={run.Aggregates?.Count ?? 0} " +
+            $"reconstructed_removed={reconstructedRemoved} " +
+            $"restored_numbers={restored} unmatched_in_deck={unmatched} " +
+            $"pending_rank_restores={_pendingRankRestores.Count} pruned_ghosts={prunedGhosts}");
+
+        RefreshShivAvailabilityLocked();
+        RefreshSovereignBladeAvailabilityLocked();
+
+        if (repairedDamageAggregates)
+        {
+            CoreMain.Logger.Info(
+                $"{context}: repaired offensive damage aggregates for run_id={run.RunId}");
+        }
+        if (repairedDamageAggregates || prunedGhosts > 0)
+        {
+            SaveCurrentRun();
+        }
+    }
+
+    /// <summary>
+    /// Every instance id ("DEF#N") currently bound to a live card ref, plus
+    /// numbers still waiting in <see cref="_pendingRankRestores"/> for late
+    /// deck population. Input to <see cref="PruneGhostAggregates"/>.
+    /// </summary>
+    private static HashSet<string> BuildLiveInstanceIdSetLocked()
+    {
+        var live = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var kv in _instanceNumbers)
+            live.Add($"{kv.Key.Id}#{kv.Value}");
+        foreach (var kv in _pendingRankRestores)
+            foreach (var n in kv.Value)
+                live.Add($"{kv.Key}#{n}");
+        return live;
+    }
+
+    /// <summary>
+    /// Remove ghost aggregates minted by CardEnterDeckPatch firing before
+    /// RunStarted on a continue-load: the repopulated deck's fresh CardModel
+    /// refs get brand-new instance numbers (continuing the old counters) and
+    /// empty arrival stamps before the adoption rebind can map them back to
+    /// their saved numbers. Those stamps are pure file pollution — never
+    /// played, never referenced, invisible after the rebind.
+    ///
+    /// Conservative by construction: prunes only aggregates whose number
+    /// exceeds the last-saved counter for their def, that aren't bound to any
+    /// live card, hold no recorded activity, and are referenced by no event.
+    /// A pruned number can be re-minted later; that's safe precisely because
+    /// nothing ever referenced it.
+    /// </summary>
+    internal static int PruneGhostAggregates(
+        RunData run,
+        Dictionary<string, int>? savedDefCounters,
+        HashSet<string> liveInstanceIds)
+    {
+        if (run.Aggregates == null || run.Aggregates.Count == 0) return 0;
+
+        // One pass over the event log up front; candidates check membership
+        // instead of rescanning the (thousands-long) list each.
+        HashSet<string>? eventCardIds = null;
+        if (run.Events != null && run.Events.Count > 0)
+        {
+            eventCardIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var cardEvent in run.Events) eventCardIds.Add(cardEvent.CardId);
+        }
+
+        List<string>? toRemove = null;
+        foreach (var kv in run.Aggregates)
+        {
+            if (!TryParseAggregateKey(kv.Key, out var defId, out var num)) continue;
+
+            int savedCounter = 0;
+            savedDefCounters?.TryGetValue(defId, out savedCounter);
+            if (num <= savedCounter) continue;                       // predates the last save — trust it
+            if (liveInstanceIds.Contains(kv.Key)) continue;          // bound to a live card
+            if (!IsGhostStampAggregate(kv.Value)) continue;          // has recorded activity
+            if (eventCardIds != null && eventCardIds.Contains(kv.Key)) continue;
+
+            (toRemove ??= new List<string>()).Add(kv.Key);
+        }
+
+        if (toRemove == null) return 0;
+        foreach (var key in toRemove) run.Aggregates.Remove(key);
+        return toRemove.Count;
+    }
+
+    /// <summary>
+    /// Split an aggregate key ("CARD.STRIKE#3") into its definition id and
+    /// instance number. False for keys that don't carry a numeric instance
+    /// suffix (e.g. historic pooled-shape keys).
+    /// </summary>
+    private static bool TryParseAggregateKey(string key, out string defId, out int number)
+    {
+        defId = "";
+        number = 0;
+        var hashIdx = key.LastIndexOf('#');
+        if (hashIdx < 0) return false;
+        if (!int.TryParse(key.Substring(hashIdx + 1), out number)) return false;
+        defId = key.Substring(0, hashIdx);
+        return true;
+    }
+
+    private static readonly System.Text.Json.JsonSerializerOptions GhostCompareOptions = new();
+
+    /// <summary>
+    /// True when the aggregate holds nothing beyond an arrival stamp
+    /// (FloorAdded / InitialUpgradeLevel) — the shape a pre-RunStarted
+    /// CardEnterDeckPatch ghost has. Compared structurally against a bare
+    /// stamp with the same lineage so ANY recorded activity — including
+    /// fields added after this check was written — disqualifies. Runs only
+    /// during adoption on a handful of candidates, so the serialization cost
+    /// is irrelevant next to the maintenance risk of a hand-kept field list.
+    /// </summary>
+    private static bool IsGhostStampAggregate(CardAggregate agg)
+    {
+        if (agg.Removed) return false;
+        var bareStamp = new CardAggregate
+        {
+            FloorAdded = agg.FloorAdded,
+            InitialUpgradeLevel = agg.InitialUpgradeLevel,
+        };
+        return System.Text.Json.JsonSerializer.Serialize(agg, GhostCompareOptions)
+            == System.Text.Json.JsonSerializer.Serialize(bareStamp, GhostCompareOptions);
+    }
+
     // -------- Lifecycle callbacks --------
 
     private static void OnRunStarted(RunState runState)
     {
         lock (_lock)
         {
-            // If a previous run was in progress (mod reload, unusual path), finalize it first.
+            long gameStartTime = 0;
+            try { gameStartTime = RunManager.Instance._startTime; }
+            catch (Exception e) { CoreMain.LogDebug($"OnRunStarted: couldn't read _startTime: {e.Message}"); }
+
+            // The game re-fires RunStarted with the SAME _startTime whenever a
+            // saved run is continued from the main menu ("Continuing run with
+            // character"). That's a continuation of the run we're already
+            // tracking, not a new run — minting a fresh RunData here is what
+            // used to strand every previously-committed stat in an orphaned
+            // file and reset tooltips to zero mid-run.
+            if (gameStartTime != 0 && _currentRun != null
+                && _currentRun.GameStartTime == gameStartTime
+                && _currentRun.Outcome == "in_progress")
+            {
+                AdoptRunLocked(_currentRun, runState, "RunStarted(continue)", repairAggregates: false);
+                return;
+            }
+
+            // If a previous (different) run was in progress (mod reload, unusual path), finalize it first.
             if (_currentRun != null)
             {
+                // The NEW run's pre-RunStarted deck population may have stamped
+                // ghost aggregates into the old run's data (CardEnterDeckPatch
+                // fires before RunStarted). This is the old run's last save —
+                // scrub them now or they're permanent. Empty live set: nothing
+                // in the identity map legitimately belongs to the old run
+                // beyond its last-saved counters at this point.
+                PruneGhostAggregates(_currentRun, _currentRun.DefCounters, new HashSet<string>(StringComparer.Ordinal));
                 _currentRun.EndedAt = Now();
                 SaveCurrentRun();
+            }
+
+            // Continue after a game restart: our statics are fresh but the
+            // run isn't. Adopt the newest resumable on-disk record for this
+            // game run rather than starting a stranded parallel file.
+            if (gameStartTime != 0)
+            {
+                var saved = RunStorage.FindByGameStartTime(gameStartTime, out _, requireInProgress: true);
+                if (saved != null && saved.Outcome == "in_progress")
+                {
+                    AdoptRunLocked(saved, runState, "RunStarted(adopt-saved)", repairAggregates: true);
+                    return;
+                }
             }
 
             // Per-instance identity is per-run. Clear assignments so the next
@@ -858,11 +1139,7 @@ public static class RunTracker
             _instanceNumbers.Clear();
             _defCounters.Clear();
             ResetCombatContextState();
-            _shivAvailableThisRun = false;
-            _shivDeckViewCard = null;
-            _sovereignBladeAvailableThisRun = false;
-            _sovereignBladeDeckViewCard = null;
-            _sovereignBladeDefinitionIdThisRun = null;
+            ResetDeckViewCachesLocked();
 
             string now = Now();
             _currentRun = new RunData
@@ -873,10 +1150,13 @@ public static class RunTracker
                 Character = runState.Players.FirstOrDefault()?.Character?.Id.ToString(),
                 Ascension = runState.AscensionLevel,
                 FloorReached = runState.TotalFloor,
-                // Publicizer gives us the private _startTime field. This is the
-                // game's own run identifier — matches the filename it uses for
-                // its run-history save ({StartTime}.run). Enables M5 correlation.
-                GameStartTime = RunManager.Instance._startTime,
+                // The game's own run identifier (RunManager._startTime via
+                // Publicizer) — matches the filename it uses for its
+                // run-history save ({StartTime}.run). Enables M5 correlation.
+                // Reuses the guarded read from the top of this method: a
+                // second raw read here would rethrow into the game's
+                // RunStarted dispatch exactly when the first read failed.
+                GameStartTime = gameStartTime != 0 ? gameStartTime : null,
             };
             _pendingCombat = null;
 
@@ -908,6 +1188,17 @@ public static class RunTracker
         {
             if (_currentRun == null) return;
 
+            // A loss reaches RunManager.OnEnded synchronously from the killing
+            // action; the fatal combat's CombatEnded only fires LATER via
+            // ProcessPendingLoss — after this handler has consumed the buffer.
+            // So promote the fatal combat here: the fight genuinely resolved
+            // (the player died). Loss only: an Abandon Run mid-combat is NOT a
+            // resolved combat, and promoting it would commit a half-played
+            // fight (and mislabel surviving block as wasted); wins always get
+            // a normal CombatEnded first, so the buffer is already null there.
+            if (string.Equals(outcome, "loss", StringComparison.Ordinal))
+                PromotePendingCombatIntoRunLocked();
+
             _currentRun.Outcome = outcome;
             _currentRun.EndedAt = Now();
             _currentRun.UpdatedAt = _currentRun.EndedAt;
@@ -927,11 +1218,7 @@ public static class RunTracker
             _currentRun = null;
             _pendingCombat = null;
             ResetCombatContextState();
-            _shivAvailableThisRun = false;
-            _shivDeckViewCard = null;
-            _sovereignBladeAvailableThisRun = false;
-            _sovereignBladeDeckViewCard = null;
-            _sovereignBladeDefinitionIdThisRun = null;
+            ResetDeckViewCachesLocked();
         }
     }
 
@@ -963,67 +1250,7 @@ public static class RunTracker
                 UpdatedAt = Now(),
             };
 
-            // Surviving player block at combat end never absorbed future
-            // damage, so treat any remaining ledger as wasted before
-            // promoting the combat aggregates into the run.
-            AttributeUnusedBlockLocked(TotalTrackedPlayerBlockLocked());
-
-            // Promote pending buffer into the run's committed state.
-            foreach (var (cardId, combatAgg) in _pendingCombat.CombatAggregates)
-            {
-                var runAgg = GetOrCreateAggregate(_currentRun, cardId);
-                MergeAggregateInto(runAgg, combatAgg);
-            }
-            _currentRun.Events.AddRange(_pendingCombat.CombatEvents);
-
-            foreach (var (relicId, pendingRelicAgg) in _pendingCombat.RelicAggregates)
-            {
-                if (!_currentRun.RelicAggregates.TryGetValue(relicId, out var runRelicAgg))
-                {
-                    runRelicAgg = new RelicAggregate();
-                    _currentRun.RelicAggregates[relicId] = runRelicAgg;
-                }
-                runRelicAgg.Activations += pendingRelicAgg.Activations;
-                runRelicAgg.EnemiesAffected += pendingRelicAgg.EnemiesAffected;
-                runRelicAgg.VulnerableApplied += pendingRelicAgg.VulnerableApplied;
-                runRelicAgg.WeakApplied += pendingRelicAgg.WeakApplied;
-                runRelicAgg.AdditionalCardsDrawn += pendingRelicAgg.AdditionalCardsDrawn;
-                runRelicAgg.AdditionalBlockGained += pendingRelicAgg.AdditionalBlockGained;
-                runRelicAgg.BlockedTriggers += pendingRelicAgg.BlockedTriggers;
-                runRelicAgg.Activations += pendingRelicAgg.Activations;
-                runRelicAgg.StrengthAdded += pendingRelicAgg.StrengthAdded;
-                runRelicAgg.PlatingAdded += pendingRelicAgg.PlatingAdded;
-                runRelicAgg.CardsUpgraded += pendingRelicAgg.CardsUpgraded;
-                runRelicAgg.BoneFluteTriggers += pendingRelicAgg.BoneFluteTriggers;
-                runRelicAgg.TotalOstyHpSummoned += pendingRelicAgg.TotalOstyHpSummoned;
-                runRelicAgg.TotalHealingAttempted += pendingRelicAgg.TotalHealingAttempted;
-                runRelicAgg.TotalHealingRestored += pendingRelicAgg.TotalHealingRestored;
-                runRelicAgg.TotalHealingLost += pendingRelicAgg.TotalHealingLost;
-                MergeHealingLostReasonsInto(runRelicAgg, pendingRelicAgg);
-                runRelicAgg.DoomDeathTriggers += pendingRelicAgg.DoomDeathTriggers;
-                runRelicAgg.DoomKills += pendingRelicAgg.DoomKills;
-                runRelicAgg.EnergyGenerated += pendingRelicAgg.EnergyGenerated;
-                runRelicAgg.PotionsGained += pendingRelicAgg.PotionsGained;
-                runRelicAgg.CommonPotionsGained += pendingRelicAgg.CommonPotionsGained;
-                runRelicAgg.UncommonPotionsGained += pendingRelicAgg.UncommonPotionsGained;
-                runRelicAgg.RarePotionsGained += pendingRelicAgg.RarePotionsGained;
-                runRelicAgg.PotionsSkipped += pendingRelicAgg.PotionsSkipped;
-                runRelicAgg.CardRewardsAffected += pendingRelicAgg.CardRewardsAffected;
-                MergeCardRewardCategories(runRelicAgg.CardRewardCategories, pendingRelicAgg.CardRewardCategories);
-            }
-
-            foreach (var (enemyId, pendingEnemyAgg) in _pendingCombat.EnemyAggregates)
-            {
-                if (!_currentRun.EnemyAggregates.TryGetValue(enemyId, out var runEnemyAgg))
-                {
-                    runEnemyAgg = new EnemyAggregate { EnemyId = enemyId };
-                    _currentRun.EnemyAggregates[enemyId] = runEnemyAgg;
-                }
-
-                MergeEnemyAggregateInto(runEnemyAgg, pendingEnemyAgg);
-            }
-
-            MergeMetaStatsInto(_currentRun.MetaStats, _pendingCombat.MetaStats);
+            PromotePendingCombatIntoRunLocked();
 
             // Refresh run-level metadata from the current game state (floor may have advanced).
             var runState = RunManager.Instance.State;
@@ -1039,6 +1266,100 @@ public static class RunTracker
             ResetCombatContextState();
             SaveCurrentRun();
         }
+    }
+
+    /// <summary>
+    /// Promote the pending combat buffer into the committed run state. Shared
+    /// by <see cref="OnCombatEnded"/> (the normal path) and
+    /// <see cref="OnRunEnded"/> — a lost run ends mid-combat with no
+    /// CombatEnded, and without this promotion everything the player did in
+    /// the fatal combat would be discarded with the buffer.
+    /// </summary>
+    private static void PromotePendingCombatIntoRunLocked()
+    {
+        if (_pendingCombat == null || _currentRun == null) return;
+
+        // Surviving player block at combat end never absorbed future
+        // damage, so treat any remaining ledger as wasted before
+        // promoting the combat aggregates into the run.
+        AttributeUnusedBlockLocked(TotalTrackedPlayerBlockLocked());
+
+        PromotePendingCombatIntoRun(_pendingCombat, _currentRun);
+    }
+
+    /// <summary>
+    /// Pure merge of a pending combat buffer into a run record. Internal so
+    /// tests can pin the promotion behavior without a live game.
+    /// </summary>
+    internal static void PromotePendingCombatIntoRun(PendingCombat pending, RunData run)
+    {
+        // Promote pending buffer into the run's committed state.
+        foreach (var (cardId, combatAgg) in pending.CombatAggregates)
+        {
+            var runAgg = GetOrCreateAggregate(run, cardId);
+            MergeAggregateInto(runAgg, combatAgg);
+        }
+        run.Events.AddRange(pending.CombatEvents);
+
+        foreach (var (relicId, pendingRelicAgg) in pending.RelicAggregates)
+        {
+            if (!run.RelicAggregates.TryGetValue(relicId, out var runRelicAgg))
+            {
+                runRelicAgg = new RelicAggregate();
+                run.RelicAggregates[relicId] = runRelicAgg;
+            }
+            MergeRelicAggregateInto(runRelicAgg, pendingRelicAgg);
+        }
+
+        foreach (var (enemyId, pendingEnemyAgg) in pending.EnemyAggregates)
+        {
+            if (!run.EnemyAggregates.TryGetValue(enemyId, out var runEnemyAgg))
+            {
+                runEnemyAgg = new EnemyAggregate { EnemyId = enemyId };
+                run.EnemyAggregates[enemyId] = runEnemyAgg;
+            }
+
+            MergeEnemyAggregateInto(runEnemyAgg, pendingEnemyAgg);
+        }
+
+        MergeMetaStatsInto(run.MetaStats, pending.MetaStats);
+    }
+
+    /// <summary>
+    /// Additive merge of one relic aggregate into another. The single home
+    /// for relic-field accumulation (mirrors <c>MergeAggregateInto</c> /
+    /// <c>MergeEnemyAggregateInto</c>) — used by both combat promotion and
+    /// the mid-combat tooltip overlay so the two can't drift. Add new relic
+    /// stat fields HERE, once.
+    /// </summary>
+    private static void MergeRelicAggregateInto(RelicAggregate target, RelicAggregate source)
+    {
+        target.Activations += source.Activations;
+        target.EnemiesAffected += source.EnemiesAffected;
+        target.VulnerableApplied += source.VulnerableApplied;
+        target.WeakApplied += source.WeakApplied;
+        target.AdditionalCardsDrawn += source.AdditionalCardsDrawn;
+        target.AdditionalBlockGained += source.AdditionalBlockGained;
+        target.BlockedTriggers += source.BlockedTriggers;
+        target.StrengthAdded += source.StrengthAdded;
+        target.PlatingAdded += source.PlatingAdded;
+        target.CardsUpgraded += source.CardsUpgraded;
+        target.BoneFluteTriggers += source.BoneFluteTriggers;
+        target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
+        target.TotalHealingAttempted += source.TotalHealingAttempted;
+        target.TotalHealingRestored += source.TotalHealingRestored;
+        target.TotalHealingLost += source.TotalHealingLost;
+        MergeHealingLostReasonsInto(target, source);
+        target.DoomDeathTriggers += source.DoomDeathTriggers;
+        target.DoomKills += source.DoomKills;
+        target.EnergyGenerated += source.EnergyGenerated;
+        target.PotionsGained += source.PotionsGained;
+        target.CommonPotionsGained += source.CommonPotionsGained;
+        target.UncommonPotionsGained += source.UncommonPotionsGained;
+        target.RarePotionsGained += source.RarePotionsGained;
+        target.PotionsSkipped += source.PotionsSkipped;
+        target.CardRewardsAffected += source.CardRewardsAffected;
+        MergeCardRewardCategories(target.CardRewardCategories, source.CardRewardCategories);
     }
 
     // -------- Event observation (from CombatHistory.Add postfix) --------
@@ -1107,6 +1428,11 @@ public static class RunTracker
                     RecordBlockGainedEntry(bge);
                     break;
                 case DamageReceivedEntry dre:
+                    // Remember the result ref so the combat-ending capture
+                    // (RecordCombatEndingSuppressedDamage) knows this hit was
+                    // recorded normally and won't synthesize a duplicate.
+                    TryMarkDamageResultObserved(dre.Result);
+
                     if (dre.Receiver.IsPlayer)
                     {
                         RecordPlayerBlockedDamage(dre);
@@ -2841,33 +3167,7 @@ public static class RunTracker
             if (_pendingCombat != null && _pendingCombat.RelicAggregates.TryGetValue(relicId, out var pending))
             {
                 result ??= new RelicAggregate();
-                result.Activations += pending.Activations;
-                result.EnemiesAffected += pending.EnemiesAffected;
-                result.VulnerableApplied += pending.VulnerableApplied;
-                result.WeakApplied += pending.WeakApplied;
-                result.AdditionalCardsDrawn += pending.AdditionalCardsDrawn;
-                result.AdditionalBlockGained += pending.AdditionalBlockGained;
-                result.BlockedTriggers += pending.BlockedTriggers;
-                result.Activations += pending.Activations;
-                result.StrengthAdded += pending.StrengthAdded;
-                result.PlatingAdded += pending.PlatingAdded;
-                result.CardsUpgraded += pending.CardsUpgraded;
-                result.BoneFluteTriggers += pending.BoneFluteTriggers;
-                result.TotalOstyHpSummoned += pending.TotalOstyHpSummoned;
-                result.TotalHealingAttempted += pending.TotalHealingAttempted;
-                result.TotalHealingRestored += pending.TotalHealingRestored;
-                result.TotalHealingLost += pending.TotalHealingLost;
-                MergeHealingLostReasonsInto(result, pending);
-                result.DoomDeathTriggers += pending.DoomDeathTriggers;
-                result.DoomKills += pending.DoomKills;
-                result.EnergyGenerated += pending.EnergyGenerated;
-                result.PotionsGained += pending.PotionsGained;
-                result.CommonPotionsGained += pending.CommonPotionsGained;
-                result.UncommonPotionsGained += pending.UncommonPotionsGained;
-                result.RarePotionsGained += pending.RarePotionsGained;
-                result.PotionsSkipped += pending.PotionsSkipped;
-                result.CardRewardsAffected += pending.CardRewardsAffected;
-                MergeCardRewardCategories(result.CardRewardCategories, pending.CardRewardCategories);
+                MergeRelicAggregateInto(result, pending);
             }
 
             return result;
@@ -5046,6 +5346,98 @@ public static class RunTracker
                 Killed = result.WasTargetKilled,
             });
         }
+    }
+
+    /// <summary>
+    /// Atomically record that this DamageResult has been observed, returning
+    /// true only for the FIRST observation. Observe() calls this for every
+    /// real DamageReceivedEntry (discarding the result); the combat-ending
+    /// capture branches on it — false means the game already emitted (or we
+    /// already synthesized) an entry for this exact DamageResult object.
+    /// One method for both sides so the dedup pairing can't drift.
+    /// </summary>
+    internal static bool TryMarkDamageResultObserved(DamageResult? result)
+    {
+        if (result == null) return false;
+        lock (_lock) { return _observedDamageResults.Add(result); }
+    }
+
+    /// <summary>Test isolation for the observed-result dedup set.</summary>
+    internal static void ClearObservedDamageResultsForTest()
+    {
+        lock (_lock) { _observedDamageResults.Clear(); }
+    }
+
+    /// <summary>
+    /// Record damage whose combat-history entry the game suppressed because
+    /// the hit itself ended the combat.
+    ///
+    /// <c>CreatureCmd.Damage</c> applies HP loss first and only then emits
+    /// <c>DamageReceivedEntry</c> behind an <c>IsInProgress &amp;&amp; !IsEnding</c>
+    /// gate — so the hit that kills the last living enemy flips
+    /// <c>CombatManager.IsEnding</c> and suppresses its own history entry.
+    /// Scaling finishers (Death March) systematically lost their biggest,
+    /// fight-ending hits to this.
+    ///
+    /// Called from <see cref="Patches.HookAfterDamageGivenPatch"/>.
+    /// <c>Hook.AfterDamageGiven</c> is dispatched directly by the game so it
+    /// "must still resolve" for the killing hit, and it fires AFTER the
+    /// (possible) history emission for the same DamageResult — so
+    /// "combat is ending" + "result not observed yet" identifies exactly the
+    /// suppressed window. Out-of-combat damage (<c>!IsInProgress</c>) stays
+    /// unrecorded, matching the game's own combat-history behavior.
+    ///
+    /// The synthesized entry is routed through <see cref="Observe"/> so
+    /// instance identity, replay marking, enemy bookkeeping, and the persisted
+    /// event schema stay identical to an organic entry. It is NOT added to the
+    /// game's own CombatHistory — game state is left untouched.
+    /// </summary>
+    public static void RecordCombatEndingSuppressedDamage(
+        MegaCrit.Sts2.Core.Combat.ICombatState? combatState,
+        Creature? dealer,
+        DamageResult? result,
+        CardModel? cardSource)
+    {
+        if (combatState == null || result == null) return;
+
+        var combatManager = CombatManager.Instance;
+        // IsEnding is only true while combat is still in progress — exactly
+        // the window where the game's emission gate is closed. Known residual:
+        // IsEnding is a live computed property re-derived here, slightly after
+        // the game's own gate evaluated it; a hook listener that spawns a new
+        // primary enemy between the two (Phrog-Parasite pattern) could flip it
+        // back and make us skip a genuinely suppressed hit. Capturing at the
+        // exact gate point would need a transpiler on CreatureCmd.Damage —
+        // deliberately not worth that fragility for the corner case.
+        if (combatManager == null || !combatManager.IsEnding) return;
+
+        // Post-OnRunEnded tail guard: on a loss the game calls
+        // RunManager.OnEnded synchronously from the killing action, and the
+        // deferred CombatEnded (ProcessPendingLoss) only fires afterwards.
+        // Damage resolving in that gap would lazily resurrect _pendingCombat
+        // through the Record* paths and mint a junk run file at that late
+        // CombatEnded. Once the run record is gone, stop capturing.
+        if (Current == null) return;
+
+        if (!TryMarkDamageResultObserved(result)) return;  // emitted normally
+
+        var receiver = result.Receiver;
+        if (receiver == null) return;
+
+        // Always-on Info (like the CardSource=null diagnostic): these should
+        // be rare — one per combat-ending hit — and when totals are disputed
+        // we want the evidence in the log without a debug flag.
+        CoreMain.Logger.Info(
+            $"Recording combat-ending suppressed damage: card={cardSource?.Title ?? "null"} " +
+            $"receiver={DescribeCreature(receiver)} dealer={DescribeCreature(dealer)} " +
+            $"blocked={result.BlockedDamage} unblocked={result.UnblockedDamage} " +
+            $"overkill={result.OverkillDamage} killed={result.WasTargetKilled}");
+
+        var entry = new DamageReceivedEntry(
+            result, receiver, dealer, cardSource,
+            combatState.RoundNumber, combatState.CurrentSide,
+            combatManager.History, combatState.Players);
+        Observe(entry);
     }
 
     private static void MarkReplayAttackDamageLocked(CardModel card)

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -719,6 +719,42 @@ public static class RunTracker
         RunStorage.SaveAsync(_currentRun);
     }
 
+    /// <summary>
+    /// Lazily create <c>_currentRun</c> when combat/relic data arrives before
+    /// <c>RunStarted</c> fired (mod hot-loaded mid-run). Always stamps
+    /// <c>GameStartTime</c> so a later Continue/hot-reload can match and resume
+    /// this record instead of stranding it — the previous inline mints omitted
+    /// it, re-seeding the stranding bug. Single home for the lazy mint.
+    /// </summary>
+    private static void EnsureLazyCurrentRunLocked()
+    {
+        if (_currentRun != null) return;
+        long gameStartTime = 0;
+        try { gameStartTime = RunManager.Instance._startTime; }
+        catch { /* no live run state — leave GameStartTime null */ }
+        string now = Now();
+        _currentRun = new RunData
+        {
+            RunId = Guid.NewGuid().ToString("N"),
+            StartedAt = now,
+            UpdatedAt = now,
+            GameStartTime = gameStartTime != 0 ? gameStartTime : null,
+        };
+    }
+
+    /// <summary>
+    /// Run a game-event handler body under a top-level guard. These handlers
+    /// are subscribed directly to RunManager/CombatManager events, so an
+    /// unhandled throw would propagate into the game's own dispatch and could
+    /// break combat/run flow. Always-on Error log so a broken handler is
+    /// visible without a debug flag.
+    /// </summary>
+    private static void GuardLifecycle(string site, Action body)
+    {
+        try { body(); }
+        catch (Exception e) { CoreMain.Logger.Error($"{site} failed: {e}"); }
+    }
+
     private static void ResetCombatContextState()
     {
         _currentPlayerCardPlay = null;
@@ -1089,7 +1125,10 @@ public static class RunTracker
 
     // -------- Lifecycle callbacks --------
 
-    private static void OnRunStarted(RunState runState)
+    private static void OnRunStarted(RunState runState) =>
+        GuardLifecycle(nameof(OnRunStarted), () => OnRunStartedImpl(runState));
+
+    private static void OnRunStartedImpl(RunState runState)
     {
         lock (_lock)
         {
@@ -1227,7 +1266,10 @@ public static class RunTracker
         }
     }
 
-    private static void OnCombatSetUp(CombatState state)
+    private static void OnCombatSetUp(CombatState state) =>
+        GuardLifecycle(nameof(OnCombatSetUp), () => OnCombatSetUpImpl(state));
+
+    private static void OnCombatSetUpImpl(CombatState state)
     {
         lock (_lock)
         {
@@ -1239,7 +1281,10 @@ public static class RunTracker
         }
     }
 
-    private static void OnCombatEnded(CombatRoom room)
+    private static void OnCombatEnded(CombatRoom room) =>
+        GuardLifecycle(nameof(OnCombatEnded), () => OnCombatEndedImpl(room));
+
+    private static void OnCombatEndedImpl(CombatRoom room)
     {
         lock (_lock)
         {
@@ -1248,12 +1293,7 @@ public static class RunTracker
             // Lazy run creation: if events came in before RunStarted ever fired
             // (e.g. mod loaded mid-run), create a minimal run record now so we
             // don't drop the combat's data.
-            _currentRun ??= new RunData
-            {
-                RunId = Guid.NewGuid().ToString("N"),
-                StartedAt = Now(),
-                UpdatedAt = Now(),
-            };
+            EnsureLazyCurrentRunLocked();
 
             PromotePendingCombatIntoRunLocked();
 
@@ -2775,7 +2815,9 @@ public static class RunTracker
                 if (otherLost > 0m)
                     AddHealingLostReasonLocked(agg, HealingLostOtherReasonId, "other/prevented", otherLost);
 
-                if (pending.PersistDirectlyToRun)
+                // Persist a late finalize that landed directly in the committed
+                // run (no live pending combat to carry it to CombatEnded).
+                if (pending.PersistDirectlyToRun || _pendingCombat == null)
                     SaveCurrentRun();
                 return;
             }
@@ -2994,12 +3036,7 @@ public static class RunTracker
         {
             try
             {
-                _currentRun ??= new RunData
-                {
-                    RunId = Guid.NewGuid().ToString("N"),
-                    StartedAt = Now(),
-                    UpdatedAt = Now(),
-                };
+                EnsureLazyCurrentRunLocked();
 
                 if (!_currentRun.RelicAggregates.TryGetValue(PrismaticGemRelicId, out var agg))
                 {
@@ -3029,12 +3066,7 @@ public static class RunTracker
         {
             try
             {
-                _currentRun ??= new RunData
-                {
-                    RunId = Guid.NewGuid().ToString("N"),
-                    StartedAt = Now(),
-                    UpdatedAt = Now(),
-                };
+                EnsureLazyCurrentRunLocked();
 
                 if (!_currentRun.RelicAggregates.TryGetValue(PrismaticGemRelicId, out var agg))
                 {
@@ -3302,19 +3334,20 @@ public static class RunTracker
 
     private static RelicAggregate GetOrCreateRelicAggregateForHealingLocked(PendingRelicHealing pending)
     {
+        // NOT GetOrCreateRelicAggregateLocked: that does `_pendingCombat ??= new`,
+        // which resurrects an orphan buffer when this healing finalize runs on a
+        // pool thread AFTER OnCombatEnded already promoted and nulled the buffer.
+        // The orphan is never promoted, so the lost-healing tail was silently
+        // dropped on a run's final victorious combat. ForCurrentContext routes to
+        // the committed run aggregate when there is no live pending combat.
         return pending.PersistDirectlyToRun
             ? GetOrCreateCurrentRunRelicAggregateLocked(pending.RelicId)
-            : GetOrCreateRelicAggregateLocked(pending.RelicId);
+            : GetOrCreateRelicAggregateForCurrentContextLocked(pending.RelicId);
     }
 
     private static RelicAggregate GetOrCreateCurrentRunRelicAggregateLocked(string relicId)
     {
-        _currentRun ??= new RunData
-        {
-            RunId = Guid.NewGuid().ToString("N"),
-            StartedAt = Now(),
-            UpdatedAt = Now(),
-        };
+        EnsureLazyCurrentRunLocked();
 
         if (!_currentRun.RelicAggregates.TryGetValue(relicId, out var agg))
         {
@@ -3564,23 +3597,24 @@ public static class RunTracker
     {
         lock (_lock)
         {
-            // Lazy run-creation guard — upgrade could fire before RunStarted
-            // if the mod hot-loaded mid-run and missed the signal. We still
-            // want to record the event.
-            _currentRun ??= new RunData
-            {
-                RunId = Guid.NewGuid().ToString("N"),
-                StartedAt = Now(),
-                UpdatedAt = Now(),
-            };
-
             // Non-assigning: skip upgrades on cards we haven't seen enter
             // the deck. This is what fixes the "starters begin at #5" bug
             // — the game fires UpgradeInternal on template/preview cards
             // at run init, and we'd previously assign them fresh numbers,
             // burning the counter before real starters arrived. Now we
             // silently ignore those.
+            //
+            // Gate BEFORE the lazy run mint: the game also fires
+            // UpgradeInternal on template cards during save deserialization,
+            // when _currentRun may be null. Minting first created a phantom
+            // in_progress run that OnRunStarted then saved. Return first so an
+            // untracked card never mints anything.
             if (!TryGetInstanceId(card, out var instanceId)) return;
+
+            // Lazy run-creation guard — upgrade could fire before RunStarted
+            // if the mod hot-loaded mid-run and missed the signal. We still
+            // want to record the event.
+            EnsureLazyCurrentRunLocked();
             var canonical = Canonical(card);
             var newLevel = canonical.CurrentUpgradeLevel;
             var floor = RunManager.Instance.State?.TotalFloor;
@@ -3886,12 +3920,7 @@ public static class RunTracker
 
             _shivAvailableThisRun = true;
 
-            _currentRun ??= new RunData
-            {
-                RunId = Guid.NewGuid().ToString("N"),
-                StartedAt = Now(),
-                UpdatedAt = Now(),
-            };
+            EnsureLazyCurrentRunLocked();
             _pendingCombat ??= new PendingCombat();
 
             bool alreadyRecorded =
@@ -4014,12 +4043,7 @@ public static class RunTracker
                 CoreMain.LogDebug($"RecordSovereignBladeGenerated clone failed: {e.Message}");
             }
 
-            _currentRun ??= new RunData
-            {
-                RunId = Guid.NewGuid().ToString("N"),
-                StartedAt = Now(),
-                UpdatedAt = Now(),
-            };
+            EnsureLazyCurrentRunLocked();
             _pendingCombat ??= new PendingCombat();
 
             var existingEvent = _pendingCombat.CombatEvents
@@ -4050,12 +4074,7 @@ public static class RunTracker
         {
             _sovereignBladeAvailableThisRun = true;
 
-            _currentRun ??= new RunData
-            {
-                RunId = Guid.NewGuid().ToString("N"),
-                StartedAt = Now(),
-                UpdatedAt = Now(),
-            };
+            EnsureLazyCurrentRunLocked();
             _pendingCombat ??= new PendingCombat();
 
             bool alreadyRecorded =

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -738,6 +738,11 @@ public static class RunTracker
         _pendingGremlinHornDrawAttributions.Clear();
         _lastPrismaticGemEnergyRoundNumber = null;
         _pendingCloakClaspBlockAttribution = false;
+        // Bone Flute's only other disarm is a racing thread-pool ContinueWith;
+        // if the killing Osty attack abandons that task, a stale armed flag
+        // would credit the next combat's first Defend to Bone Flute. Reset it
+        // at the combat boundary like its sibling one-shots.
+        _pendingBoneFluteBlockAttribution = false;
         _pendingMakeItSoSummons.Clear();
         _pendingReplayExtraPlaySources.Clear();
         _pendingReplayExtraPlaySeriesStarted.Clear();
@@ -1370,7 +1375,6 @@ public static class RunTracker
     /// by later milestones.
     /// </summary>
     private static int _observeCount;
-    private static readonly Dictionary<string, int> _typeCountDiag = new();
     public static void Observe(object entry)
     {
         try
@@ -1378,24 +1382,12 @@ public static class RunTracker
             var n = System.Threading.Interlocked.Increment(ref _observeCount);
 
             // Debug-level: per-event trace. Silent in production, verbose
-            // when CUS_DEBUG is set.
+            // when CUS_DEBUG is set. (The always-on [CUS-diag] type-count and
+            // first-500 dumps that lived here were a temporary draw-tracking
+            // probe — the question is resolved and documented in the primer,
+            // and the backing counter was the one tracker static mutated
+            // outside _lock, so it was removed.)
             CoreMain.LogDebug($"Observe #{n}: {entry.GetType().Name}");
-
-            // Temporary diagnostic for draw-tracking bug. Logs the first
-            // 500 entries per Core load, every CardDrawnEntry always, and a
-            // type-count summary every 50 entries so we can spot whether
-            // CardDrawnEntry ever shows up in the distribution.
-            var typeName = entry.GetType().Name;
-            _typeCountDiag.TryGetValue(typeName, out var typeN);
-            _typeCountDiag[typeName] = typeN + 1;
-            if (entry is CardDrawnEntry || entry is CardPlayFinishedEntry || n <= 500 || n % 500 == 0)
-                CoreMain.Logger.Info($"[CUS-diag] Observe #{n}: {typeName}");
-            if (n % 50 == 0)
-            {
-                var counts = string.Join(", ", _typeCountDiag.OrderBy(kv => kv.Key)
-                    .Select(kv => $"{kv.Key}={kv.Value}"));
-                CoreMain.Logger.Info($"[CUS-diag] types-so-far (n={n}): {counts}");
-            }
 
             switch (entry)
             {
@@ -1412,10 +1404,8 @@ public static class RunTracker
                     RecordCardPlay(cpf.CardPlay);
                     break;
                 case CardDrawnEntry cde:
-                    // Diagnostic always-on while we're validating draw tracking.
-                    // If we're seeing this line in logs, the hook works. If we're
-                    // not, CombatHistory.Add postfix isn't firing for draws (unusual).
-                    CoreMain.Logger.Info($"CardDrawnEntry card='{cde.Card?.Title ?? "null"}' fromHandDraw={cde.FromHandDraw}");
+                    // Draw-hook validation is complete; keep the trace debug-gated.
+                    CoreMain.LogDebug($"CardDrawnEntry card='{cde.Card?.Title ?? "null"}' fromHandDraw={cde.FromHandDraw}");
                     if (cde.Card != null) RecordCardDrawn(cde);
                     break;
                 case CardDiscardedEntry cdisc when cdisc.Card != null:
@@ -4948,8 +4938,14 @@ public static class RunTracker
                     && target != null
                     && !target.IsPlayer)
                     RecordPoisonApplicationLocked(target, instanceId, entry.Power, entry.Amount);
-                else
+                else if (entry.Amount > 0m)
                 {
+                    // Only positive applications count. The game fires
+                    // History.PowerReceived even for Artifact-zeroed (amount==0)
+                    // and debuff-consuming (negative) deltas; without this guard
+                    // an Artifact-eaten stack showed as both "applied" and
+                    // "blocked by Artifact", and negatives drove TotalAmountApplied
+                    // below zero.
                     var effect = GetOrCreateAppliedEffect(agg, entry.Power);
                     effect.TimesApplied++;
                     effect.TotalAmountApplied += entry.Amount;

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Available only on in-run deck-view surfaces for now (not Compendium - lifetime a
 
 Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, blocked-draw attempt/reason tracking, Regent star-resource tracking, forge granted tracking, recurring summon-to-hand tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution including stacked Noxious Fumes contributor preservation.
 
-Open: [#10 Run outcome detection](https://github.com/romaine-life/spirelens/issues/10) - non-blocking for M1-M3, required before M6.
+Run outcome detection (win/loss/abandoned) is implemented ([#10](https://github.com/romaine-life/spirelens/issues/10), closed) via the run-history entry hook.
 
 ## Storage
 

--- a/Tests/SpireLens.Core.Tests/AggregateDriftTests.cs
+++ b/Tests/SpireLens.Core.Tests/AggregateDriftTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Reflection-exhaustive drift guard for the aggregate merge/clone functions.
+///
+/// The recurring bug class in this codebase (the doubled relic Activations bug,
+/// omitted-field-on-merge/clone/pool) comes from hand-maintained parallel field
+/// lists. These tests populate EVERY field of each aggregate with a distinct
+/// value and assert:
+///   - Clone(src) == src                    (a clone omitting a field fails)
+///   - Merge(new, src) == src               (a merge omitting a field leaves it
+///                                            default; a merge adding a field
+///                                            TWICE leaves it doubled — both fail)
+/// so any field added to an aggregate but not to its merge/clone fails the day
+/// it is added. Add new aggregate stat fields to the Merge*Into functions only;
+/// the clones delegate to them.
+/// </summary>
+public class AggregateDriftTests
+{
+    // Per-test incrementing seed → every populated field gets a distinct value.
+    // xUnit runs tests within a class sequentially, so a static seed is safe;
+    // each test resets it.
+    private int _seed;
+
+    private object? MakeScalar(Type t)
+    {
+        _seed++;
+        if (t == typeof(int) || t == typeof(int?)) return _seed;
+        if (t == typeof(long) || t == typeof(long?)) return (long)_seed;
+        if (t == typeof(decimal) || t == typeof(decimal?)) return _seed + 0.5m;
+        if (t == typeof(bool) || t == typeof(bool?)) return true;
+        if (t == typeof(string)) return "s" + _seed;
+        return null; // unhandled type → left at default (e.g. SerializableCard)
+    }
+
+    private void Populate(object obj, ISet<string> skip)
+    {
+        foreach (var p in obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (skip.Contains(p.Name)) continue;
+            var t = p.PropertyType;
+
+            if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+            {
+                var valType = t.GetGenericArguments()[1];
+                var dict = (IDictionary?)p.GetValue(obj);
+                if (dict == null)
+                {
+                    dict = (IDictionary)Activator.CreateInstance(t)!;
+                    if (p.CanWrite) p.SetValue(obj, dict);
+                }
+                var inner = Activator.CreateInstance(valType)!;
+                Populate(inner, skip);
+                dict[$"k{++_seed}"] = inner;
+                continue;
+            }
+
+            var v = MakeScalar(t);
+            if (v != null && p.CanWrite) p.SetValue(obj, v);
+        }
+    }
+
+    // Compare SCALAR accumulating fields only. The inner reason/status
+    // dictionaries are deliberately excluded: their merge helpers legitimately
+    // re-key by an inner id field (so an arbitrary test key wouldn't survive),
+    // and they have their own dedicated bucket tests. The scalar fields are
+    // where the drift class lives (the doubled-Activations bug was a scalar).
+    private static string ScalarJson(object o)
+    {
+        foreach (var p in o.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var t = p.PropertyType;
+            if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+                ((IDictionary?)p.GetValue(o))?.Clear();
+        }
+        return JsonSerializer.Serialize(o, RunStorage.Options);
+    }
+
+    // Lineage/identity fields a merge intentionally does NOT accumulate.
+    private static readonly HashSet<string> CardLineage = new()
+    {
+        "FloorAdded", "InitialUpgradeLevel", "Removed", "RemovedAtFloor", "RemovedSnapshot",
+    };
+    // RemovedSnapshot is a game type we can't reflectively populate.
+    private static readonly HashSet<string> Unconstructable = new() { "RemovedSnapshot" };
+
+    [Fact]
+    public void CloneAggregate_CopiesEveryCardAggregateField()
+    {
+        _seed = 0;
+        var src = new CardAggregate();
+        Populate(src, Unconstructable);
+
+        var clone = RunTracker.CloneAggregate(src);
+
+        Assert.Equal(ScalarJson(src), ScalarJson(clone));
+    }
+
+    [Fact]
+    public void MergeAggregateInto_Empty_ReproducesEveryAccumulatingCardField()
+    {
+        _seed = 0;
+        var src = new CardAggregate();
+        Populate(src, CardLineage);
+
+        var target = new CardAggregate();
+        RunTracker.MergeAggregateInto(target, src);
+
+        Assert.Equal(ScalarJson(src), ScalarJson(target));
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_Empty_ReproducesEveryRelicField()
+    {
+        _seed = 0;
+        var src = new RelicAggregate();
+        Populate(src, new HashSet<string>());
+
+        var target = new RelicAggregate();
+        RunTracker.MergeRelicAggregateInto(target, src);
+
+        Assert.Equal(ScalarJson(src), ScalarJson(target));
+    }
+
+    [Fact]
+    public void CloneEnemyAggregate_CopiesEveryEnemyField()
+    {
+        _seed = 0;
+        var src = new EnemyAggregate();
+        Populate(src, new HashSet<string>());
+
+        var clone = RunTracker.CloneEnemyAggregate(src);
+
+        Assert.Equal(ScalarJson(src), ScalarJson(clone));
+    }
+
+    [Fact]
+    public void MergeEnemyAggregateInto_Empty_ReproducesEveryEnemyField()
+    {
+        _seed = 0;
+        var src = new EnemyAggregate();
+        Populate(src, new HashSet<string>());
+
+        var target = new EnemyAggregate();
+        RunTracker.MergeEnemyAggregateInto(target, src);
+
+        Assert.Equal(ScalarJson(src), ScalarJson(target));
+    }
+
+    [Fact]
+    public void RunStorageOptions_IncludeFields_SoPublicFieldsRoundTrip()
+    {
+        // Guards the RemovedSnapshot data-loss fix: the game's SerializableCard
+        // stores data in public fields, which only serialize with IncludeFields.
+        var probe = new FieldBackedProbe { Value = 7, Name = "keep" };
+        var json = JsonSerializer.Serialize(probe, RunStorage.Options);
+        Assert.Contains("\"value\"", json);
+        Assert.Contains("\"name\"", json);
+        var back = JsonSerializer.Deserialize<FieldBackedProbe>(json, RunStorage.Options)!;
+        Assert.Equal(7, back.Value);
+        Assert.Equal("keep", back.Name);
+    }
+
+    private sealed class FieldBackedProbe
+    {
+        public int Value;
+        public string? Name;
+    }
+}

--- a/Tests/SpireLens.Core.Tests/BlockTooltipTests.cs
+++ b/Tests/SpireLens.Core.Tests/BlockTooltipTests.cs
@@ -48,6 +48,7 @@ public class BlockTooltipTests
         Assert.Equal("[img=16x16]res://images/ui/combat/block.png[/img] gained", label);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void AppendCompactBody_UsesShieldIconForBlockRows()
     {
@@ -121,6 +122,7 @@ public class BlockTooltipTests
         Assert.Equal("Forge gained", label);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void AppendCompactBody_UsesDrawPowerIconForUnplayableDrawRows()
     {
@@ -138,6 +140,7 @@ public class BlockTooltipTests
         Assert.Contains("[b]4[/b]", text);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void AppendCompactBody_UsesEnergyPotionIconForEnergyRows()
     {
@@ -157,6 +160,7 @@ public class BlockTooltipTests
         Assert.Contains("[b]2[/b]", text);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void AppendCompactBody_UsesStarIconForStarRows()
     {
@@ -176,6 +180,7 @@ public class BlockTooltipTests
         Assert.Contains("[b]2[/b]", text);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void AppendCompactBody_UsesQuietTextForForgeRows()
     {

--- a/Tests/SpireLens.Core.Tests/CombatEndingDamageTests.cs
+++ b/Tests/SpireLens.Core.Tests/CombatEndingDamageTests.cs
@@ -1,0 +1,65 @@
+using System.Runtime.CompilerServices;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Pins the dedup contract behind the combat-ending killing-blow capture
+/// (HookAfterDamageGivenPatch → RunTracker.RecordCombatEndingSuppressedDamage):
+/// a DamageResult the game already emitted through CombatHistory must never be
+/// recorded a second time, and a suppressed one must be claimable exactly once.
+/// Observe() and the capture share one helper (TryMarkDamageResultObserved);
+/// first observation wins, every later observation of the same object loses.
+///
+/// DamageResult instances are materialized without running the game
+/// constructor (it requires a live Creature); the dedup set is
+/// reference-keyed, so field state is irrelevant.
+/// </summary>
+public class CombatEndingDamageTests
+{
+    private static DamageResult UnconstructedResult() =>
+        (DamageResult)RuntimeHelpers.GetUninitializedObject(typeof(DamageResult));
+
+    [Fact]
+    public void TryMark_UnseenResult_ClaimsExactlyOnce()
+    {
+        RunTracker.ClearObservedDamageResultsForTest();
+        var result = UnconstructedResult();
+
+        Assert.True(RunTracker.TryMarkDamageResultObserved(result));
+        Assert.False(RunTracker.TryMarkDamageResultObserved(result));
+    }
+
+    [Fact]
+    public void TryMark_ResultObservedThroughHistory_IsNotClaimableByCapture()
+    {
+        RunTracker.ClearObservedDamageResultsForTest();
+        var result = UnconstructedResult();
+
+        // Observe() marking the organic entry...
+        Assert.True(RunTracker.TryMarkDamageResultObserved(result));
+        // ...means the combat-ending capture loses the claim.
+        Assert.False(RunTracker.TryMarkDamageResultObserved(result));
+    }
+
+    [Fact]
+    public void TryMark_DistinctResults_AreIndependent()
+    {
+        RunTracker.ClearObservedDamageResultsForTest();
+        var emitted = UnconstructedResult();
+        var suppressed = UnconstructedResult();
+
+        Assert.True(RunTracker.TryMarkDamageResultObserved(emitted));
+
+        Assert.False(RunTracker.TryMarkDamageResultObserved(emitted));
+        Assert.True(RunTracker.TryMarkDamageResultObserved(suppressed));
+    }
+
+    [Fact]
+    public void TryMark_Null_IsNeverClaimable()
+    {
+        Assert.False(RunTracker.TryMarkDamageResultObserved(null));
+    }
+}

--- a/Tests/SpireLens.Core.Tests/OstySummonStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/OstySummonStatsTests.cs
@@ -62,6 +62,7 @@ public class OstySummonStatsTests
         Assert.Equal(11m, restored.MetaStats.TotalOstyDamageAbsorbed);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void Tooltip_OstySummonStats_FullViewShowsCardSummonsAndMetaAbsorbedDamage()
     {
@@ -86,6 +87,7 @@ public class OstySummonStatsTests
         Assert.Contains("[b]11[/b]", body);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void Tooltip_OstySummonStats_CompactSkipsSummonCount()
     {
@@ -106,6 +108,7 @@ public class OstySummonStatsTests
         Assert.DoesNotContain("Osty summons", body);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void Tooltip_OstySummonStats_MetaDamageCanShowOnUnplayedSummonCard()
     {

--- a/Tests/SpireLens.Core.Tests/PendingCombatPromotionTests.cs
+++ b/Tests/SpireLens.Core.Tests/PendingCombatPromotionTests.cs
@@ -1,0 +1,122 @@
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Pins the pending-combat → run promotion merge now shared by OnCombatEnded
+/// and OnRunEnded. The OnRunEnded call is what keeps a lost run's fatal combat
+/// (which never gets a CombatEnded) from being discarded with the buffer.
+/// </summary>
+public class PendingCombatPromotionTests
+{
+    [Fact]
+    public void Promote_MergesCardAggregatesAndEventsIntoEmptyRun()
+    {
+        var pending = new PendingCombat();
+        pending.CombatAggregates["CARD.DEATH_MARCH#1"] = new CardAggregate
+        {
+            Plays = 2,
+            TotalIntended = 47,
+            TotalEffective = 39,
+            TotalOverkill = 8,
+            Kills = 1,
+        };
+        pending.CombatEvents.Add(new CardEvent
+        {
+            Type = "damage_received",
+            CardId = "CARD.DEATH_MARCH#1",
+            Receiver = "MONSTER.FLYCONID",
+            Unblocked = 39,
+            Overkill = 8,
+            Killed = true,
+        });
+
+        var run = new RunData();
+        RunTracker.PromotePendingCombatIntoRun(pending, run);
+
+        var agg = run.Aggregates["CARD.DEATH_MARCH#1"];
+        Assert.Equal(2, agg.Plays);
+        Assert.Equal(47, agg.TotalIntended);
+        Assert.Equal(39, agg.TotalEffective);
+        Assert.Equal(8, agg.TotalOverkill);
+        Assert.Equal(1, agg.Kills);
+        Assert.Single(run.Events);
+        Assert.Equal("MONSTER.FLYCONID", run.Events[0].Receiver);
+    }
+
+    [Fact]
+    public void Promote_AddsOntoExistingCommittedAggregates()
+    {
+        var pending = new PendingCombat();
+        pending.CombatAggregates["CARD.STRIKE#1"] = new CardAggregate
+        {
+            Plays = 1,
+            TotalIntended = 9,
+            TotalEffective = 9,
+        };
+
+        var run = new RunData();
+        run.Aggregates["CARD.STRIKE#1"] = new CardAggregate
+        {
+            Plays = 3,
+            TotalIntended = 27,
+            TotalEffective = 20,
+            TotalBlocked = 7,
+        };
+
+        RunTracker.PromotePendingCombatIntoRun(pending, run);
+
+        var agg = run.Aggregates["CARD.STRIKE#1"];
+        Assert.Equal(4, agg.Plays);
+        Assert.Equal(36, agg.TotalIntended);
+        Assert.Equal(29, agg.TotalEffective);
+        Assert.Equal(7, agg.TotalBlocked);
+    }
+
+    [Fact]
+    public void Promote_MergesRelicAggregates_CountsActivationsOnce()
+    {
+        // Regression: the old inline merge added Activations twice
+        // (copy-paste duplicate line), doubling every relic's run totals.
+        var pending = new PendingCombat();
+        pending.RelicAggregates["RELIC.MEAL_TICKET"] = new RelicAggregate
+        {
+            Activations = 3,
+            EnergyGenerated = 2,
+        };
+
+        var run = new RunData();
+        RunTracker.PromotePendingCombatIntoRun(pending, run);
+
+        var relic = run.RelicAggregates["RELIC.MEAL_TICKET"];
+        Assert.Equal(3, relic.Activations);
+        Assert.Equal(2, relic.EnergyGenerated);
+    }
+
+    [Fact]
+    public void Promote_MergesEnemyAggregatesAndMetaStats()
+    {
+        var pending = new PendingCombat();
+        pending.EnemyAggregates["MONSTER.SHRINKER_BEETLE"] = new EnemyAggregate
+        {
+            EnemyId = "MONSTER.SHRINKER_BEETLE",
+            DisplayName = "Shrinker Beetle",
+            DamageInstances = 2,
+            DamageAttempted = 16,
+            DamageDealt = 11,
+            DamageBlocked = 5,
+        };
+        pending.MetaStats.TotalOstyDamageAbsorbed = 4;
+
+        var run = new RunData();
+        RunTracker.PromotePendingCombatIntoRun(pending, run);
+
+        var enemy = run.EnemyAggregates["MONSTER.SHRINKER_BEETLE"];
+        Assert.Equal(2, enemy.DamageInstances);
+        Assert.Equal(16, enemy.DamageAttempted);
+        Assert.Equal(11, enemy.DamageDealt);
+        Assert.Equal(5, enemy.DamageBlocked);
+        Assert.Equal(4, run.MetaStats.TotalOstyDamageAbsorbed);
+    }
+}

--- a/Tests/SpireLens.Core.Tests/ReplayStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/ReplayStatsTests.cs
@@ -91,6 +91,7 @@ public class ReplayStatsTests
         Assert.Equal("Burst", agg.ReplayExtraPlayReasons["power:POWER.BURST"].DisplayName);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void IsReplayExtraPlay_UsesNonzeroPlayIndex()
     {

--- a/Tests/SpireLens.Core.Tests/RunAdoptionTests.cs
+++ b/Tests/SpireLens.Core.Tests/RunAdoptionTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Pins the ghost-aggregate pruning that runs when a run is adopted (main-menu
+/// Continue re-fire, Continue after game restart, or hot-reload resume).
+///
+/// Ghosts are the empty arrival stamps minted when CardEnterDeckPatch fires
+/// before RunStarted on a continue-load: fresh CardModel refs get brand-new
+/// instance numbers continuing the old counters (e.g. DEATH_MARCH#3/#4 for a
+/// two-copy deck) before the adoption rebind can map them back to #1/#2.
+/// Pruning must remove exactly those and nothing with recorded history.
+/// </summary>
+public class RunAdoptionTests
+{
+    private static CardAggregate GhostStamp() => new()
+    {
+        FloorAdded = 10,
+        InitialUpgradeLevel = 1,
+    };
+
+    private static RunData RunWithGhosts()
+    {
+        var run = new RunData
+        {
+            DefCounters = new Dictionary<string, int> { ["CARD.DEATH_MARCH"] = 2 },
+        };
+        run.Aggregates["CARD.DEATH_MARCH#1"] = new CardAggregate { Plays = 6, TotalEffective = 60 };
+        run.Aggregates["CARD.DEATH_MARCH#2"] = new CardAggregate { Plays = 3, TotalEffective = 72 };
+        run.Aggregates["CARD.DEATH_MARCH#3"] = GhostStamp();
+        run.Aggregates["CARD.DEATH_MARCH#4"] = GhostStamp();
+        return run;
+    }
+
+    private static HashSet<string> Live(params string[] ids) => new(ids);
+
+    [Fact]
+    public void Prune_RemovesEmptyUnmappedStampsBeyondSavedCounter()
+    {
+        var run = RunWithGhosts();
+
+        int pruned = RunTracker.PruneGhostAggregates(
+            run, run.DefCounters, Live("CARD.DEATH_MARCH#1", "CARD.DEATH_MARCH#2"));
+
+        Assert.Equal(2, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.DEATH_MARCH#1"));
+        Assert.True(run.Aggregates.ContainsKey("CARD.DEATH_MARCH#2"));
+        Assert.False(run.Aggregates.ContainsKey("CARD.DEATH_MARCH#3"));
+        Assert.False(run.Aggregates.ContainsKey("CARD.DEATH_MARCH#4"));
+    }
+
+    [Fact]
+    public void Prune_KeepsAggregatesWithinSavedCounter()
+    {
+        // An empty, unmapped stamp at or below the saved counter predates the
+        // last save — e.g. a card that entered the deck and was legitimately
+        // saved before ever being drawn. Never prune those.
+        var run = new RunData
+        {
+            DefCounters = new Dictionary<string, int> { ["CARD.STRIKE"] = 3 },
+        };
+        run.Aggregates["CARD.STRIKE#3"] = GhostStamp();
+
+        int pruned = RunTracker.PruneGhostAggregates(run, run.DefCounters, Live());
+
+        Assert.Equal(0, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.STRIKE#3"));
+    }
+
+    [Fact]
+    public void Prune_KeepsLiveMappedNumbers()
+    {
+        // A number beyond the saved counter that IS bound to a live card is a
+        // legitimately-added card whose save just hadn't happened yet.
+        var run = new RunData
+        {
+            DefCounters = new Dictionary<string, int> { ["CARD.STRIKE"] = 2 },
+        };
+        run.Aggregates["CARD.STRIKE#3"] = GhostStamp();
+
+        int pruned = RunTracker.PruneGhostAggregates(run, run.DefCounters, Live("CARD.STRIKE#3"));
+
+        Assert.Equal(0, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.STRIKE#3"));
+    }
+
+    [Fact]
+    public void Prune_KeepsAggregatesWithRecordedActivity()
+    {
+        var run = new RunData
+        {
+            DefCounters = new Dictionary<string, int> { ["CARD.STRIKE"] = 2 },
+        };
+        run.Aggregates["CARD.STRIKE#3"] = new CardAggregate { TimesDrawn = 1 };
+
+        int pruned = RunTracker.PruneGhostAggregates(run, run.DefCounters, Live());
+
+        Assert.Equal(0, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.STRIKE#3"));
+    }
+
+    [Fact]
+    public void Prune_KeepsAggregatesReferencedByEvents()
+    {
+        var run = new RunData
+        {
+            DefCounters = new Dictionary<string, int> { ["CARD.STRIKE"] = 2 },
+        };
+        run.Aggregates["CARD.STRIKE#3"] = GhostStamp();
+        run.Events.Add(new CardEvent { Type = "card_upgraded", CardId = "CARD.STRIKE#3" });
+
+        int pruned = RunTracker.PruneGhostAggregates(run, run.DefCounters, Live());
+
+        Assert.Equal(0, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.STRIKE#3"));
+    }
+
+    [Fact]
+    public void Prune_KeepsRemovedAggregates()
+    {
+        var run = new RunData
+        {
+            DefCounters = new Dictionary<string, int> { ["CARD.STRIKE"] = 2 },
+        };
+        run.Aggregates["CARD.STRIKE#3"] = new CardAggregate { Removed = true, RemovedAtFloor = 5 };
+
+        int pruned = RunTracker.PruneGhostAggregates(run, run.DefCounters, Live());
+
+        Assert.Equal(0, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.STRIKE#3"));
+    }
+
+    [Fact]
+    public void Prune_MissingDefCounters_StillGuardedByLiveSetAndActivity()
+    {
+        // Files without counters for a def (or legacy nulls) fall back to a
+        // zero counter — pruning then rests entirely on the live-map, event,
+        // and emptiness guards.
+        var run = new RunData();
+        run.Aggregates["CARD.FETCH#1"] = new CardAggregate { Plays = 4 };
+        run.Aggregates["CARD.FETCH#2"] = GhostStamp();
+
+        int pruned = RunTracker.PruneGhostAggregates(run, null, Live("CARD.FETCH#1"));
+
+        Assert.Equal(1, pruned);
+        Assert.True(run.Aggregates.ContainsKey("CARD.FETCH#1"));
+        Assert.False(run.Aggregates.ContainsKey("CARD.FETCH#2"));
+    }
+}

--- a/Tests/SpireLens.Core.Tests/RunTrackerDamageMathTests.cs
+++ b/Tests/SpireLens.Core.Tests/RunTrackerDamageMathTests.cs
@@ -28,4 +28,22 @@ public class RunTrackerDamageMathTests
         Assert.Equal(12, totals.IntendedDamage);
         Assert.Equal(7, totals.EffectiveDamage);
     }
+
+    // The lethal-overkill case is the shared convention behind the poison
+    // killing-tick fix: a 10-poison tick on a 4-HP enemy reports unblocked=4
+    // (HP actually lost) and overkill=6 (disjoint excess). Effective is the 4
+    // HP removed, intended is the full 10. Poison attribution now routes
+    // through this helper, so pinning it here covers TryRecordPoisonTickDamage,
+    // RecordDamageFromCard, and enemy damage with one convention.
+    [Fact]
+    public void ComputeEnemyDamageTotals_LethalOverkill_EffectiveIsHpLost_IntendedIsFullTick()
+    {
+        var totals = RunTracker.ComputeEnemyDamageTotals(
+            blockedDamage: 0,
+            unblockedDamage: 4,
+            overkillDamage: 6);
+
+        Assert.Equal(10, totals.IntendedDamage);
+        Assert.Equal(4, totals.EffectiveDamage);
+    }
 }

--- a/Tests/SpireLens.Core.Tests/UnleashStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/UnleashStatsTests.cs
@@ -54,6 +54,7 @@ public class UnleashStatsTests
         Assert.Equal(3, agg.TimesOstyHpAttackBonusApplied);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void Tooltip_UnleashStats_ShowTotalAndAverage()
     {
@@ -73,6 +74,7 @@ public class UnleashStatsTests
         Assert.Contains("[b]12.5[/b]", body);
     }
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void Tooltip_UnleashStats_CompactShowsTotalOnly()
     {

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -57,22 +57,27 @@ When adding a hook:
 
 SpireLens persistence is combat-boundary based.
 
-- `RunManager.Instance.RunStarted` starts a new run record.
+- `RunManager.Instance.RunStarted` starts a new run record — or resumes one; see below.
 - `CombatManager.Instance.CombatSetUp` creates `_pendingCombat`.
 - During combat, live observations accumulate in `_pendingCombat`.
 - `CombatManager.Instance.CombatEnded` promotes pending aggregates/events into committed `RunData`, updates run metadata, saves, and clears `_pendingCombat`.
+- `RunTracker.OnRunEnded` also promotes `_pendingCombat` before stamping the outcome — for the `loss` outcome only. Loss ordering (decompiled `CreatureCmd.Kill` → `LoseCombat()` → `RunManager.OnEnded`): `OnRunEnded` runs synchronously from the killing action, and the fatal combat's `CombatEnded` only fires LATER via `ProcessPendingLoss` — after the buffer has been consumed. Without this second promotion site the fatal combat's stats would be discarded. Abandoning mid-combat still discards the buffer (a half-played fight is not a resolved combat — a save-and-quit may even have rolled it back), and wins always get a normal `CombatEnded` first. Promotion is idempotent per buffer (the buffer is nulled after), so the two sites cannot double-promote. `RecordCombatEndingSuppressedDamage` stops capturing once `_currentRun` is null so the post-`OnRunEnded` damage tail can't resurrect the buffer and mint a junk run file at that deferred `CombatEnded`.
 - Between-combat and between-floor reloads are supported.
 - Mid-combat restore is intentionally out of scope.
 
-This distinction is easy to blur because tooltips merge committed and pending data for immediate display. That merged view is for UI only. The permanent run file is not promoted until combat ends.
+This distinction is easy to blur because tooltips merge committed and pending data for immediate display. That merged view is for UI only. The permanent run file is not promoted until combat ends — or, for the final combat of a lost run, until the run ends.
 
-When implementing new combat attribution, write it into `_pendingCombat` first unless the event is truly outside combat, such as card arrival/removal/upgrade lineage. Promotion should stay centralized at combat end.
+`RunStarted` does NOT always mean a new run. The game re-fires `RunManager.RunStarted` with the SAME `RunManager._startTime` every time a saved run is continued from the main menu (log line: "Continuing run with character"). `RunTracker.OnRunStarted` therefore treats a matching in-progress `game_start_time` as a continuation: it keeps the in-memory `RunData` (or, after a full game restart, adopts the newest resumable on-disk record via `RunStorage.FindByGameStartTime`) and rebinds card identity through `AdoptRunLocked` instead of minting a fresh run file. Historic builds minted a fresh `RunData` here, which stranded all previously committed stats in orphaned files and reset tooltips to zero mid-run.
+
+When implementing new combat attribution, write it into `_pendingCombat` first unless the event is truly outside combat, such as card arrival/removal/upgrade lineage. Promotion should stay centralized in `PromotePendingCombatIntoRun` and its two callers.
 
 ## RunStarted Is Not Deck-Ready
 
 Do not use `RunStarted` as the source of truth for starter deck population.
 
 Earlier code tried to walk `player.Deck.Cards` at `RunStarted`, but fresh runs had a timing race: the deck was not always populated yet. The durable hook is `CardPile.AddInternal` filtered to `PileType.Deck`, implemented by `CardEnterDeckPatch`.
+
+Continue-loads make the ordering worse: when a saved run is continued from the main menu, the game repopulates the deck with brand-new `CardModel` refs, and `CardPile.AddInternal` can fire BEFORE or AFTER the `RunStarted` re-fire — neither order is guaranteed. Observed consequence of the before-ordering: `CardEnterDeckPatch` stamps the fresh refs with brand-new instance numbers continuing the old counters (ghost aggregates like `CARD.DEATH_MARCH#3/#4` for a two-copy deck) before run adoption can rebind them. `AdoptRunLocked` handles both orderings with one mechanism: it seeds the saved `InstanceNumbersByDef` snapshot into `_pendingRankRestores` (per-def queues in deck-rank order), walks whatever portion of the deck already exists through `GetOrAssignNumber` (which claims queued numbers in arrival order before minting), leaves the rest queued for later `CardEnterDeckPatch` arrivals, and prunes the ghost stamps afterward via `PruneGhostAggregates`. Known assumption (shared with the hot-reload deck walk): repopulation arrival order matches `player.Deck.Cards` enumeration order at save time — if the game ever repopulates same-def copies out of deck order, two copies of the same def would silently swap stats. `CaptureInstanceNumbersByDeckRank` includes still-queued numbers in every snapshot, so a save during adoption cannot strand them; queues left unclaimed at combat setup are discarded with an always-on log line.
 
 `CardPile.AddInternal` catches:
 
@@ -199,6 +204,8 @@ SpireLens definitions:
 Effective damage is the user-facing total damage because it is the HP actually removed. Intended damage is useful internally and for waste percentages.
 
 Known trap: an attack can play and produce no damage event, for example if the target is already dead/not fully removed or if no damage is actually received. Tooltip code treats a played attack with zero intended damage as a real but zero-damage case rather than inventing damage.
+
+Known trap — combat-ending killing blows: `DamageReceivedEntry` is NOT complete. In decompiled `CreatureCmd.Damage`, HP loss (`LoseHpInternal`) is applied BEFORE the emission gate `if (CombatManager.Instance.IsInProgress && !CombatManager.Instance.IsEnding) History.DamageReceived(...)`, and `CombatManager.IsEnding` is a live computed property that flips true the moment no living primary enemy remains — so the hit that kills the last enemy suppresses its own history entry and never reaches `CombatHistory.Add`. Mid-combat kills (another enemy still alive) emit normally. Scaling finishers systematically lose their biggest hits to this (diagnosed 2026-07-02 with Death March: 5/5 combat-ending kills unrecorded, all mid-combat hits recorded). SpireLens closes the gap with `HookAfterDamageGivenPatch`: `Hook.AfterDamageGiven` is dispatched directly by the game (its own doc comment: it "fires from the same damage event that ends combat (the killing hit), so it must still resolve for that hit"), fires after the possible emission for the same `DamageResult`, and runs before `Kill()` triggers `CombatEnded`. `RunTracker.RecordCombatEndingSuppressedDamage` synthesizes the missing `DamageReceivedEntry` (never touching the game's own history) only when `IsEnding` is true AND the `DamageResult` reference wasn't already observed via `CombatHistory.Add` — dedup is by result-object reference through `TryMarkDamageResultObserved`. Deliberate scope note: this captures ALL history-suppressed damage in the ending window, not only the killing blow itself — e.g. thorns or residual hits that really applied HP loss while combat wound down. That is the observed-outcomes principle: the damage genuinely happened (`LoseHpInternal` ran); only the game's history omitted it. Damage that never applied produces no `Hook.AfterDamageGiven` dispatch and is never invented.
 
 Player self-damage is tracked as HP lost from playing a card and uses observed unblocked damage after reductions. That is the real cost, not the text value.
 
@@ -449,7 +456,8 @@ specific blocker ids as they are discovered. See [ADR 0002](adr/0002-healing-att
 
 Good hook surfaces already proven useful:
 
-- `CombatHistory.Add`: broad real-entry observation point.
+- `CombatHistory.Add`: broad real-entry observation point. Caveat: does NOT see damage from combat-ending killing blows (see the Damage Attribution known trap).
+- `Hook.AfterDamageGiven`: fires for every `DamageResult` including the killing hit that ends combat (game dispatches it directly, bypassing the combat-hook guard); the surface used to capture history-suppressed combat-ending damage.
 - `Hook.AfterCardDrawn`: reliable card draw arrival.
 - `Hook.ShouldDraw`: draw attempts and blocked draw modifier.
 - `Hook.AfterCardChangedPiles`: final pile result.


### PR DESCRIPTION
Runs the C# unit suite on GitHub's Linux runners against the checked-in lib/ stubs, so the deterministic gate no longer depends on the laptop. First run is unfiltered to diagnose headless behavior; will filter/tag any Linux-only failures. Addresses #258.