### PR TITLE
Track Pen Nib base damage added

### DIFF
--- a/Core/Patches/PenNibStatsPatch.cs
+++ b/Core/Patches/PenNibStatsPatch.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+using MegaCrit.Sts2.Core.ValueProps;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Pen Nib contributes by doubling the current attack damage amount. Record
+/// that pre-Pen-Nib amount when the real card play is the one being doubled,
+/// avoiding target-side downstream multipliers such as Vulnerable.
+/// </summary>
+[HarmonyPatch(typeof(PenNib), nameof(PenNib.ModifyDamageMultiplicative))]
+public static class PenNibModifyDamageMultiplicativePatch
+{
+    private static readonly AsyncLocal<Stack<DamageFrame>?> DamageFrames = new();
+
+    [HarmonyPostfix]
+    public static void Postfix(
+        PenNib __instance,
+        Creature? target,
+        decimal amount,
+        ValueProp props,
+        Creature? dealer,
+        CardModel? cardSource,
+        CardPlay? cardPlay,
+        decimal __result)
+    {
+        try
+        {
+            if (__result != 2m) return;
+            if (__instance == null || !RunTracker.IsTrackedRelic(__instance)) return;
+            if (!props.IsPoweredAttack()) return;
+            if (cardSource == null || cardPlay?.Card == null) return;
+            if (!ReferenceEquals(cardSource, cardPlay.Card)) return;
+            if (cardSource.Type != CardType.Attack) return;
+            if (amount <= 0m) return;
+
+            RunTracker.RecordPenNibBaseDamageAdded(ResolveBaseDamageAmount(cardSource, cardPlay, amount));
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"PenNibModifyDamageMultiplicativePatch failed: {e.Message}");
+        }
+    }
+
+    internal static decimal ResolveBaseDamageAmount(CardModel? cardSource, CardPlay? cardPlay, decimal fallbackAmount)
+    {
+        var frames = DamageFrames.Value;
+        if (frames == null || frames.Count == 0) return fallbackAmount;
+
+        foreach (var frame in frames)
+        {
+            if (ReferenceEquals(frame.CardSource, cardSource)
+                && ReferenceEquals(frame.CardPlay, cardPlay))
+            {
+                return frame.Amount;
+            }
+        }
+
+        return fallbackAmount;
+    }
+
+    internal static void PushDamageFrame(CardModel? cardSource, CardPlay? cardPlay, decimal amount)
+    {
+        var frames = DamageFrames.Value;
+        if (frames == null)
+        {
+            frames = new Stack<DamageFrame>();
+            DamageFrames.Value = frames;
+        }
+
+        frames.Push(new DamageFrame(cardSource, cardPlay, amount));
+    }
+
+    internal static void PopDamageFrame()
+    {
+        var frames = DamageFrames.Value;
+        if (frames == null || frames.Count == 0) return;
+
+        frames.Pop();
+        if (frames.Count == 0) DamageFrames.Value = null;
+    }
+
+    private readonly record struct DamageFrame(CardModel? CardSource, CardPlay? CardPlay, decimal Amount);
+}
+
+/// <summary>
+/// Captures the raw damage amount passed into the real damage command, before
+/// any hook modifiers run. Pen Nib's multiplicative hook can then record the
+/// command's base per-hit amount rather than an intermediate modified value.
+/// </summary>
+[HarmonyPatch(
+    typeof(CreatureCmd),
+    nameof(CreatureCmd.Damage),
+    new[]
+    {
+        typeof(PlayerChoiceContext),
+        typeof(IEnumerable<Creature>),
+        typeof(decimal),
+        typeof(ValueProp),
+        typeof(Creature),
+        typeof(CardModel),
+        typeof(CardPlay),
+    })]
+public static class PenNibCreatureDamagePatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(
+        decimal amount,
+        CardModel? cardSource,
+        CardPlay? cardPlay,
+        out bool __state)
+    {
+        __state = false;
+
+        try
+        {
+            if (amount <= 0m || cardSource == null || cardPlay == null) return;
+
+            PenNibModifyDamageMultiplicativePatch.PushDamageFrame(cardSource, cardPlay, amount);
+            __state = true;
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"PenNibCreatureDamagePatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(bool __state)
+    {
+        if (!__state) return;
+
+        try
+        {
+            PenNibModifyDamageMultiplicativePatch.PopDamageFrame();
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"PenNibCreatureDamagePatch.Postfix failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -231,6 +231,16 @@ public static class RelicHoverShowPatch
                 return;
             }
 
+            if (relicNode.Model is PenNib)
+            {
+                const string relicId = "RELIC.PEN_NIB";
+                var agg = RelicAgg(relicId);
+
+                var body = BuildPenNibBodyBBCode(agg);
+                StatsTooltip.Show(tree, __instance, "Pen Nib", "SpireLens", body);
+                return;
+            }
+
             if (relicNode.Model is HornCleat)
             {
                 const string relicId = "RELIC.HORN_CLEAT";
@@ -539,6 +549,13 @@ public static class RelicHoverShowPatch
         Row3(sb, "Combats triggered", agg.Activations.ToString(), "");
         Row3(sb, "Damage dealt", agg.TotalDamageDealt.ToString(), "");
         Row3(sb, "Damage per combat", FormatDecimal(damagePerCombat), "");
+        return sb.ToString();
+    }
+
+    private static string BuildPenNibBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        Row3(sb, "Base damage added", agg.TotalDamageAttempted.ToString(), "");
         return sb.ToString();
     }
 

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -436,10 +436,12 @@ public class RelicAggregate
     // Total Vigor applied by Akabeko's combat-start effect.
     public int VigorGained { get; set; }
 
-    // Total attempted damage from relic effects whose actual damage is not
+    // Total attempted/base damage from relic effects whose actual damage is not
     // source-attributed by the game's damage entries. Used by Letter Opener
     // and observed-damage relics such as Parrying Shield, Festive Popper, and
-    // Mercury Hourglass.
+    // Mercury Hourglass. For Pen Nib, this stores the raw per-hit amount
+    // handed to the damage command: the extra base damage added, before
+    // downstream hook effects such as Lethality or Vulnerable.
     public int TotalDamageAttempted { get; set; }
 
     // Relic damage outcome split. Used by relics such as Parrying Shield,

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -2060,6 +2060,7 @@ public static class RunTracker
     private const string TheAbacusRelicId = "RELIC.THE_ABACUS";
     private const string LetterOpenerRelicId = "RELIC.LETTER_OPENER";
     private const int LetterOpenerDamagePerTarget = 5;
+    private const string PenNibRelicId = "RELIC.PEN_NIB";
     private const string AkabekoRelicId = "RELIC.AKABEKO";
     private const string BookRepairKnifeRelicId = "RELIC.BOOK_REPAIR_KNIFE";
     private const string EternalFeatherRelicId = "RELIC.ETERNAL_FEATHER";
@@ -2393,7 +2394,41 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Record a confirmed Bone Flute trigger. Called from
+    /// Record the raw per-hit damage amount doubled by Pen Nib. This is the
+    /// extra base damage the relic contributed, intentionally before
+    /// downstream hook multipliers such as Lethality or Vulnerable.
+    /// </summary>
+    public static void RecordPenNibBaseDamageAdded(decimal baseDamageAdded)
+    {
+        if (baseDamageAdded <= 0m) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateRelicAggregateLocked(PenNibRelicId);
+                AddPenNibBaseDamageAdded(agg, baseDamageAdded);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordPenNibBaseDamageAdded failed: {e.Message}");
+            }
+        }
+    }
+
+    internal static void RecordPenNibBaseDamageAddedForTest(RelicAggregate agg, decimal baseDamageAdded)
+        => AddPenNibBaseDamageAdded(agg, baseDamageAdded);
+
+    private static void AddPenNibBaseDamageAdded(RelicAggregate agg, decimal baseDamageAdded)
+    {
+        var added = (int)decimal.Truncate(baseDamageAdded);
+        if (added <= 0) return;
+        agg.TotalDamageAttempted += added;
+    }
+
+    /// <summary>
+    /// Record a confirmed Bone Flute trigger and arm the next player block
+    /// gain as its observed payload. Called from
     /// <see cref="Patches.BoneFluteAfterAttackPatch"/> only after the relic's
     /// owner-specific Osty attack condition is satisfied. (The block-gain
     /// arming this method's name refers to is currently non-functional — see

