### PR TITLE
Track Strike Dummy stats

### DIFF
--- a/Core/Patches/RelicCmdObtainStrikeDummyPatch.cs
+++ b/Core/Patches/RelicCmdObtainStrikeDummyPatch.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Stamps Strike Dummy's deck-composition stats when the relic is obtained.
+/// The command path catches reward, shop, event, and direct relic grants.
+/// </summary>
+[HarmonyPatch]
+public static class RelicCmdObtainStrikeDummyPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        return AccessTools.Method(
+            typeof(RelicCmd),
+            nameof(RelicCmd.Obtain),
+            new[] { typeof(RelicModel), typeof(Player), typeof(int) });
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(RelicModel relic, Player player, Task<RelicModel> __result)
+    {
+        try
+        {
+            if (relic is not StrikeDummy) return;
+
+            if (__result == null)
+            {
+                RunTracker.RecordStrikeDummyObtained(relic, player);
+                return;
+            }
+
+            if (__result.IsCompleted)
+            {
+                if (!__result.IsCanceled && !__result.IsFaulted)
+                    RunTracker.RecordStrikeDummyObtained(__result.Result ?? relic, player);
+                return;
+            }
+
+            __result.ContinueWith(
+                task =>
+                {
+                    if (!task.IsCanceled && !task.IsFaulted)
+                        RunTracker.RecordStrikeDummyObtained(task.Result ?? relic, player);
+                },
+                TaskScheduler.Default);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RelicCmdObtainStrikeDummyPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -361,6 +361,15 @@ public static class RelicHoverShowPatch
                 return;
             }
 
+            if (IsRelicModel(relicNode.Model, "MegaCrit.Sts2.Core.Models.Relics.StrikeDummy"))
+            {
+                var agg = RunTracker.GetStrikeDummyAggregate();
+
+                var body = BuildStrikeDummyBodyBBCode(agg);
+                StatsTooltip.Show(tree, __instance, "Strike Dummy", "SpireLens", body);
+                return;
+            }
+
             if (relicNode.Model is WhiteBeastStatue)
             {
                 const string relicId = "RELIC.WHITE_BEAST_STATUE";
@@ -676,6 +685,15 @@ public static class RelicHoverShowPatch
         var floorCount = RunTracker.GetCurrentFloorForRateStats();
         var rate = floorCount <= 0 ? 0m : (decimal)agg.SacrificesMade / floorCount;
         Row3(sb, "Sacrifice rate", FormatDecimal(rate), "/floor");
+        return sb.ToString();
+    }
+
+    private static string BuildStrikeDummyBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        Row3(sb, "Strikes played", agg.StrikeDummyStrikesPlayed.ToString(), "");
+        Row3(sb, "Base Strikes in deck", agg.StrikeDummyBaseStrikesInDeck.ToString(), "");
+        Row3(sb, "Non-base Strike cards in deck", agg.StrikeDummyNonBaseStrikeCardsInDeck.ToString(), "");
         return sb.ToString();
     }
 

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -480,6 +480,12 @@ public class RelicAggregate
     public int SacrificesMade { get; set; }
     public int SacrificesSkipped { get; set; }
 
+    // Strike Dummy tracking. StrikesPlayed is cumulative since the relic was
+    // picked up; deck counts are current permanent-deck snapshots.
+    public int StrikeDummyStrikesPlayed { get; set; }
+    public int StrikeDummyBaseStrikesInDeck { get; set; }
+    public int StrikeDummyNonBaseStrikeCardsInDeck { get; set; }
+
     // Total card rewards whose creation options were modified by this relic.
     // Used by Prismatic Gem.
     public int CardRewardsAffected { get; set; }

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -14,6 +14,7 @@ using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Enchantments;
 using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Models.Powers;
+using MegaCrit.Sts2.Core.Models.Relics;
 using MegaCrit.Sts2.Core.Rewards;
 using MegaCrit.Sts2.Core.Rooms;
 using MegaCrit.Sts2.Core.Runs;
@@ -591,6 +592,8 @@ public static class RunTracker
             // identity for the tracked player's cards.
             if (!IsTrackedCard(card)) return;
             GetOrAssignNumber(card);
+            if (RefreshStrikeDummyDeckCountsIfOwnedLocked())
+                SaveCurrentRun();
         }
     }
 
@@ -1023,6 +1026,7 @@ public static class RunTracker
                 GetOrAssignNumber(card);
             }
         }
