### PR TITLE
Backlog burndown: repair-254 data-loss, PatchGuard, hygiene, block-ledger coverage (#254/#261/#257/#262)

### DIFF
--- a/Api/SpireLensApiRegistry.cs
+++ b/Api/SpireLensApiRegistry.cs
@@ -17,7 +17,18 @@ public static class SpireLensApiRegistry
 
     private sealed class ReflectionBackedSpireLensApi : ISpireLensApi
     {
-        private static readonly JsonSerializerOptions JsonOptions = new();
+        // Match the canonical on-disk run-file wire format so API consumers
+        // read the same shape as the JSON files (snake_case, nulls omitted,
+        // public fields included). Mirrors Core's RunStorage.Options, which the
+        // Loader assembly can't reference directly across the reflection
+        // boundary. Used for aggregate snapshots; the full run goes through the
+        // Core-side locked serializer below.
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            IncludeFields = true,
+        };
 
         public bool IsCoreLoaded => ResolveLatestCoreType("SpireLens.Core.RunTracker") != null;
 
@@ -28,6 +39,15 @@ public static class SpireLensApiRegistry
 
         public string? GetCurrentRunJson()
         {
+            // Serialize inside Core under RunTracker's lock and in the canonical
+            // wire format, rather than fetching the live ref and serializing it
+            // here (which raced OnCombatEnded promotion and emitted PascalCase).
+            var method = ResolveLatestCoreType("SpireLens.Core.RunTracker")
+                ?.GetMethod("SerializeCurrentRunJson", BindingFlags.Public | BindingFlags.Static);
+            if (method != null)
+                return (string?)method.Invoke(null, null);
+
+            // Fallback for an older Core without the locked serializer.
             var currentRun = ResolveLatestCoreType("SpireLens.Core.RunTracker")
                 ?.GetProperty("Current", BindingFlags.Public | BindingFlags.Static)
                 ?.GetValue(null);

--- a/Core/PatchGuard.cs
+++ b/Core/PatchGuard.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+
+namespace SpireLens.Core;
+
+/// <summary>
+/// Wraps a Harmony patch body so an unhandled exception is caught, logged, and
+/// rate-limited per call site — it never propagates back into game code.
+///
+/// Two problems this fixes across the ~60 patch classes:
+///   1. Most patches swallowed exceptions into <see cref="CoreMain.LogDebug"/>,
+///      which is a no-op unless the debug flag is on — so a patch that silently
+///      broke after a Slay the Spire 2 update left no trace. PatchGuard logs at
+///      always-on Error level instead, so a broken hook is visible by default.
+///   2. A few sites (the combat-history master hook, per-frame turn hooks) fire
+///      dozens of times a turn. A naive always-on log would flood godot.log if
+///      one started throwing every call. PatchGuard logs the first failure per
+///      site immediately, then at most once per <see cref="ThrottleWindow"/>,
+///      folding the suppressed count into the next surfaced line.
+/// </summary>
+internal static class PatchGuard
+{
+    /// <summary>
+    /// After a site's first Error, further Errors for that site are suppressed
+    /// until this much time has elapsed. Internal + mutable so the convention
+    /// test can shrink it; the default keeps a wedged hot hook to ~2 lines/min.
+    /// </summary>
+    internal static TimeSpan ThrottleWindow = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Injectable clock. Defaults to wall time; the convention test swaps it for
+    /// a deterministic one so throttle behavior is exercised without sleeping.
+    /// </summary>
+    internal static Func<DateTime> Clock = () => DateTime.UtcNow;
+
+    /// <summary>
+    /// Injectable log sink. Defaults to the always-on Error logger; the test
+    /// swaps it to count surfaced-vs-throttled lines without scraping stderr.
+    /// </summary>
+    internal static Action<string> LogSink = msg => CoreMain.Logger.Error(msg);
+
+    private static readonly object _gate = new();
+    private static readonly Dictionary<string, SiteState> _sites = new();
+
+    private sealed class SiteState
+    {
+        public bool HasLogged;
+        public DateTime LastLogged;
+        public long SuppressedSinceLast;
+    }
+
+    /// <summary>
+    /// Run a patch body, swallowing and rate-logging any exception so it never
+    /// escapes into the game. <paramref name="site"/> identifies the call site
+    /// for both throttling and the log line — pass a stable string (typically
+    /// the patch class name).
+    /// </summary>
+    public static void Run(string site, Action body)
+    {
+        try
+        {
+            body();
+        }
+        catch (Exception e)
+        {
+            Report(site, e);
+        }
+    }
+
+    private static void Report(string site, Exception e)
+    {
+        bool shouldLog;
+        long suppressed = 0;
+
+        lock (_gate)
+        {
+            if (!_sites.TryGetValue(site, out var state))
+            {
+                state = new SiteState();
+                _sites[site] = state;
+            }
+
+            var now = Clock();
+            if (!state.HasLogged || now - state.LastLogged >= ThrottleWindow)
+            {
+                shouldLog = true;
+                suppressed = state.SuppressedSinceLast;
+                state.SuppressedSinceLast = 0;
+                state.LastLogged = now;
+                state.HasLogged = true;
+            }
+            else
+            {
+                shouldLog = false;
+                state.SuppressedSinceLast++;
+            }
+        }
+
+        if (!shouldLog) return;
+
+        var suffix = suppressed > 0 ? $" ({suppressed} similar suppressed)" : string.Empty;
+        LogSink($"[PatchGuard] {site} threw: {e}{suffix}");
+    }
+
+    /// <summary>Test isolation for the per-site throttle state, clock, and sink.</summary>
+    internal static void ResetForTest()
+    {
+        lock (_gate)
+        {
+            _sites.Clear();
+            ThrottleWindow = TimeSpan.FromSeconds(30);
+            Clock = () => DateTime.UtcNow;
+            LogSink = msg => CoreMain.Logger.Error(msg);
+        }
+    }
+}

--- a/Core/Patches/AkabekoStatsPatch.cs
+++ b/Core/Patches/AkabekoStatsPatch.cs
@@ -24,16 +24,12 @@ public static class AkabekoAfterSideTurnStartPatch
     [HarmonyPrefix]
     public static void Prefix(CombatSide side, ICombatState combatState)
     {
-        try
+        PatchGuard.Run(nameof(AkabekoAfterSideTurnStartPatch), () =>
         {
             if (side != CombatSide.Player) return;
             if (combatState == null || combatState.RoundNumber != 1) return;
             RunTracker.ArmAkabekoVigorAttribution();
-        }
-        catch (Exception e)
-        {
-            CoreMain.LogDebug($"AkabekoAfterSideTurnStartPatch failed: {e.Message}");
-        }
+        });
     }
 }
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -579,9 +579,9 @@ public static class CardHoverShowPatch
                      .OrderByDescending(r => r.Count)
                      .ThenBy(r => r.DisplayName))
         {
-            var displayName = string.IsNullOrWhiteSpace(reason.DisplayName)
+            var displayName = StatsTooltip.EscapeBbcode(string.IsNullOrWhiteSpace(reason.DisplayName)
                 ? reason.ReasonId
-                : reason.DisplayName;
+                : reason.DisplayName);
             Row3(sb, $"Replay from {displayName}", reason.Count.ToString(), "");
         }
 