--- a/Tests/SpireLens.Core.Tests/OpenBranchRelicStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/OpenBranchRelicStatsTests.cs
@@ -68,6 +68,10 @@ public class OpenBranchRelicStatsTests
             Kills = 1,
             TotalTargets = 2,
         };
+        run.RelicAggregates["RELIC.PEN_NIB"] = new RelicAggregate
+        {
+            TotalDamageAttempted = 27,
+        };
         run.RelicAggregates["RELIC.HORN_CLEAT"] = new RelicAggregate
         {
             Activations = 2,
@@ -109,8 +113,53 @@ public class OpenBranchRelicStatsTests
         Assert.Equal(2, restored.RelicAggregates["RELIC.PARRYING_SHIELD"].TotalDamageOverkill);
         Assert.Equal(1, restored.RelicAggregates["RELIC.PARRYING_SHIELD"].Kills);
         Assert.Equal(2, restored.RelicAggregates["RELIC.PARRYING_SHIELD"].TotalTargets);
+        Assert.Equal(27, restored.RelicAggregates["RELIC.PEN_NIB"].TotalDamageAttempted);
         Assert.Equal(2, restored.RelicAggregates["RELIC.HORN_CLEAT"].Activations);
         Assert.Equal(24, restored.RelicAggregates["RELIC.HORN_CLEAT"].AdditionalBlockGained);
+    }
+
+    [Fact]
+    public void RunTracker_RecordPenNibBaseDamageAdded_AccumulatesTruncatedBaseDamage()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordPenNibBaseDamageAddedForTest(agg, 9m);
+        RunTracker.RecordPenNibBaseDamageAddedForTest(agg, 6.9m);
+        RunTracker.RecordPenNibBaseDamageAddedForTest(agg, 0.9m);
+        RunTracker.RecordPenNibBaseDamageAddedForTest(agg, -5m);
+
+        Assert.Equal(15, agg.TotalDamageAttempted);
+    }
+
+    [Fact]
+    public void PenNib_ResolveBaseDamageAmount_PrefersRawDamageFrame()
+    {
+        try
+        {
+            PenNibModifyDamageMultiplicativePatch.PushDamageFrame(null, null, 9m);
+
+            Assert.Equal(
+                9m,
+                PenNibModifyDamageMultiplicativePatch.ResolveBaseDamageAmount(
+                    null,
+                    null,
+                    13.5m));
+        }
+        finally
+        {
+            PenNibModifyDamageMultiplicativePatch.PopDamageFrame();
+        }
+    }
+
+    [Fact]
+    public void PenNib_ResolveBaseDamageAmount_FallsBackWithoutRawDamageFrame()
+    {
+        Assert.Equal(
+            13.5m,
+            PenNibModifyDamageMultiplicativePatch.ResolveBaseDamageAmount(
+                null,
+                null,
+                13.5m));
     }
 
     [Fact]