+        bool strikeDummyDeckCountsChanged = RefreshStrikeDummyDeckCountsIfOwnedLocked();
         int stillWaiting = _pendingRankRestores.Values.Sum(q => q.Count);
         int restored = seeded - stillWaiting;
         int unmatched = deckCards - restored;
@@ -1100,7 +1104,7 @@ public static class RunTracker
             CoreMain.Logger.Info(
                 $"{context}: repaired offensive damage aggregates for run_id={run.RunId}");
         }
-        if (repairedDamageAggregates || prunedGhosts > 0)
+        if (repairedDamageAggregates || prunedGhosts > 0 || strikeDummyDeckCountsChanged)
         {
             SaveCurrentRun();
         }
@@ -1510,6 +1514,12 @@ public static class RunTracker
         target.RareCardsConsumed += source.RareCardsConsumed;
         target.SacrificesMade += source.SacrificesMade;
         target.SacrificesSkipped += source.SacrificesSkipped;
+
+        target.StrikeDummyStrikesPlayed += source.StrikeDummyStrikesPlayed;
+        if (source.StrikeDummyBaseStrikesInDeck != 0 || target.StrikeDummyBaseStrikesInDeck == 0)
+            target.StrikeDummyBaseStrikesInDeck = source.StrikeDummyBaseStrikesInDeck;
+        if (source.StrikeDummyNonBaseStrikeCardsInDeck != 0 || target.StrikeDummyNonBaseStrikeCardsInDeck == 0)
+            target.StrikeDummyNonBaseStrikeCardsInDeck = source.StrikeDummyNonBaseStrikeCardsInDeck;
         target.CardRewardsAffected += source.CardRewardsAffected;
         MergeCardRewardCategories(target.CardRewardCategories, source.CardRewardCategories);
     }
@@ -1554,8 +1564,11 @@ public static class RunTracker
                     // At hover time, the deck view sees canonicalHash — matching
                     // the two is how we verify the DeckVersion-based key works.
                     CoreMain.LogDebug($"  -> RecordCardPlay '{card?.Title ?? "?"}' hash={card?.GetHashCode()} canonicalHash={(card == null ? 0 : Canonical(card).GetHashCode())}");
-                    if (cpf.CardPlay != null) NoteCardPlayFinished(cpf.CardPlay);
-                    RecordCardPlay(cpf.CardPlay);
+                    if (cpf.CardPlay != null)
+                    {
+                        NoteCardPlayFinished(cpf.CardPlay);
+                        RecordCardPlay(cpf.CardPlay);
+                    }
                     break;
                 case CardDrawnEntry cde:
                     // Draw-hook validation is complete; keep the trace debug-gated.
@@ -1627,8 +1640,10 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (cardPlay?.Card == null) return;
+
             // Co-op: only the tracked local player's card plays are ours.
-            if (!IsTrackedCard(cardPlay?.Card)) return;
+            if (!IsTrackedCard(cardPlay.Card)) return;
             // Defensive: if CombatSetUp never fired (unusual), allocate lazily.
             _pendingCombat ??= new PendingCombat();
 
@@ -1638,6 +1653,7 @@ public static class RunTracker
 
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
             agg.Plays++;
+            RecordStrikeDummyStrikePlayedIfOwnedLocked(cardPlay.Card);
             if (IsReplayExtraPlay(cardPlay))
             {
                 agg.TimesReplayExtraPlayed++;
@@ -2089,6 +2105,7 @@ public static class RunTracker
     private const string PhylacteryUnboundRelicId = "RELIC.PHYLACTERY_UNBOUND";
     private const string ToolboxRelicId = "RELIC.TOOLBOX";
     private const string PaelsWingRelicId = "RELIC.PAELS_WING";
+    private const string StrikeDummyRelicId = "RELIC.STRIKE_DUMMY";
 
     /// <summary>
     /// Record a Bag of Marbles combat-start Vulnerable application.
@@ -3055,12 +3072,88 @@ public static class RunTracker
         }
     }
 