@@ -593,9 +593,9 @@ public static class CardHoverShowPatch
                      .OrderByDescending(r => r.Count)
                      .ThenBy(r => r.DisplayName))
         {
-            var displayName = string.IsNullOrWhiteSpace(reason.DisplayName)
+            var displayName = StatsTooltip.EscapeBbcode(string.IsNullOrWhiteSpace(reason.DisplayName)
                 ? reason.ReasonId
-                : reason.DisplayName;
+                : reason.DisplayName);
             Row3(sb, $"No damage from {displayName}", reason.Count.ToString(), "");
         }
     }
@@ -922,7 +922,10 @@ public static class CardHoverShowPatch
 
     private static string GetAppliedEffectLabel(AppliedEffectAggregate effect)
     {
-        var label = string.IsNullOrWhiteSpace(effect.DisplayName) ? effect.EffectId : effect.DisplayName;
+        // Escape the game/data-derived name before it lands in a BBCode cell:
+        // a display name containing '[' would otherwise be parsed as markup.
+        var label = StatsTooltip.EscapeBbcode(
+            string.IsNullOrWhiteSpace(effect.DisplayName) ? effect.EffectId : effect.DisplayName);
         if (!string.IsNullOrWhiteSpace(effect.IconPath))
             return GetInlineIconStatLabel(effect.IconPath, label);
         if (IsEnergyEffect(effect))
@@ -983,7 +986,7 @@ public static class CardHoverShowPatch
 
     private static string GetBlockedDrawReasonLabel(string reasonDisplayName)
     {
-        return GetBlockedDrawStatLabel($"blocked by {reasonDisplayName}");
+        return GetBlockedDrawStatLabel($"blocked by {StatsTooltip.EscapeBbcode(reasonDisplayName)}");
     }
 
     private static bool IsEnergyEffect(AppliedEffectAggregate effect)

--- a/Core/Patches/CombatHistoryAddPatch.cs
+++ b/Core/Patches/CombatHistoryAddPatch.cs
@@ -22,9 +22,13 @@ public static class CombatHistoryAddPatch
 {
     // Postfix runs after the entry is already appended to CombatHistory._entries,
     // so we know the entry survived the game's own logic and is "real."
+    //
+    // This is the single busiest hook — every combat event flows through it, so
+    // a throw here must never reach the game's dispatch loop. PatchGuard swallows
+    // it, surfaces the first failure at Error level, then throttles the rest.
     [HarmonyPostfix]
     public static void Postfix(CombatHistoryEntry entry)
     {
-        RunTracker.Observe(entry);
+        PatchGuard.Run(nameof(CombatHistoryAddPatch), () => RunTracker.Observe(entry));
     }
 }

--- a/Core/Patches/EnemyHoverTooltipPatch.cs
+++ b/Core/Patches/EnemyHoverTooltipPatch.cs
@@ -75,9 +75,9 @@ public static class EnemyHoverShowPatch
                      .ThenBy(card => card.DisplayName))
         {
             if (card.Count <= 0) continue;
-            var label = string.IsNullOrWhiteSpace(card.DisplayName)
+            var label = StatsTooltip.EscapeBbcode(string.IsNullOrWhiteSpace(card.DisplayName)
                 ? RunTracker.FormatCardIdForDisplay(card.CardId)
-                : card.DisplayName;
+                : card.DisplayName);
             Row3(sb, label, card.Count.ToString(), "");
         }
 

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -484,7 +484,7 @@ public static class RelicHoverShowPatch
             .OrderBy(kvp => kvp.Key == "colorless" ? 1 : 0)
             .ThenBy(kvp => kvp.Value.DisplayName, StringComparer.OrdinalIgnoreCase))
         {
-            Row3(sb, $"{category.Value.DisplayName} rewards", category.Value.Count.ToString(), "");
+            Row3(sb, $"{StatsTooltip.EscapeBbcode(category.Value.DisplayName)} rewards", category.Value.Count.ToString(), "");
         }
         return sb.ToString();
     }
@@ -606,7 +606,7 @@ public static class RelicHoverShowPatch
             if (reason.Amount <= 0m) continue;
             var label = string.IsNullOrWhiteSpace(reason.DisplayName)
                 ? "lost to other/prevented"
-                : $"lost to {reason.DisplayName}";
+                : $"lost to {StatsTooltip.EscapeBbcode(reason.DisplayName)}";
             Row3(sb, label, FormatDecimal(reason.Amount), "");
         }
     }

--- a/Core/Patches/RunHistoryUtilitiesCreateEntryPatch.cs
+++ b/Core/Patches/RunHistoryUtilitiesCreateEntryPatch.cs
@@ -1,4 +1,3 @@
-using System;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Runs;
 
@@ -34,9 +33,10 @@ public static class RunHistoryUtilitiesCreateEntryPatch
     {
         // Guard the terminal run-end funnel: an unhandled throw here would
         // propagate into RunManager.OnEnded / NMainMenu.AbandonRun and could
-        // skip the game's own run cleanup. Always-on Error log (not LogDebug)
-        // so a broken run-end is visible without a debug flag.
-        try
+        // skip the game's own run cleanup. PatchGuard logs at always-on Error
+        // level (not the debug-gated LogDebug) so a broken run-end is visible
+        // without a debug flag.
+        PatchGuard.Run(nameof(RunHistoryUtilitiesCreateEntryPatch), () =>
         {
             string outcome;
             if (isAbandoned) outcome = "abandoned";
@@ -44,10 +44,6 @@ public static class RunHistoryUtilitiesCreateEntryPatch
             else outcome = "loss";
 
             RunTracker.OnRunEnded(outcome);
-        }
-        catch (Exception e)
-        {
-            CoreMain.Logger.Error($"RunHistoryUtilitiesCreateEntryPatch.Postfix failed: {e}");
-        }
+        });
     }
 }

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -67,16 +67,12 @@ public static class RunTracker
     private static readonly System.Threading.AsyncLocal<EnemyStatusSourceFrame?> _enemyStatusSourceFrame = new();
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
-    private static bool _pendingOrichalcumBlockAttribution;
     private static bool _pendingAnchorBlockAttribution;
-    private static bool _pendingTheAbacusBlockAttribution;
     private static bool _pendingAkabekoVigorAttribution;
     private static bool _pendingBoneFluteBlockAttribution;
     private static readonly List<PendingRelicHealing> _pendingRelicHeals = new();
     private static bool _pendingHappyFlowerEnergyAttribution;
     private static bool _pendingBoomingConchEnergyAttribution;
