### PR TITLE
Address multi-lens verification findings (PatchGuard throttle, block-ledger LIFO/conservation coverage)

### DIFF
--- a/Core/Patches/CombatHistoryAddPatch.cs
+++ b/Core/Patches/CombatHistoryAddPatch.cs
@@ -24,8 +24,11 @@ public static class CombatHistoryAddPatch
     // so we know the entry survived the game's own logic and is "real."
     //
     // This is the single busiest hook — every combat event flows through it, so
-    // a throw here must never reach the game's dispatch loop. PatchGuard swallows
-    // it, surfaces the first failure at Error level, then throttles the rest.
+    // a throw here must never reach the game's dispatch loop. Observe() self-
+    // guards (it routes its whole body through PatchGuard "RunTracker.Observe",
+    // which is where the surface-first-then-throttle happens for the flood-prone
+    // path); this outer PatchGuard.Run is defense-in-depth for anything around
+    // the Observe call itself.
     [HarmonyPostfix]
     public static void Postfix(CombatHistoryEntry entry)
     {

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1506,7 +1506,14 @@ public static class RunTracker
     private static int _observeCount;
     public static void Observe(object entry)
     {
-        try
+        // Guard + throttle HERE, not just at the CombatHistoryAddPatch caller.
+        // This method wraps its whole body and never rethrows, so a PatchGuard
+        // at the call site would never see a throw — its per-site throttle
+        // would be dead. Routing Observe's own guard through PatchGuard gives
+        // this (the busiest hook) the rate-limited always-on Error logging, and
+        // covers every Observe caller — including the combat-ending
+        // suppressed-damage path, which is NOT itself PatchGuard-wrapped.
+        PatchGuard.Run("RunTracker.Observe", () =>
         {
             var n = System.Threading.Interlocked.Increment(ref _observeCount);
 
@@ -1595,12 +1602,7 @@ public static class RunTracker
                     RecordPowerReceived(pre);
                     break;
             }
-        }
-        catch (Exception e)
-        {
-            // Never let tracker exceptions escape into the game loop.
-            CoreMain.Logger.Error($"RunTracker.Observe failed: {e}");
-        }
+        });
     }
 
     private static void RecordCardPlay(CardPlay cardPlay)
@@ -5834,7 +5836,17 @@ public static class RunTracker
                 var scratch = new PendingCombat();
                 _pendingCombat = scratch;
                 foreach (var (cardInstanceId, amount) in gains)
+                {
+                    // Mirror the production block-gain pairing: a card-attributed
+                    // gain credits TotalBlockGained AND pushes a ledger chunk of
+                    // the same amount (see RecordBlockGainedEntry). Crediting it
+                    // here lets the conservation test assert the real invariant
+                    // gained == effective + wasted — the tooltip divides absorbed
+                    // and wasted percentages by TotalBlockGained.
+                    if (cardInstanceId != null)
+                        GetOrCreateAggregate(scratch, cardInstanceId).TotalBlockGained += amount;
                     AppendPlayerBlockChunkLocked(cardInstanceId, amount);
+                }
                 AttributeBlockedDamageLocked(blockedDamage);
                 AttributeUnusedBlockLocked(clearedUnusedBlock);
                 return scratch;

--- a/Tests/SpireLens.Core.Tests/BlockLedgerConservationTests.cs
+++ b/Tests/SpireLens.Core.Tests/BlockLedgerConservationTests.cs
@@ -8,7 +8,9 @@ namespace SpireLens.Core.Tests;
 /// credited FIFO (oldest block first) as TotalBlockEffective, block cleared
 /// unused at end of turn is charged LIFO (newest survivor first) as
 /// TotalBlockWasted, and for every card-attributed chunk