@@ -195,6 +244,12 @@ public class OpenBranchRelicStatsTests
         Assert.Contains("Kills", parryingShieldBody);
         Assert.Contains("[b]17[/b]", parryingShieldBody);
         Assert.Contains("[b]11[/b]", parryingShieldBody);
+
+        var penNibBody = InvokeTooltipBuilder(
+            "BuildPenNibBodyBBCode",
+            new RelicAggregate { TotalDamageAttempted = 27 });
+        Assert.Contains("Base damage added", penNibBody);
+        Assert.Contains("[b]27[/b]", penNibBody);
 
         var hornCleatBody = InvokeTooltipBuilder(
             "BuildHornCleatBodyBBCode",

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -358,6 +358,12 @@ For relics that grant block after a specific owner-owned condition, arm a narrow
 
 For relics that emit damage commands, prefer the relic-owned callback plus the resolved `CreatureCmd.Damage` result. Mercury Hourglass arms from `MercuryHourglass.AfterPlayerTurnStart`, records the actual multi-target damage split from the command result on each turn, and counts the combat once so damage per combat is not confused with damage per turn-start trigger.
 
+Pen Nib is detected at its `ModifyDamageMultiplicative` hook when the relic
+returns `2` for the actual `CardPlay`, but the amount recorded comes from the
+raw per-hit value passed into `CreatureCmd.Damage` before hook modifiers run.
+SpireLens labels this "base damage added" rather than deriving from final
+damage, so effects such as Lethality or Vulnerable do not inflate the stat.
+
 ## Generated And Supplemental Cards
 
 Not every visible card should become a permanent per-instance deck card.


### PR DESCRIPTION
Adds Pen Nib relic tracking for the raw base damage it adds before downstream multipliers such as Vulnerable.