-    private static readonly List<Player> _pendingGremlinHornEnergyAttributions = new();
-    private static readonly List<Player> _pendingGremlinHornDrawAttributions = new();
     private static readonly List<Player> _pendingPendulumDrawAttributions = new();
     private static readonly List<Creature> _pendingParryingShieldDamageAttributions = new();
     private static readonly List<Creature> _pendingHornCleatBlockAttributions = new();
@@ -2162,37 +2158,6 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Record block gained from Orichalcum's end-of-turn effect. Called from
-    /// <see cref="Patches.HookAfterBlockGainedPatch"/> when the attribution
-    /// flag is armed and the player gains block.
-    /// </summary>
-    public static void RecordOrichalcumBlockGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingOrichalcumBlockAttribution) return;
-                _pendingOrichalcumBlockAttribution = false;
-
-                _pendingCombat ??= new PendingCombat();
-                if (!_pendingCombat.RelicAggregates.TryGetValue(OrichalcumRelicId, out var agg))
-                {
-                    agg = new RelicAggregate();
-                    _pendingCombat.RelicAggregates[OrichalcumRelicId] = agg;
-                }
-                agg.AdditionalBlockGained += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordOrichalcumBlockGained failed: {e.Message}");
-            }
-        }
-    }
-
-    /// <summary>
     /// Record Orichalcum's owner-specific end-turn check being blocked by the
     /// player already having block. Called from the relic's
     /// <c>BeforeSideTurnEndVeryEarly</c> method, where the game performs this
@@ -2233,28 +2198,6 @@ public static class RunTracker
         lock (_lock)
         {
             _pendingAnchorBlockAttribution = false;
-        }
-    }
-
-    public static void RecordAnchorBlockGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingAnchorBlockAttribution) return;
-                _pendingAnchorBlockAttribution = false;
-
-                var agg = GetOrCreateRelicAggregateLocked(AnchorRelicId);
-                agg.Activations += 1;
-                agg.AdditionalBlockGained += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordAnchorBlockGained failed: {e.Message}");
-            }
         }
     }
 
@@ -2349,37 +2292,6 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Record block gained from The Abacus's shuffle effect. Called from
-    /// <see cref="Patches.HookAfterBlockGainedPatch"/> when the attribution
-    /// flag is armed and the player gains block.
-    /// </summary>
-    public static void RecordTheAbacusBlockGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingTheAbacusBlockAttribution) return;
-                _pendingTheAbacusBlockAttribution = false;
-
-                _pendingCombat ??= new PendingCombat();
-                if (!_pendingCombat.RelicAggregates.TryGetValue(TheAbacusRelicId, out var agg))
-                {
-                    agg = new RelicAggregate();
-                    _pendingCombat.RelicAggregates[TheAbacusRelicId] = agg;
-                }
-                agg.AdditionalBlockGained += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordTheAbacusBlockGained failed: {e.Message}");
-            }
-        }
-    }
-
-    /// <summary>
     /// Record Letter Opener's every-N-skills activation. The game does not
     /// source its damage entries to the relic, so this records attempted damage
     /// from the owner callback and the live hittable enemy count at trigger time.
@@ -2465,38 +2377,6 @@ public static class RunTracker
         lock (_lock)
         {
             _pendingBoneFluteBlockAttribution = false;
-        }
-    }
-
-    /// <summary>
-    /// Record actual block gained from Bone Flute's owned-Osty attack trigger.
-    /// Called from <see cref="Patches.HookAfterBlockGainedPatch"/> while the
-    /// owner-specific attribution flag is armed.
-    /// </summary>
-    public static void RecordBoneFluteBlockGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingBoneFluteBlockAttribution) return;
-                _pendingBoneFluteBlockAttribution = false;
-
-                _pendingCombat ??= new PendingCombat();
-                if (!_pendingCombat.RelicAggregates.TryGetValue(BoneFluteRelicId, out var agg))
-                {
-                    agg = new RelicAggregate();
-                    _pendingCombat.RelicAggregates[BoneFluteRelicId] = agg;
-                }
-
-                agg.AdditionalBlockGained += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordBoneFluteBlockGained failed: {e.Message}");
-            }
         }
     }
 
@@ -3172,32 +3052,6 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Record energy generated by Happy Flower's every-3-turns effect. Called
-    /// from <see cref="Patches.PlayerGainEnergyPatch"/> when the Happy Flower
-    /// attribution window is armed and the player gains energy.
-    /// </summary>
-    public static void RecordHappyFlowerEnergyGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingHappyFlowerEnergyAttribution) return;
-                _pendingHappyFlowerEnergyAttribution = false;
-
-                var agg = GetOrCreateRelicAggregateLocked(HappyFlowerRelicId);
-                agg.EnergyGenerated += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordHappyFlowerEnergyGained failed: {e.Message}");
-            }
-        }
-    }
-
-    /// <summary>
     /// Arm the one-shot flag that attributes the next player energy gain to
     /// Booming Conch's Elite combat-start effect.
     /// </summary>
@@ -3214,27 +3068,6 @@ public static class RunTracker
         lock (_lock)
         {
             _pendingBoomingConchEnergyAttribution = false;
-        }
-    }
-
-    public static void RecordBoomingConchEnergyGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingBoomingConchEnergyAttribution) return;
-                _pendingBoomingConchEnergyAttribution = false;
-
-                var agg = GetOrCreateRelicAggregateLocked(BoomingConchRelicId);
-                agg.EnergyGenerated += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordBoomingConchEnergyGained failed: {e.Message}");
-            }
         }
     }
 
@@ -3359,27 +3192,6 @@ public static class RunTracker
             catch (Exception e)
             {
                 CoreMain.LogDebug($"DispatchPlayerEnergyGain failed: {e.Message}");
-            }
-        }
-    }
-
-    public static void RecordGremlinHornEnergyGained(PlayerCombatState combatState, int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                var owner = combatState._player;
-                if (!ConsumePendingGremlinHornAttribution(_pendingGremlinHornEnergyAttributions, owner)) return;
-
-                var agg = GetOrCreateRelicAggregateLocked(GremlinHornRelicId);
-                agg.EnergyGenerated += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordGremlinHornEnergyGained failed: {e.Message}");
             }
         }
     }
@@ -3632,16 +3444,6 @@ public static class RunTracker
         }
     }
 
-    private static void DisarmGremlinHornEnergyAttributionLocked(Player player)
-    {
-        for (int i = 0; i < _pendingGremlinHornEnergyAttributions.Count; i++)
-        {
-            if (!ReferenceEquals(_pendingGremlinHornEnergyAttributions[i], player)) continue;
-            _pendingGremlinHornEnergyAttributions.RemoveAt(i);
-            return;
-        }
-    }
-
     private static bool ConsumePendingGremlinHornAttribution(List<Player> pendingPlayers, Player? player)
     {
         if (player == null) return false;
@@ -3794,13 +3596,6 @@ public static class RunTracker
         }
     }
 