+    /// <summary>
+    /// Record that Strike Dummy was obtained, stamping the current permanent
+    /// deck split between base Strikes and other Strike-tagged cards.
+    /// </summary>
+    public static void RecordStrikeDummyObtained(RelicModel relic, Player player)
+    {
+        if (relic is not StrikeDummy || player == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedPlayer(player)) return;
+                var agg = GetOrCreateCurrentRunRelicAggregateLocked(StrikeDummyRelicId);
+                RefreshStrikeDummyDeckCountsLocked(agg, player);
+                SaveCurrentRun();
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordStrikeDummyObtained failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Return Strike Dummy stats after refreshing the current permanent-deck
+    /// composition. Used by the relic hover tooltip so hot reload/continue
+    /// state catches up even if the pickup happened before this build.
+    /// </summary>
+    public static RelicAggregate GetStrikeDummyAggregate()
+    {
+        lock (_lock)
+        {
+            try
+            {
+                RefreshStrikeDummyDeckCountsIfOwnedLocked();
+
+                RelicAggregate? result = null;
+                if (_currentRun != null && _currentRun.RelicAggregates.TryGetValue(StrikeDummyRelicId, out var committed))
+                {
+                    result = new RelicAggregate();
+                    MergeRelicAggregateInto(result, committed);
+                }
+
+                if (_pendingCombat != null && _pendingCombat.RelicAggregates.TryGetValue(StrikeDummyRelicId, out var pending))
+                {
+                    result ??= new RelicAggregate();
+                    MergeRelicAggregateInto(result, pending);
+                }
+
+                return result ?? new RelicAggregate();
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"GetStrikeDummyAggregate failed: {e.Message}");
+                return new RelicAggregate();
+            }
+        }
+    }
+
     internal static void RecordLeesWafflePickupHpGainedForTest(RelicAggregate agg, decimal hpGained)
     {
         if (agg == null || hpGained < 0m) return;
 
         agg.Activations++;
         agg.TotalHealingRestored += hpGained;
+    }
+
+    internal static void RecordStrikeDummyStrikePlayedForTest(RelicAggregate agg)
+    {
+        if (agg == null) return;
+        agg.StrikeDummyStrikesPlayed += 1;
+    }
+
+    internal static void SetStrikeDummyDeckCountsForTest(
+        RelicAggregate agg,
+        int baseStrikesInDeck,
+        int nonBaseStrikeCardsInDeck)
+    {
+        if (agg == null) return;
+        agg.StrikeDummyBaseStrikesInDeck = Math.Max(0, baseStrikesInDeck);
+        agg.StrikeDummyNonBaseStrikeCardsInDeck = Math.Max(0, nonBaseStrikeCardsInDeck);
     }
 
     private static void RecordRelicHealingTrigger(
@@ -4231,6 +4324,109 @@ public static class RunTracker
         return _currentRun?.FloorReached;
     }
 