-/// effective + wasted == the block it contributed.
+/// TotalBlockGained == TotalBlockEffective + TotalBlockWasted (the invariant the
+/// CardHover tooltip relies on — it divides absorbed% and wasted% by
+/// TotalBlockGained).
 /// </summary>
 public class BlockLedgerConservationTests
 {
@@ -26,14 +28,16 @@ public class BlockLedgerConservationTests
         var a = pending.CombatAggregates["CARD.DEFEND#1"];
         var b = pending.CombatAggregates["CARD.DEFEND#2"];
 
+        Assert.Equal(5, a.TotalBlockGained);
         Assert.Equal(5, a.TotalBlockEffective);
         Assert.Equal(0, a.TotalBlockWasted);
+        Assert.Equal(3, b.TotalBlockGained);
         Assert.Equal(1, b.TotalBlockEffective);
         Assert.Equal(2, b.TotalBlockWasted);
 
-        // Conservation: each card's gained block == absorbed + wasted.
-        Assert.Equal(5, a.TotalBlockEffective + a.TotalBlockWasted);
-        Assert.Equal(3, b.TotalBlockEffective + b.TotalBlockWasted);
+        // The real invariant: gained == absorbed + wasted, per card.
+        Assert.Equal(a.TotalBlockGained, a.TotalBlockEffective + a.TotalBlockWasted);
+        Assert.Equal(b.TotalBlockGained, b.TotalBlockEffective + b.TotalBlockWasted);
     }
 
     [Fact]
@@ -41,7 +45,7 @@ public class BlockLedgerConservationTests
     {
         // A null cardInstanceId chunk models relic/innate block: it absorbs
         // damage (removing it from the ledger) but must not mint a phantom
-        // aggregate for any card.
+        // aggregate for any card, nor credit TotalBlockGained.
         var pending = RunTracker.RunBlockLedgerForTest(
             gains: new (string?, int)[] { (null, 4), ("CARD.DEFEND#1", 4) },
             blockedDamage: 6,
@@ -51,24 +55,52 @@ public class BlockLedgerConservationTests
         Assert.True(pending.CombatAggregates.ContainsKey("CARD.DEFEND#1"));
         Assert.Single(pending.CombatAggregates);
 
+        var a = pending.CombatAggregates["CARD.DEFEND#1"];
+        Assert.Equal(4, a.TotalBlockGained);
         // 6 blocked: null chunk eats 4 (FIFO first), card eats 2.
-        Assert.Equal(2, pending.CombatAggregates["CARD.DEFEND#1"].TotalBlockEffective);
+        Assert.Equal(2, a.TotalBlockEffective);
     }
 
     [Fact]
-    public void ClearedBlockChargesNewestSurvivorFirst()
+    public void AllBlockClearedUnused_EachCardFullyWasted()
     {
-        // No damage taken; the whole turn's block is cleared unused. LIFO
-        // means the last card to contribute is charged first — here both are
-        // fully wasted, so each card's waste equals its own contribution.
+        // No damage taken; the whole turn's block is cleared unused. With the
+        // total cleared, both cards are fully wasted regardless of order — this
+        // pins conservation on the all-wasted path (NOT LIFO ordering; see the
+        // partial-clear test for that).
         var pending = RunTracker.RunBlockLedgerForTest(
             gains: new (string?, int)[] { ("CARD.DEFEND#1", 5), ("CARD.DEFEND#2", 3) },
             blockedDamage: 0,
             clearedUnusedBlock: 8);
 
-        Assert.Equal(0, pending.CombatAggregates["CARD.DEFEND#1"].TotalBlockEffective);
-        Assert.Equal(5, pending.CombatAggregates["CARD.DEFEND#1"].TotalBlockWasted);
-        Assert.Equal(3, pending.CombatAggregates["CARD.DEFEND#2"].TotalBlockWasted);
+        var a = pending.CombatAggregates["CARD.DEFEND#1"];
+        var b = pending.CombatAggregates["CARD.DEFEND#2"];
+
+        Assert.Equal(0, a.TotalBlockEffective);
+        Assert.Equal(5, a.TotalBlockWasted);
+        Assert.Equal(3, b.TotalBlockWasted);
+        Assert.Equal(a.TotalBlockGained, a.TotalBlockEffective + a.TotalBlockWasted);
+        Assert.Equal(b.TotalBlockGained, b.TotalBlockEffective + b.TotalBlockWasted);
+    }
+
+    [Fact]
+    public void PartialClear_ChargesNewestSurvivorFirst_Lifo()
+    {
+        // The distinguishing case for LIFO. A gains 5, then B gains 3; no damage
+        // taken; only 3 block cleared unused. LIFO charges the newest survivor
+        // (B) first, so B is fully wasted and A is left untouched. Under FIFO
+        // this would instead waste A's 3 and leave B untouched — so this test
+        // fails if AttributeUnusedBlockLocked ever flips to forward iteration.
+        var pending = RunTracker.RunBlockLedgerForTest(
+            gains: new (string?, int)[] { ("CARD.DEFEND#1", 5), ("CARD.DEFEND#2", 3) },
+            blockedDamage: 0,
+            clearedUnusedBlock: 3);
+
+        var a = pending.CombatAggregates["CARD.DEFEND#1"];
+        var b = pending.CombatAggregates["CARD.DEFEND#2"];
+
+        Assert.Equal(3, b.TotalBlockWasted); // newest survivor charged first
+        Assert.Equal(0, a.TotalBlockWasted); // oldest untouched (would be 3 under FIFO)
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/PatchGuardTests.cs
+++ b/Tests/SpireLens.Core.Tests/PatchGuardTests.cs
@@ -99,6 +99,19 @@ public class PatchGuardTests
             Assert.Contains("PatchGuard.Run", text);
         }
     }