-    /// <summary>
-    /// Accumulate block gained from Cloak Clasp's end-of-turn effect. Called
-    /// from <see cref="Patches.HookAfterBlockGainedPatch"/> while the
-    /// attribution window is armed. Does NOT clear the flag so that multiple
-    /// <c>AfterBlockGained</c> calls (one per card in hand) are all captured.
-    /// The window is cleared at the <c>Hook.AfterTurnEnd</c> boundary.
-    /// </summary>
     /// <summary>Single arbitration point for player block gains at
     /// Hook.AfterBlockGained. The oldest fresh armed PlayerBlockGain window
     /// claims the gain; that relic's AdditionalBlockGained is credited.
@@ -3824,26 +3619,6 @@ public static class RunTracker
             catch (Exception e)
             {
                 CoreMain.LogDebug($"DispatchPlayerBlockGain failed: {e.Message}");
-            }
-        }
-    }
-
-    public static void RecordCloakClaspBlockGained(int amount)
-    {
-        if (amount <= 0) return;
-
-        lock (_lock)
-        {
-            try
-            {
-                if (!_pendingCloakClaspBlockAttribution) return;
-
-                var agg = GetOrCreateRelicAggregateLocked(CloakClaspRelicId);
-                agg.AdditionalBlockGained += amount;
-            }
-            catch (Exception e)
-            {
-                CoreMain.LogDebug($"RecordCloakClaspBlockGained failed: {e.Message}");
             }
         }
     }
@@ -5987,7 +5762,6 @@ public static class RunTracker
         {
             CardInstanceId = cardInstanceId,
             Remaining = amount,
-            Sequence = _pendingCombat.NextBlockSequence++,
         });
     }
 
@@ -6085,6 +5859,23 @@ public static class RunTracker
                 // show up as less HP loss. That's what the user wants to
                 // see: what did this card really cost me?
                 agg.TotalHpLost += result.UnblockedDamage;
+
+                _pendingCombat.CombatEvents.Add(new CardEvent
+                {
+                    T = Now(),
+                    Type = "damage_received",
+                    CardId = instanceId,
+                    // A player creature always has a Character id; the
+                    // "PLAYER" fallback only guards the theoretical null
+                    // and — crucially — never carries the "MONSTER."
+                    // prefix, so the repair path keeps classifying this
+                    // as self-damage (excluded from offensive totals).
+                    Receiver = entry.Receiver.Player?.Character?.Id.ToString() ?? "PLAYER",
+                    Blocked = result.BlockedDamage,
+                    Unblocked = result.UnblockedDamage,
+                    Overkill = result.OverkillDamage,
+                    Killed = result.WasTargetKilled,
+                });
             }
             else
             {
@@ -6098,21 +5889,26 @@ public static class RunTracker
                 agg.TotalOverkill += result.OverkillDamage;
                 agg.TotalEffective += damageTotals.EffectiveDamage;
                 if (result.WasTargetKilled) agg.Kills++;
-            }
 
-            _pendingCombat.CombatEvents.Add(new CardEvent
-            {
-                T = Now(),
-                Type = "damage_received",
-                CardId = instanceId,
-                Receiver = entry.Receiver.IsPlayer
-                    ? entry.Receiver.Player?.Character?.Id.ToString()
-                    : entry.Receiver.Monster?.Id.ToString(),
-                Blocked = result.BlockedDamage,
-                Unblocked = result.UnblockedDamage,
-                Overkill = result.OverkillDamage,
-                Killed = result.WasTargetKilled,
-            });
+                _pendingCombat.CombatEvents.Add(new CardEvent
+                {
+                    T = Now(),
+                    Type = "damage_received",
+                    CardId = instanceId,
+                    // GetEnemyId falls back to "MONSTER.UNKNOWN" when the
+                    // receiver has no Monster ref, so an enemy event always
+                    // carries the "MONSTER." prefix the repair keys on. A
+                    // raw Monster?.Id.ToString() could be null, and the
+                    // repair drops null/non-"MONSTER." receivers — silently
+                    // wiping this card's damage + kills on any adopt or
+                    // Continue rebuild (#254).
+                    Receiver = GetEnemyId(entry.Receiver),
+                    Blocked = result.BlockedDamage,
+                    Unblocked = result.UnblockedDamage,
+                    Overkill = result.OverkillDamage,
+                    Killed = result.WasTargetKilled,
+                });
+            }
         }
     }
 