+    private static void RecordStrikeDummyStrikePlayedIfOwnedLocked(CardModel card)
+    {
+        if (!IsStrikeDummyStrikeCard(card)) return;
+
+        var owner = card.Owner;
+        if (owner == null || !IsTrackedPlayer(owner) || !PlayerHasStrikeDummy(owner)) return;
+
+        var agg = GetOrCreateRelicAggregateForCurrentContextLocked(StrikeDummyRelicId);
+        agg.StrikeDummyStrikesPlayed += 1;
+    }
+
+    private static bool RefreshStrikeDummyDeckCountsIfOwnedLocked()
+    {
+        if (_currentRun == null) return false;
+
+        var player = GetTrackedRunPlayerLocked();
+        if (player == null || !PlayerHasStrikeDummy(player)) return false;
+
+        bool created = false;
+        if (!_currentRun.RelicAggregates.TryGetValue(StrikeDummyRelicId, out var agg) || agg == null)
+        {
+            agg = new RelicAggregate();
+            _currentRun.RelicAggregates[StrikeDummyRelicId] = agg;
+            created = true;
+        }
+        return RefreshStrikeDummyDeckCountsLocked(agg) || created;
+    }
+
+    private static bool RefreshStrikeDummyDeckCountsLocked(RelicAggregate agg, Player? player = null)
+    {
+        player ??= GetTrackedRunPlayerLocked();
+        if (player?.Deck?.Cards == null) return false;
+
+        int baseStrikes = 0;
+        int nonBaseStrikeCards = 0;
+        foreach (var deckCard in player.Deck.Cards)
+        {
+            if (deckCard == null) continue;
+            if (!IsStrikeDummyStrikeCard(deckCard)) continue;
+
+            if (IsBaseStrikeForStrikeDummy(deckCard))
+                baseStrikes++;
+            else
+                nonBaseStrikeCards++;
+        }
+
+        bool changed =
+            agg.StrikeDummyBaseStrikesInDeck != baseStrikes ||
+            agg.StrikeDummyNonBaseStrikeCardsInDeck != nonBaseStrikeCards;
+
+        agg.StrikeDummyBaseStrikesInDeck = baseStrikes;
+        agg.StrikeDummyNonBaseStrikeCardsInDeck = nonBaseStrikeCards;
+        return changed;
+    }
+
+    private static Player? GetTrackedRunPlayerLocked()
+    {
+        try
+        {
+            var players = RunManager.Instance?.State?.Players;
+            if (players == null || players.Count == 0) return null;
+
+            if (_trackedNetId.HasValue)
+                return players.FirstOrDefault(p => p.NetId == _trackedNetId.Value);
+
+            return players.Count == 1 ? players[0] : players.FirstOrDefault();
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"GetTrackedRunPlayerLocked failed: {e.Message}");
+            return null;
+        }
+    }
+
+    private static bool PlayerHasStrikeDummy(Player player)
+    {
+        try
+        {
+            return player.Relics.Any(r => r is StrikeDummy);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsStrikeDummyStrikeCard(CardModel? card)
+    {
+        try
+        {
+            return card?.Tags?.Contains(CardTag.Strike) == true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsBaseStrikeForStrikeDummy(CardModel? card)
+    {
+        return card != null && IsStrikeDummyStrikeCard(card) && card.IsBasicStrikeOrDefend;
+    }
+
     private static void RecordCombatsInDeckForCurrentDeckLocked()
     {
         try
@@ -4461,6 +4657,7 @@ public static class RunTracker
             // flag lives only in memory and would be lost on F5 between the
             // removal and the next CombatEnded. Removals are infrequent so
             // the I/O cost is negligible.
+            RefreshStrikeDummyDeckCountsIfOwnedLocked();
             SaveCurrentRun();
         }
     }

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -98,6 +98,9 @@ New fixtures added going forward do not need a `v*-` prefix.
 - `paels-wing-sacrifice-relic-run.json`
   Adds Pael's Wing sacrifice tracking: consumed card reward options split by
   common, uncommon, and rare, plus sacrifices made and skipped.
+- `strike-dummy-relic-run.json`
+  Adds Strike Dummy tracked Strike-card plays since pickup plus current
+  permanent-deck counts for base Strikes and non-base Strike-tagged cards.
 
 Why these exist:
 

--- a/Fixtures/RunSchema/strike-dummy-relic-run.json
+++ b/Fixtures/RunSchema/strike-dummy-relic-run.json
@@ -1,0 +1,35 @@
+{
+  "run_id": "strike-dummy-relic-fixture",
+  "started_at": "2026-07-03T00:00:00Z",
+  "updated_at": "2026-07-03T00:10:00Z",
+  "outcome": "in_progress",
+  "aggregates": {
+    "CARD.STRIKE_IRONCLAD#1": {
+      "plays": 2
+    },
+    "CARD.POMMEL_STRIKE#1": {
+      "plays": 1
+    }
+  },
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.STRIKE_DUMMY": {
+      "strike_dummy_strikes_played": 8,
+      "strike_dummy_base_strikes_in_deck": 4,
+      "strike_dummy_non_base_strike_cards_in_deck": 3
+    }
+  },
+  "meta_stats": {},
+  "instance_numbers_by_def": {
+    "CARD.STRIKE_IRONCLAD": [
+      1
+    ],
+    "CARD.POMMEL_STRIKE": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.STRIKE_IRONCLAD": 1,
+    "CARD.POMMEL_STRIKE": 1
+  }
+}

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -1050,4 +1050,29 @@ public class SchemaLoadingTests
         Assert.Equal(3, relicAgg.SacrificesMade);
         Assert.Equal(2, relicAgg.SacrificesSkipped);
     }
+
+    [Fact]
+    public void HistoricalLoad_AcceptsStrikeDummyRelicFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("strike-dummy-relic-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        var relicAgg = loaded.Data.RelicAggregates["RELIC.STRIKE_DUMMY"];
+        Assert.Equal(8, relicAgg.StrikeDummyStrikesPlayed);
+        Assert.Equal(4, relicAgg.StrikeDummyBaseStrikesInDeck);
+        Assert.Equal(3, relicAgg.StrikeDummyNonBaseStrikeCardsInDeck);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsStrikeDummyRelicFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("strike-dummy-relic-run.json"));
+
+        Assert.NotNull(resumed);
+        var relicAgg = resumed!.RelicAggregates["RELIC.STRIKE_DUMMY"];
+        Assert.Equal(8, relicAgg.StrikeDummyStrikesPlayed);
+        Assert.Equal(4, relicAgg.StrikeDummyBaseStrikesInDeck);
+        Assert.Equal(3, relicAgg.StrikeDummyNonBaseStrikeCardsInDeck);
+    }
 }