+
+    [Fact]
+    public void Observe_SelfGuardsThroughPatchGuard()
+    {
+        // RunTracker.Observe wraps its whole body and never rethrows, so a guard
+        // only at the CombatHistoryAddPatch caller would have a dead throttle.
+        // The real, throttled guard for the busiest hook must live in Observe
+        // itself — pin that at the source level so it can't silently regress.
+        var runTracker = File.ReadAllText(Path.Combine(RepoRoot, "Core", "RunTracker.cs"));
+        Assert.Contains("PatchGuard.Run(\"RunTracker.Observe\"", runTracker);
+        // And the old un-throttled swallow it replaced must not creep back in.
+        Assert.DoesNotContain("RunTracker.Observe failed", runTracker);
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Follow-up to #269. A multi-lens adversarial verification (5 independent lenses + a confirm pass) over the merged diff surfaced three real issues — all fixed here, plus a strengthened convention test.

1. **PatchGuard throttle was dead on the busiest hook.** `RunTracker.Observe` wraps its whole body in one catch and never rethrows, so `PatchGuard.Run` at the `CombatHistoryAddPatch` caller never saw a throw — the per-site throttle was unreachable and Observe's own un-throttled `Logger.Error` could flood `godot.log` if a combat entry started throwing per-event. Observe now routes its own guard through `PatchGuard.Run("RunTracker.Observe")`, covering every caller (incl. the combat-ending suppressed-damage path). The caller's wrap stays as documented defense-in-depth.

2. **The block-ledger LIFO invariant wasn't actually pinned.** Every prior test drained both chunks identically under FIFO or LIFO — flipping `AttributeUnusedBlockLocked` to forward iteration left the suite green. Added `PartialClear_ChargesNewestSurvivorFirst_Lifo`, **verified to fail under a temporary FIFO mutation** and pass on the real LIFO code. Renamed the old full-clear test to stop claiming to test ordering.

3. **Conservation asserted against literals; `TotalBlockGained` untested.** The seam bypassed production's gain credit, so the tooltip's denominator (`TotalBlockGained`) was never exercised. `RunBlockLedgerForTest` now mirrors production's gain pairing and the tests assert the real per-card invariant `gained == effective + wasted`.

Also strengthened the PatchGuard convention test to pin Observe's self-guard at the source level so #1 can't silently regress.

Suite: **266 passing**, 0 new warnings. The verification also re-flagged the repair-254 legacy null-Receiver ambiguity (already reviewed as acceptable — no persisted field can disambiguate legacy events, and the writer's `"PLAYER"` fallback prevents all future occurrences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)