@@ -6250,8 +6046,14 @@ public static class RunTracker
         {
             if (!string.Equals(cardEvent.Type, "damage_received", StringComparison.Ordinal)) continue;
             if (string.IsNullOrWhiteSpace(cardEvent.CardId)) continue;
-            if (string.IsNullOrWhiteSpace(cardEvent.Receiver)) continue;
-            if (!cardEvent.Receiver.StartsWith("MONSTER.", StringComparison.Ordinal)) continue;
+            // A null/empty Receiver is treated as enemy damage. The pre-#254
+            // writer could stamp a null Receiver for enemy hits (no Monster
+            // ref), and dropping those here permanently wiped the card's
+            // offensive totals on rebuild. Self-damage always carries a
+            // non-null character id, so a present-but-non-"MONSTER." receiver
+            // is the only thing still excluded from offensive stats.
+            if (!string.IsNullOrWhiteSpace(cardEvent.Receiver) &&
+                !cardEvent.Receiver.StartsWith("MONSTER.", StringComparison.Ordinal)) continue;
 
             rebuilt.TryGetValue(cardEvent.CardId, out var totals);
 
@@ -6781,7 +6583,6 @@ internal class PendingCombat
     public Dictionary<Creature, PendingPoisonTick> PendingPoisonTicks { get; }
         = new(ReferenceEqualityComparer.Instance);
     public RunMetaStats MetaStats { get; } = new();
-    public int NextBlockSequence { get; set; }
 
     /// <summary>Exclusive per-kind attribution windows for this combat. A fresh
     /// PendingCombat (setup/end, run boundary) starts empty, so this IS the reset.</summary>
@@ -6798,7 +6599,6 @@ internal sealed class BlockChunk
 {
     public string? CardInstanceId { get; init; }
     public int Remaining { get; set; }
-    public int Sequence { get; init; }
     public bool CountsForCardStats => CardInstanceId != null;
 }
 

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -67,17 +67,12 @@ public static class RunTracker
     private static readonly System.Threading.AsyncLocal<EnemyStatusSourceFrame?> _enemyStatusSourceFrame = new();
     private static int _pendingPlayerBlockClearAmount;
     private static bool _pendingPlayerBlockClearArmed;
-    private static bool _pendingAnchorBlockAttribution;
     private static bool _pendingAkabekoVigorAttribution;
-    private static bool _pendingBoneFluteBlockAttribution;
     private static readonly List<PendingRelicHealing> _pendingRelicHeals = new();
-    private static bool _pendingHappyFlowerEnergyAttribution;
-    private static bool _pendingBoomingConchEnergyAttribution;
     private static readonly List<Player> _pendingPendulumDrawAttributions = new();
     private static readonly List<Creature> _pendingParryingShieldDamageAttributions = new();
     private static readonly List<Creature> _pendingHornCleatBlockAttributions = new();
     private static int? _lastPrismaticGemEnergyRoundNumber;
-    private static bool _pendingCloakClaspBlockAttribution;
     private static int _pendingWhiteBeastPotionRewards;
     private static int _pendingToolboxOfferScreens;
     private static readonly HashSet<PotionReward> _whiteBeastPotionRewards = new(ReferenceEqualityComparer.Instance);
@@ -2195,10 +2190,13 @@ public static class RunTracker
 
     public static void DisarmAnchorBlockAttribution()
     {
-        lock (_lock)
-        {
-            _pendingAnchorBlockAttribution = false;
-        }
+        // No-op. Anchor's attribution now lives entirely in the per-combat
+        // registry (see ArmAnchorBlockAttribution); the window closes on
+        // consumption or the combat boundary. Routing this to
+        // Windows.Disarm(...) — an explicit early close to prevent a late
+        // mis-claim — changes live window-close timing, so it's a deferred,
+        // live-verified follow-up (#257). Kept wired so that follow-up has a
+        // seam.
     }
 
     /// <summary>
@@ -2340,10 +2338,12 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Record a confirmed Bone Flute trigger and arm the next player block
-    /// gain as its observed payload. Called from
+    /// Record a confirmed Bone Flute trigger. Called from
     /// <see cref="Patches.BoneFluteAfterAttackPatch"/> only after the relic's
-    /// owner-specific Osty attack condition is satisfied.
+    /// owner-specific Osty attack condition is satisfied. (The block-gain
+    /// arming this method's name refers to is currently non-functional — see
+    /// <see cref="DisarmBoneFluteBlockAttribution"/> — so only the trigger
+    /// count is recorded today.)
     /// </summary>
     public static void RecordBoneFluteTriggerAndArmBlockAttribution()
     {
@@ -2359,7 +2359,6 @@ public static class RunTracker
                 }
 
                 agg.BoneFluteTriggers++;
-                _pendingBoneFluteBlockAttribution = true;
             }
             catch (Exception e)
             {
@@ -2369,15 +2368,15 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Clear any armed Bone Flute attribution window without recording block.
-    /// Used as a safety reset after the relic's async gain-block task finishes.
+    /// No-op safety reset kept wired for Bone Flute's async gain-block task.
+    /// The block-gain consumer that once read the armed flag was already
+    /// unreachable, so Bone Flute's per-block attribution is currently
+    /// non-functional (a known bug: it never routed to the registry). Fixing
+    /// it — arm a PlayerBlockGain window and credit AdditionalBlockGained — is
+    /// a separate, live-verified change; this seam stays so it has a home.
     /// </summary>
     public static void DisarmBoneFluteBlockAttribution()
     {
-        lock (_lock)
-        {
-            _pendingBoneFluteBlockAttribution = false;
-        }
     }
 
     /// <summary>
@@ -3039,36 +3038,32 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Clear the Happy Flower attribution flag without recording. Used as a
-    /// safety reset at <c>Hook.AfterSideTurnStart</c> if no energy was granted
-    /// this turn (counter not yet at 3).
+    /// No-op safety reset kept wired at <c>Hook.AfterSideTurnStart</c>. Happy
+    /// Flower's window is armed with maxHistoryAdvance=0 (see
+    /// <see cref="ArmHappyFlowerEnergyAttribution"/>), so it self-expires by
+    /// history-count and needs no explicit disarm — a Windows.Disarm call
+    /// here would find nothing armed.
     /// </summary>
     public static void DisarmHappyFlowerEnergyAttribution()
     {
-        lock (_lock)
-        {
-            _pendingHappyFlowerEnergyAttribution = false;
-        }
     }
 
     /// <summary>
-    /// Arm the one-shot flag that attributes the next player energy gain to
-    /// Booming Conch's Elite combat-start effect.
+    /// No-op arm/disarm pair kept wired for Booming Conch's Elite combat-start
+    /// energy. The energy-gain consumer that once read the armed flag was
+    /// already unreachable, so Booming Conch's energy attribution is currently
+    /// non-functional (a known bug: it never routed to the registry). Fixing
+    /// it — arm a PlayerEnergyGain window and credit EnergyGenerated, mirroring
+    /// Happy Flower — is a separate, live-verified change; these seams stay so
+    /// it has a home. (Its card-draw stat via RecordBoomingConchDraw still
+    /// works.)
     /// </summary>
     public static void ArmBoomingConchEnergyAttribution()
     {
-        lock (_lock)
-        {
-            _pendingBoomingConchEnergyAttribution = true;
-        }
     }
 
     public static void DisarmBoomingConchEnergyAttribution()
     {
-        lock (_lock)
-        {
-            _pendingBoomingConchEnergyAttribution = false;
-        }
     }
 
     public static void RecordBoomingConchDraw(int cardsDrawn)
@@ -3585,15 +3580,16 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Clear the Cloak Clasp attribution window. Called at
-    /// <c>Hook.AfterTurnEnd</c> after the relic's block grants have resolved.
+    /// No-op safety reset kept wired at <c>Hook.AfterTurnEnd</c>. Cloak Clasp's
+    /// attribution now lives entirely in the per-combat registry (see
+    /// <see cref="ArmCloakClaspBlockAttribution"/>); the window closes on
+    /// consumption or the combat boundary. Routing this to Windows.Disarm(...)
+    /// — an explicit early close after the relic's block grants resolve —
+    /// changes live window-close timing, so it's a deferred, live-verified
+    /// follow-up (#257). Kept wired so that follow-up has a seam.
     /// </summary>
     public static void DisarmCloakClaspBlockAttribution()
     {
-        lock (_lock)
-        {
-            _pendingCloakClaspBlockAttribution = false;
-        }
     }
 
     /// <summary>Single arbitration point for player block gains at

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -5817,6 +5817,39 @@ public static class RunTracker
         return _pendingCombat?.PlayerBlockLedger.Sum(chunk => chunk.Remaining) ?? 0;
     }
 