--- a/Tests/SpireLens.Core.Tests/StrikeDummyStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/StrikeDummyStatsTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class StrikeDummyStatsTests
+{
+    private const string StrikeDummyRelicId = "RELIC.STRIKE_DUMMY";
+
+    private static readonly MethodInfo BuildStrikeDummyBodyMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildStrikeDummyBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildStrikeDummyBodyBBCode not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void RelicAggregate_StrikeDummyFields_DefaultToZero()
+    {
+        var agg = new RelicAggregate();
+
+        Assert.Equal(0, agg.StrikeDummyStrikesPlayed);
+        Assert.Equal(0, agg.StrikeDummyBaseStrikesInDeck);
+        Assert.Equal(0, agg.StrikeDummyNonBaseStrikeCardsInDeck);
+    }
+
+    [Fact]
+    public void RelicAggregate_StrikeDummyFields_JsonRoundtrip_PreservesFields()
+    {
+        var run = new RunData();
+        run.RelicAggregates[StrikeDummyRelicId] = new RelicAggregate
+        {
+            StrikeDummyStrikesPlayed = 8,
+            StrikeDummyBaseStrikesInDeck = 4,
+            StrikeDummyNonBaseStrikeCardsInDeck = 3,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("strike_dummy_strikes_played", json);
+        Assert.Contains("strike_dummy_base_strikes_in_deck", json);
+        Assert.Contains("strike_dummy_non_base_strike_cards_in_deck", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var restoredAgg = restored!.RelicAggregates[StrikeDummyRelicId];
+        Assert.Equal(8, restoredAgg.StrikeDummyStrikesPlayed);
+        Assert.Equal(4, restoredAgg.StrikeDummyBaseStrikesInDeck);
+        Assert.Equal(3, restoredAgg.StrikeDummyNonBaseStrikeCardsInDeck);
+    }
+
+    [Fact]
+    public void RunTracker_StrikeDummyHelpers_AccumulatePlaysAndClampDeckCounts()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordStrikeDummyStrikePlayedForTest(agg);
+        RunTracker.RecordStrikeDummyStrikePlayedForTest(agg);
+        RunTracker.SetStrikeDummyDeckCountsForTest(agg, 4, 3);
+        RunTracker.SetStrikeDummyDeckCountsForTest(agg, -1, -2);
+
+        Assert.Equal(2, agg.StrikeDummyStrikesPlayed);
+        Assert.Equal(0, agg.StrikeDummyBaseStrikesInDeck);
+        Assert.Equal(0, agg.StrikeDummyNonBaseStrikeCardsInDeck);
+    }
+
+    [Fact]
+    public void RelicTooltip_StrikeDummy_ShowsPlayAndDeckRows()
+    {
+        var agg = new RelicAggregate
+        {
+            StrikeDummyStrikesPlayed = 8,
+            StrikeDummyBaseStrikesInDeck = 4,
+            StrikeDummyNonBaseStrikeCardsInDeck = 3,
+        };
+
+        var body = (string)(BuildStrikeDummyBodyMethod.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException("BuildStrikeDummyBodyBBCode returned null."));
+
+        Assert.Contains("Strikes played", body);
+        Assert.Contains("Base Strikes in deck", body);
+        Assert.Contains("Non-base Strike cards in deck", body);
+        Assert.Contains("[b]8[/b]", body);
+        Assert.Contains("[b]4[/b]", body);
+        Assert.Contains("[b]3[/b]", body);
+    }
+}

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -369,6 +369,13 @@ across the full pickup callback when that is what the player experiences. Lee's
 Waffle records current-HP gained across `AfterObtained`, covering both its
 max-HP grant and the follow-up heal-to-full.
 
+Strike Dummy identifies eligible cards through the game's `CardTag.Strike`.
+Its damage modifier can run per damage evaluation, so count Strike cards played
+from finished card-play events while the relic is owned; use the modifier only
+to confirm the eligibility rule. Base Strikes are `IsBasicStrikeOrDefend` cards
+that also carry the Strike tag, while non-base Strike cards are every other
+permanent deck card with that tag.
+
 ## Generated And Supplemental Cards
 
 Not every visible card should become a permanent per-instance deck card.


### PR DESCRIPTION
Adds Strike Dummy tracking for Strike plays since pickup and current deck counts for base and non-base Strike cards.