+    /// <summary>
+    /// Test seam for the block-ledger attribution pipeline (issue #6). Runs the
+    /// real gain → absorb → clear sequence against a throwaway pending combat
+    /// and returns it so the FIFO-absorb / LIFO-waste invariant can be pinned
+    /// headlessly, without needing a live combat to feed BlockGainedEntry /
+    /// DamageReceivedEntry. Saves and restores the live <c>_pendingCombat</c>
+    /// under <c>_lock</c>, so it never disturbs a concurrent real combat.
+    /// </summary>
+    internal static PendingCombat RunBlockLedgerForTest(
+        IEnumerable<(string? cardInstanceId, int amount)> gains,
+        int blockedDamage,
+        int clearedUnusedBlock)
+    {
+        lock (_lock)
+        {
+            var previous = _pendingCombat;
+            try
+            {
+                var scratch = new PendingCombat();
+                _pendingCombat = scratch;
+                foreach (var (cardInstanceId, amount) in gains)
+                    AppendPlayerBlockChunkLocked(cardInstanceId, amount);
+                AttributeBlockedDamageLocked(blockedDamage);
+                AttributeUnusedBlockLocked(clearedUnusedBlock);
+                return scratch;
+            }
+            finally
+            {
+                _pendingCombat = previous;
+            }
+        }
+    }
+
     private static void ReconcilePlayerBlockLedgerLocked(Creature creature)
     {
         if (_pendingCombat == null || !creature.IsPlayer) return;

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -168,6 +168,24 @@ public static class RunTracker
     }
 
     /// <summary>
+    /// Serialize the current run to JSON in the canonical on-disk wire format
+    /// (snake_case, WhenWritingNull, IncludeFields) UNDER the lock, so external
+    /// API consumers read exactly the run-file shape and never observe a
+    /// half-promoted run mid-CombatEnded. The public API (SpireLensApiRegistry)
+    /// calls this reflectively instead of serializing the live ref itself,
+    /// which both raced OnCombatEnded and emitted an incompatible PascalCase
+    /// shape (#86/#96).
+    /// </summary>
+    public static string? SerializeCurrentRunJson()
+    {
+        lock (_lock)
+        {
+            if (_currentRun == null) return null;
+            return System.Text.Json.JsonSerializer.Serialize(_currentRun, RunStorage.Options);
+        }
+    }
+
+    /// <summary>
     /// Resolve any CardModel (combat clone or deck original) to its canonical
     /// per-deck reference. Combat clones have <c>DeckVersion</c> set to the
     /// original deck card by <c>Player.PopulateCombatState</c>

--- a/Core/StatsTooltip.cs
+++ b/Core/StatsTooltip.cs
@@ -293,6 +293,20 @@ public static class StatsTooltip
         _panel.CallDeferred(Control.MethodName.ResetSize);
     }
 
+    /// <summary>
+    /// Escape a dynamic string for safe inclusion in a RichTextLabel BBCode
+    /// body. A display name containing '[' — a modded card/relic/status id or
+    /// future game content — would otherwise be parsed as a BBCode tag and
+    /// break the tooltip's formatting (or swallow the text that follows).
+    /// Godot renders "[lb]" as a literal '[', so neutralizing the opening
+    /// bracket is enough; a lone ']' is inert.
+    /// </summary>
+    public static string EscapeBbcode(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return text ?? string.Empty;
+        return text.Replace("[", "[lb]");
+    }
+
     public static void Hide()
     {
         _anchor = null;

--- a/Tests/SpireLens.Core.Tests/BlockLedgerConservationTests.cs
+++ b/Tests/SpireLens.Core.Tests/BlockLedgerConservationTests.cs
@@ -1,0 +1,87 @@
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Pins the per-card block-ledger attribution (issue #6): absorbed damage is
+/// credited FIFO (oldest block first) as TotalBlockEffective, block cleared
+/// unused at end of turn is charged LIFO (newest survivor first) as
+/// TotalBlockWasted, and for every card-attributed chunk
+/// effective + wasted == the block it contributed.
+/// </summary>
+public class BlockLedgerConservationTests
+{
+    [Fact]
+    public void AbsorbedThenCleared_ConservesEachCardsBlock()
+    {
+        // A gains 5, then B gains 3 (ledger FIFO order: A, B).
+        // 6 damage blocked → A absorbs all 5, B absorbs 1 (FIFO).
+        // 2 block cleared unused at turn end → B's surviving 2 wasted (LIFO).
+        var pending = RunTracker.RunBlockLedgerForTest(
+            gains: new (string?, int)[] { ("CARD.DEFEND#1", 5), ("CARD.DEFEND#2", 3) },
+            blockedDamage: 6,
+            clearedUnusedBlock: 2);
+
+        var a = pending.CombatAggregates["CARD.DEFEND#1"];
+        var b = pending.CombatAggregates["CARD.DEFEND#2"];
+
+        Assert.Equal(5, a.TotalBlockEffective);
+        Assert.Equal(0, a.TotalBlockWasted);
+        Assert.Equal(1, b.TotalBlockEffective);
+        Assert.Equal(2, b.TotalBlockWasted);
+
+        // Conservation: each card's gained block == absorbed + wasted.
+        Assert.Equal(5, a.TotalBlockEffective + a.TotalBlockWasted);
+        Assert.Equal(3, b.TotalBlockEffective + b.TotalBlockWasted);
+    }
+
+    [Fact]
+    public void UnattributedChunk_IsConsumedButCreditsNoCard()
+    {
+        // A null cardInstanceId chunk models relic/innate block: it absorbs
+        // damage (removing it from the ledger) but must not mint a phantom
+        // aggregate for any card.
+        var pending = RunTracker.RunBlockLedgerForTest(
+            gains: new (string?, int)[] { (null, 4), ("CARD.DEFEND#1", 4) },
+            blockedDamage: 6,
+            clearedUnusedBlock: 0);
+
+        // Only the card chunk should appear; the null chunk credits nothing.
+        Assert.True(pending.CombatAggregates.ContainsKey("CARD.DEFEND#1"));
+        Assert.Single(pending.CombatAggregates);
+
+        // 6 blocked: null chunk eats 4 (FIFO first), card eats 2.
+        Assert.Equal(2, pending.CombatAggregates["CARD.DEFEND#1"].TotalBlockEffective);
+    }
+
+    [Fact]
+    public void ClearedBlockChargesNewestSurvivorFirst()
+    {
+        // No damage taken; the whole turn's block is cleared unused. LIFO
+        // means the last card to contribute is charged first — here both are
+        // fully wasted, so each card's waste equals its own contribution.
+        var pending = RunTracker.RunBlockLedgerForTest(
+            gains: new (string?, int)[] { ("CARD.DEFEND#1", 5), ("CARD.DEFEND#2", 3) },
+            blockedDamage: 0,
+            clearedUnusedBlock: 8);
+
+        Assert.Equal(0, pending.CombatAggregates["CARD.DEFEND#1"].TotalBlockEffective);
+        Assert.Equal(5, pending.CombatAggregates["CARD.DEFEND#1"].TotalBlockWasted);
+        Assert.Equal(3, pending.CombatAggregates["CARD.DEFEND#2"].TotalBlockWasted);
+    }
+
+    [Fact]
+    public void FullyResolvedLedger_IsEmptied()
+    {
+        // Every chunk either absorbed damage or was cleared, so the ledger
+        // holds no leftover block afterward — no double-counting on the next
+        // gain.
+        var pending = RunTracker.RunBlockLedgerForTest(
+            gains: new (string?, int)[] { ("CARD.DEFEND#1", 5), ("CARD.DEFEND#2", 3) },
+            blockedDamage: 5,
+            clearedUnusedBlock: 3);
+
+        Assert.Empty(pending.PlayerBlockLedger);
+    }
+}

--- a/Tests/SpireLens.Core.Tests/CombatEndingDamageTests.cs
+++ b/Tests/SpireLens.Core.Tests/CombatEndingDamageTests.cs
@@ -16,7 +16,13 @@ namespace SpireLens.Core.Tests;
 /// DamageResult instances are materialized without running the game
 /// constructor (it requires a live Creature); the dedup set is
 /// reference-keyed, so field state is irrelevant.
+///
+/// These tests clear and mutate the process-wide observed-result set without
+/// restoring it, so they run in the serialized <c>RunTrackerState</c>
+/// collection — otherwise a future class that also touches that static could
+/// interleave and flake (#118).
 /// </summary>
+[Collection("RunTrackerState")]
 public class CombatEndingDamageTests
 {
     private static DamageResult UnconstructedResult() =>

--- a/Tests/SpireLens.Core.Tests/PatchGuardTests.cs
+++ b/Tests/SpireLens.Core.Tests/PatchGuardTests.cs
@@ -1,0 +1,109 @@
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Pins <see cref="PatchGuard"/>'s two guarantees — a patch body never
+/// propagates a throw into game code, and a wedged hot hook is surfaced once
+/// then throttled rather than flooding the log — plus a source-scan convention
+/// that keeps the three template patches routed through the guard.
+/// </summary>
+[Collection("PatchGuardState")]
+public class PatchGuardTests
+{
+    private static readonly string RepoRoot =
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+
+    [Fact]
+    public void Run_ExecutesBody_WhenNoThrow()
+    {
+        PatchGuard.ResetForTest();
+
+        bool ran = false;
+        PatchGuard.Run("site.ok", () => ran = true);
+
+        Assert.True(ran);
+    }
+
+    [Fact]
+    public void Run_SwallowsException_DoesNotPropagate()
+    {
+        PatchGuard.ResetForTest();
+
+        var thrown = Record.Exception(() =>
+            PatchGuard.Run("site.boom", () => throw new InvalidOperationException("boom")));
+
+        Assert.Null(thrown);
+    }
+
+    [Fact]
+    public void Run_LogsFirstFailure_ThenThrottlesWithinWindow_AndFoldsSuppressedCount()
+    {
+        PatchGuard.ResetForTest();
+        var logs = new List<string>();
+        PatchGuard.LogSink = logs.Add;
+        PatchGuard.ThrottleWindow = TimeSpan.FromSeconds(30);
+        var clock = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        PatchGuard.Clock = () => clock;
+
+        // Five failures at the same instant: only the first surfaces.
+        for (int i = 0; i < 5; i++)
+            PatchGuard.Run("site.hot", () => throw new InvalidOperationException("x"));
+
+        Assert.Single(logs);
+        Assert.Contains("site.hot", logs[0]);
+
+        // Once the window elapses, the next failure surfaces again and reports
+        // how many were suppressed in between (the 4 after the first).
+        clock = clock.AddSeconds(31);
+        PatchGuard.Run("site.hot", () => throw new InvalidOperationException("x"));
+
+        Assert.Equal(2, logs.Count);
+        Assert.Contains("4 similar suppressed", logs[1]);
+
+        PatchGuard.ResetForTest();
+    }
+
+    [Fact]
+    public void Run_ThrottlesPerSiteIndependently()
+    {
+        PatchGuard.ResetForTest();
+        var logs = new List<string>();
+        PatchGuard.LogSink = logs.Add;
+        var clock = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        PatchGuard.Clock = () => clock;
+
+        // Distinct sites do not share a throttle: both first-failures surface.
+        PatchGuard.Run("site.a", () => throw new InvalidOperationException());
+        PatchGuard.Run("site.b", () => throw new InvalidOperationException());
+
+        Assert.Equal(2, logs.Count);
+
+        PatchGuard.ResetForTest();
+    }
+
+    [Fact]
+    public void TemplatePatches_RouteThroughPatchGuard()
+    {
+        var patchesDir = Path.Combine(RepoRoot, "Core", "Patches");
+
+        foreach (var file in new[]
+                 {
+                     "CombatHistoryAddPatch.cs",
+                     "RunHistoryUtilitiesCreateEntryPatch.cs",
+                     "AkabekoStatsPatch.cs",
+                 })
+        {
+            var text = File.ReadAllText(Path.Combine(patchesDir, file));
+            Assert.Contains("PatchGuard.Run", text);
+        }
+    }
+}
+
+/// <summary>
+/// Serializes the PatchGuard tests: they mutate the shared static throttle
+/// state, clock, and sink, so they must not interleave with each other.
+/// </summary>
+[CollectionDefinition("PatchGuardState", DisableParallelization = true)]
+public sealed class PatchGuardStateCollection { }

--- a/Tests/SpireLens.Core.Tests/RunTrackerRepairTests.cs
+++ b/Tests/SpireLens.Core.Tests/RunTrackerRepairTests.cs
@@ -38,4 +38,67 @@ public class RunTrackerRepairTests
         Assert.Equal(1, aggregate.Kills);
         Assert.Equal(1, aggregate.Plays);
     }
+
+    [Fact]
+    public void RepairOffensiveDamageAggregatesFromEvents_NullReceiverIsTreatedAsEnemyDamage()
+    {
+        // Regression (#254): the pre-fix writer could stamp a null Receiver
+        // for an enemy hit (the receiver had no Monster ref). The repair used
+        // to drop null Receivers, permanently wiping that card's damage +
+        // kills on every adopt/Continue rebuild. Now a null Receiver is
+        // recovered as enemy damage.
+        var run = new RunData();
+        run.Aggregates["CARD.DEATH_MARCH#1"] = new CardAggregate
+        {
+            Plays = 1,
+            TotalIntended = 20,
+            TotalEffective = 20,
+            Kills = 1,
+        };
+        run.Events.Add(new CardEvent
+        {
+            Type = "damage_received",
+            CardId = "CARD.DEATH_MARCH#1",
+            Receiver = null,
+            Blocked = 0,
+            Unblocked = 20,
+            Overkill = 0,
+            Killed = true,
+        });
+
+        bool changed = RunTracker.RepairOffensiveDamageAggregatesFromEvents(run);
+
+        var aggregate = run.Aggregates["CARD.DEATH_MARCH#1"];
+        Assert.True(changed);
+        Assert.Equal(20, aggregate.TotalIntended);
+        Assert.Equal(20, aggregate.TotalEffective);
+        Assert.Equal(1, aggregate.Kills);
+    }
+
+    [Fact]
+    public void RepairOffensiveDamageAggregatesFromEvents_ExcludesPlayerSelfDamage()
+    {
+        // Self-damage carries a non-null, non-"MONSTER." receiver and must
+        // stay out of offensive totals — the null-Receiver recovery above
+        // must not sweep genuine self-damage into the enemy branch.
+        var run = new RunData();
+        run.Aggregates["CARD.HEMOKINESIS#1"] = new CardAggregate { Plays = 1 };
+        run.Events.Add(new CardEvent
+        {
+            Type = "damage_received",
+            CardId = "CARD.HEMOKINESIS#1",
+            Receiver = "PLAYER",
+            Blocked = 0,
+            Unblocked = 3,
+            Overkill = 0,
+            Killed = false,
+        });
+
+        RunTracker.RepairOffensiveDamageAggregatesFromEvents(run);
+
+        var aggregate = run.Aggregates["CARD.HEMOKINESIS#1"];
+        Assert.Equal(0, aggregate.TotalIntended);
+        Assert.Equal(0, aggregate.TotalEffective);
+        Assert.Equal(0, aggregate.Kills);
+    }
 }

--- a/Tests/SpireLens.Core.Tests/StatsTooltipBbcodeTests.cs
+++ b/Tests/SpireLens.Core.Tests/StatsTooltipBbcodeTests.cs
@@ -1,0 +1,45 @@
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Pins <see cref="StatsTooltip.EscapeBbcode"/>: dynamic display names injected
+/// into the RichTextLabel body must not be interpretable as BBCode tags, or a
+/// modded card/relic/status name containing '[' would break tooltip rendering.
+/// </summary>
+public class StatsTooltipBbcodeTests
+{
+    [Fact]
+    public void EscapeBbcode_LeavesPlainTextUntouched()
+    {
+        Assert.Equal("Poison", StatsTooltip.EscapeBbcode("Poison"));
+        Assert.Equal("Weak (2)", StatsTooltip.EscapeBbcode("Weak (2)"));
+    }
+
+    [Fact]
+    public void EscapeBbcode_NeutralizesOpeningBracket()
+    {
+        Assert.Equal("[lb]b]bold[lb]/b]", StatsTooltip.EscapeBbcode("[b]bold[/b]"));
+    }
+
+    [Fact]
+    public void EscapeBbcode_EscapesEveryOpeningBracket()
+    {
+        Assert.Equal("[lb][lb][lb]", StatsTooltip.EscapeBbcode("[[["));
+    }
+
+    [Fact]
+    public void EscapeBbcode_LeavesLoneClosingBracketInert()
+    {
+        // A ']' with no matching '[' is not a tag, so it needs no escaping.
+        Assert.Equal("x]y", StatsTooltip.EscapeBbcode("x]y"));
+    }
+
+    [Fact]
+    public void EscapeBbcode_HandlesNullAndEmpty()
+    {
+        Assert.Equal(string.Empty, StatsTooltip.EscapeBbcode(null));
+        Assert.Equal(string.Empty, StatsTooltip.EscapeBbcode(string.Empty));
+    }
+}

--- a/Tests/SpireLens.Core.Tests/TestCollections.cs
+++ b/Tests/SpireLens.Core.Tests/TestCollections.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+/// <summary>
+/// Serializes tests that mutate RunTracker's process-wide mutable statics
+/// (the observed-DamageResult dedup set, the live current/pending run) without
+/// restoring them. xUnit runs distinct test classes in parallel by default;
+/// enrolling every such class here keeps them from interleaving and flaking
+/// (#118). Tests that fully save/restore the static they touch don't need it.
+/// </summary>
+[CollectionDefinition("RunTrackerState", DisableParallelization = true)]
+public sealed class RunTrackerStateCollection { }


### PR DESCRIPTION
Burns down the safe/verifiable subset of the audit backlog. Every change is headless-tested; the full suite is **264 passing** (`Category!=RequiresLiveGame`). Live-only items are deferred (see below), not silently dropped.

## What landed

**repair-254 (Part A) — real data-loss fix.** A card's damage + kills were silently wiped on every adopt/Continue rebuild whenever an enemy hit had no `Monster` ref: the writer stamped a null `Receiver`, and the aggregate-repair pass drops null / non-`MONSTER.` receivers. The writer now uses the `GetEnemyId` → `"MONSTER.UNKNOWN"` fallback (and splits the per-branch `CombatEvents.Add`), and the repair now recovers a null/empty `Receiver` as enemy damage while still excluding genuine self-damage (`"PLAYER"` fallback keeps it out of the `MONSTER.` bucket). +2 `RunTrackerRepairTests`.

**patchguard-261 — visible, throttled patch errors.** New `Core/PatchGuard.cs` wraps a Harmony patch body so a throw never reaches the game loop. It logs at always-on Error level (most patches buried failures in the debug-gated `LogDebug`) and rate-limits per call site so a wedged per-frame hook can't flood `godot.log`. Converted the 3 template patches (combat-history master hook, run-end funnel, Akabeko prefix). +5 `PatchGuardTests` incl. a source-scan convention check.

**hygiene-257 (safe subset) — dead code + tooltip hardening.** Deleted 8 unreachable `Record*Gained` methods, `DisarmGremlinHornEnergyAttributionLocked`, 4 fully-dead fields (Orichalcum/TheAbacus block bools + both dead Gremlin lists), and the vestigial `BlockChunk.Sequence` / `PendingCombat.NextBlockSequence` (#44). Added `StatsTooltip.EscapeBbcode` and applied it at all 7 tooltip sites where a game/data-derived display name flows into BBCode, so a name containing `[` can't break tooltip rendering. +5 EscapeBbcode tests.

**testcov-262 — block-ledger conservation (#115) + flake guard (#118).** New `RunTracker.RunBlockLedgerForTest` seam runs the real gain→absorb→clear pipeline against a throwaway pending combat (saving+restoring live `_pendingCombat` under `_lock`). `BlockLedgerConservationTests` pins the issue #6 invariant: absorbed = FIFO `TotalBlockEffective`, cleared-unused = LIFO `TotalBlockWasted`, each card's gained == effective + wasted, unattributed (relic) chunks mint no phantom aggregate. `CombatEndingDamageTests` now runs in a serialized `RunTrackerState` collection so a future class touching the shared observed-result static can't interleave.

## Deferred (live-combat verification required — not dropped)
- **repair-254 Part B (#41):** routing Osty/`IsPet` receivers away from the offensive branch — no headless fixture for a live pet `Creature`.
- **relic-fidelity-256:** all six relic gate fixes depend on live `ICombatState`/`Creature`/`CardModel`.
- **hygiene-257 3 disarm→registry conversions:** change live disarm/window-close timing.
- **testcov-262 ClassifyEntry hot-path refactor + #116 routing test:** the game's `*Entry` types can't be constructed headless, so that test can't feed real inputs; rewriting the busiest code path for an infeasible test is the wrong trade. Poison-tick math (#117) is already pinned by `ComputeEnemyDamageTotals`' lethal-overkill test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)