### PR TITLE
Add fake relic stats and clarify dev workflow

### DIFF
--- a/.codex/skills/dev-work/SKILL.md
+++ b/.codex/skills/dev-work/SKILL.md
@@ -18,6 +18,9 @@ Treat SpireLens work as branch-based, pushed, live-validated development. Do not
    - Pull fast-forward only.
    - If main cannot be updated cleanly, stop and report the blocker.
 3. Branch from fresh `main`, using the `codex/` prefix unless the user asks otherwise.
+   - Do this when starting a new dev-work session, or after the current feature branch has been PR'd/merged and work is continuing.
+   - During an ongoing user session, expect the user may provide many related fixes in sequence. Keep stacking follow-up commits on the current live feature branch unless the user explicitly asks for a separate branch.
+   - Do not switch back to `main` or create sibling branches mid-session just because the user gives another issue. If the current branch feels unrelated to the new request, say so and ask before splitting.
    - Prefer a worktree for substantial work or anything likely to overlap with existing dirty state.
    - If staying in the current worktree, inspect dirty files and do not disturb unrelated user changes.
 

--- a/Core/Patches/AnchorBeforeSideTurnStartPatch.cs
+++ b/Core/Patches/AnchorBeforeSideTurnStartPatch.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Reflection;
 using HarmonyLib;
-using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
 
 namespace SpireLens.Core.Patches;
 
@@ -11,27 +11,51 @@ namespace SpireLens.Core.Patches;
 /// actual block gained is observed by Hook.AfterBlockGained.
 /// </summary>
 [HarmonyPatch]
-public static class AnchorBeforeSideTurnStartPatch
+public static class AnchorBeforeCombatStartPatch
 {
     private static MethodBase? TargetMethod()
     {
         var t = AccessTools.TypeByName("MegaCrit.Sts2.Core.Models.Relics.Anchor");
-        return t == null ? null : AccessTools.Method(t, "BeforeSideTurnStart");
+        return t == null ? null : AccessTools.Method(t, "BeforeCombatStart");
     }
 
     [HarmonyPrefix]
-    public static void Prefix(CombatSide side, ICombatState combatState)
+    public static void Prefix(RelicModel __instance)
+    {
+        ArmIfTracked(__instance, nameof(AnchorBeforeCombatStartPatch));
+    }
+
+    internal static void ArmIfTracked(RelicModel? relic, string caller)
     {
         try
         {
-            if (side != CombatSide.Player) return;
-            if (combatState == null || combatState.RoundNumber != 1) return;
+            if (!RunTracker.IsTrackedRelic(relic)) return;
             RunTracker.ArmAnchorBlockAttribution();
         }
         catch (Exception e)
         {
-            CoreMain.LogDebug($"AnchorBeforeSideTurnStartPatch failed: {e.Message}");
+            CoreMain.LogDebug($"{caller} failed: {e.Message}");
         }
+    }
+}
+
+/// <summary>
+/// Fake Anchor grants a smaller combat-start block amount but otherwise uses
+/// the same observed Anchor stat bucket.
+/// </summary>
+[HarmonyPatch]
+public static class FakeAnchorBeforeCombatStartPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        var t = AccessTools.TypeByName("MegaCrit.Sts2.Core.Models.Relics.FakeAnchor");
+        return t == null ? null : AccessTools.Method(t, "BeforeCombatStart");
+    }
+
+    [HarmonyPrefix]
+    public static void Prefix(RelicModel __instance)
+    {
+        AnchorBeforeCombatStartPatch.ArmIfTracked(__instance, nameof(FakeAnchorBeforeCombatStartPatch));
     }
 }
 

--- a/Core/Patches/RelicCmdObtainStrikeDummyPatch.cs
+++ b/Core/Patches/RelicCmdObtainStrikeDummyPatch.cs
@@ -29,7 +29,7 @@ public static class RelicCmdObtainStrikeDummyPatch
     {
         try
         {
-            if (relic is not StrikeDummy) return;
+            if (!RunTracker.IsStrikeDummyStatsRelic(relic)) return;
 
             if (__result == null)
             {

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -795,8 +795,15 @@ public static class RelicHoverShowPatch
 
     private static bool IsRelicModel(object model, string typeName)
     {
-        var type = AccessTools.TypeByName(typeName);
-        return type != null && type.IsInstanceOfType(model);
+        for (var type = model.GetType(); type != null; type = type.BaseType)
+        {
+            if (string.Equals(type.FullName, typeName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsAnchorStatsRelicModel(object model)

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -101,13 +101,14 @@ public static class RelicHoverShowPatch
                 return;
             }
 
-            if (IsRelicModel(relicNode.Model, "MegaCrit.Sts2.Core.Models.Relics.Anchor"))
+            if (IsAnchorStatsRelicModel(relicNode.Model))
             {
                 const string relicId = "RELIC.ANCHOR";
                 var agg = RelicAgg(relicId);
 
                 var body = BuildAnchorBodyBBCode(agg);
-                StatsTooltip.Show(tree, __instance, "Anchor", "SpireLens", body);
+                var title = IsFakeAnchorRelicModel(relicNode.Model) ? "???" : "Anchor";
+                StatsTooltip.Show(tree, __instance, title, "SpireLens", body);
                 return;
             }
 
@@ -795,6 +796,17 @@ public static class RelicHoverShowPatch
     {
         var type = AccessTools.TypeByName(typeName);
         return type != null && type.IsInstanceOfType(model);
+    }
+
+    private static bool IsAnchorStatsRelicModel(object model)
+    {
+        return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.Anchor")
+            || IsFakeAnchorRelicModel(model);
+    }
+
+    private static bool IsFakeAnchorRelicModel(object model)
+    {
+        return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.FakeAnchor");
     }
 
     private static string NormalizeResourcePath(string path)

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -362,12 +362,13 @@ public static class RelicHoverShowPatch
                 return;
             }
 
-            if (IsRelicModel(relicNode.Model, "MegaCrit.Sts2.Core.Models.Relics.StrikeDummy"))
+            if (IsStrikeDummyStatsRelicModel(relicNode.Model))
             {
                 var agg = RunTracker.GetStrikeDummyAggregate();
 
                 var body = BuildStrikeDummyBodyBBCode(agg);
-                StatsTooltip.Show(tree, __instance, "Strike Dummy", "SpireLens", body);
+                var title = IsFakeStrikeDummyRelicModel(relicNode.Model) ? "???" : "Strike Dummy";
+                StatsTooltip.Show(tree, __instance, title, "SpireLens", body);
                 return;
             }
 
@@ -807,6 +808,17 @@ public static class RelicHoverShowPatch
     private static bool IsFakeAnchorRelicModel(object model)
     {
         return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.FakeAnchor");
+    }
+
+    private static bool IsStrikeDummyStatsRelicModel(object model)
+    {
+        return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.StrikeDummy")
+            || IsFakeStrikeDummyRelicModel(model);
+    }
+
+    private static bool IsFakeStrikeDummyRelicModel(object model)
+    {
+        return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.FakeStrikeDummy");
     }
 
     private static string NormalizeResourcePath(string path)

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -3205,7 +3205,7 @@ public static class RunTracker
     /// </summary>
     public static void RecordStrikeDummyObtained(RelicModel relic, Player player)
     {
-        if (relic is not StrikeDummy || player == null) return;
+        if (!IsStrikeDummyStatsRelic(relic) || player == null) return;
 
         lock (_lock)
         {
@@ -3281,6 +3281,18 @@ public static class RunTracker
         if (agg == null) return;
         agg.StrikeDummyBaseStrikesInDeck = Math.Max(0, baseStrikesInDeck);
         agg.StrikeDummyNonBaseStrikeCardsInDeck = Math.Max(0, nonBaseStrikeCardsInDeck);
+    }
+
+    internal static bool IsStrikeDummyStatsRelic(RelicModel? relic)
+    {
+        try
+        {
+            return relic is StrikeDummy or FakeStrikeDummy;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static void RecordRelicHealingTrigger(
@@ -4528,7 +4540,7 @@ public static class RunTracker
     {
         try
         {
-            return player.Relics.Any(r => r is StrikeDummy);
+            return player.Relics.Any(IsStrikeDummyStatsRelic);
         }
         catch
         {

--- a/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
+++ b/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
@@ -25,8 +25,23 @@ public class HookPatchTargetTests
         Assert.Equal("MegaCrit.Sts2.Core.Combat.CombatSide", sideParameter!.ParameterType.FullName);
     }
 
+    [Theory]
+    [Trait("Category", "RequiresLiveGame")]
+    [InlineData(typeof(AnchorBeforeCombatStartPatch), "MegaCrit.Sts2.Core.Models.Relics.Anchor")]
+    [InlineData(typeof(FakeAnchorBeforeCombatStartPatch), "MegaCrit.Sts2.Core.Models.Relics.FakeAnchor")]
+    public void AnchorCombatStartPatches_ResolveBeforeCombatStart(Type patchType, string declaringTypeName)
+    {
+        var target = InvokeTargetMethod(patchType);
+
+        Assert.NotNull(target);
+        Assert.Equal(declaringTypeName, target!.DeclaringType?.FullName);
+        Assert.Equal("BeforeCombatStart", target.Name);
+        Assert.Empty(target.GetParameters());
+    }
+
     private static MethodBase? InvokeTargetMethod(Type patchType)
     {
+        _ = Assembly.Load("sts2");
         var targetMethod = patchType.GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.NotNull(targetMethod);
         return (MethodBase?)targetMethod!.Invoke(null, Array.Empty<object>());

--- a/Tests/SpireLens.Core.Tests/OpenBranchRelicStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/OpenBranchRelicStatsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Models.Relics;
 using SpireLens.Core;
 using SpireLens.Core.Patches;
 using Xunit;
@@ -10,6 +11,10 @@ namespace SpireLens.Core.Tests;
 
 public class OpenBranchRelicStatsTests
 {
+    private static readonly MethodInfo IsAnchorStatsRelicModelMethod =
+        typeof(RelicHoverShowPatch).GetMethod("IsAnchorStatsRelicModel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("IsAnchorStatsRelicModel not found.");
+
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -160,6 +165,18 @@ public class OpenBranchRelicStatsTests
                 null,
                 null,
                 13.5m));
+    }
+
+    [Fact]
+    public void RelicTooltip_AnchorModelRecognition_IncludesFakeAnchor()
+    {
+        var real = (bool)(IsAnchorStatsRelicModelMethod.Invoke(null, new object[] { new Anchor() })
+            ?? throw new InvalidOperationException("IsAnchorStatsRelicModel returned null."));
+        var fake = (bool)(IsAnchorStatsRelicModelMethod.Invoke(null, new object[] { new FakeAnchor() })
+            ?? throw new InvalidOperationException("IsAnchorStatsRelicModel returned null."));
+
+        Assert.True(real);
+        Assert.True(fake);
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/OpenBranchRelicStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/OpenBranchRelicStatsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MegaCrit.Sts2.Core.Models.Relics;
@@ -170,9 +171,9 @@ public class OpenBranchRelicStatsTests
     [Fact]
     public void RelicTooltip_AnchorModelRecognition_IncludesFakeAnchor()
     {
-        var real = (bool)(IsAnchorStatsRelicModelMethod.Invoke(null, new object[] { new Anchor() })
+        var real = (bool)(IsAnchorStatsRelicModelMethod.Invoke(null, new object[] { Uninitialized<Anchor>() })
             ?? throw new InvalidOperationException("IsAnchorStatsRelicModel returned null."));
-        var fake = (bool)(IsAnchorStatsRelicModelMethod.Invoke(null, new object[] { new FakeAnchor() })
+        var fake = (bool)(IsAnchorStatsRelicModelMethod.Invoke(null, new object[] { Uninitialized<FakeAnchor>() })
             ?? throw new InvalidOperationException("IsAnchorStatsRelicModel returned null."));
 
         Assert.True(real);
@@ -285,5 +286,10 @@ public class OpenBranchRelicStatsTests
         Assert.NotNull(method);
         return (string)(method!.Invoke(null, new object[] { agg })
             ?? throw new InvalidOperationException($"{methodName} returned null."));
+    }
+
+    private static T Uninitialized<T>() where T : class
+    {
+        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
     }
 }

--- a/Tests/SpireLens.Core.Tests/StrikeDummyStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/StrikeDummyStatsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MegaCrit.Sts2.Core.Models.Relics;
@@ -81,17 +82,17 @@ public class StrikeDummyStatsTests
     [Fact]
     public void RunTracker_StrikeDummyStatsRelic_IncludesFakeStrikeDummy()
     {
-        Assert.True(RunTracker.IsStrikeDummyStatsRelic(new StrikeDummy()));
-        Assert.True(RunTracker.IsStrikeDummyStatsRelic(new FakeStrikeDummy()));
+        Assert.True(RunTracker.IsStrikeDummyStatsRelic(Uninitialized<StrikeDummy>()));
+        Assert.True(RunTracker.IsStrikeDummyStatsRelic(Uninitialized<FakeStrikeDummy>()));
         Assert.False(RunTracker.IsStrikeDummyStatsRelic(null));
     }
 
     [Fact]
     public void RelicTooltip_StrikeDummyModelRecognition_IncludesFakeStrikeDummy()
     {
-        var real = (bool)(IsStrikeDummyStatsRelicModelMethod.Invoke(null, new object[] { new StrikeDummy() })
+        var real = (bool)(IsStrikeDummyStatsRelicModelMethod.Invoke(null, new object[] { Uninitialized<StrikeDummy>() })
             ?? throw new InvalidOperationException("IsStrikeDummyStatsRelicModel returned null."));
-        var fake = (bool)(IsStrikeDummyStatsRelicModelMethod.Invoke(null, new object[] { new FakeStrikeDummy() })
+        var fake = (bool)(IsStrikeDummyStatsRelicModelMethod.Invoke(null, new object[] { Uninitialized<FakeStrikeDummy>() })
             ?? throw new InvalidOperationException("IsStrikeDummyStatsRelicModel returned null."));
 
         Assert.True(real);
@@ -117,5 +118,10 @@ public class StrikeDummyStatsTests
         Assert.Contains("[b]8[/b]", body);
         Assert.Contains("[b]4[/b]", body);
         Assert.Contains("[b]3[/b]", body);
+    }
+
+    private static T Uninitialized<T>() where T : class
+    {
+        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
     }
 }

--- a/Tests/SpireLens.Core.Tests/StrikeDummyStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/StrikeDummyStatsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Models.Relics;
 using SpireLens.Core;
 using SpireLens.Core.Patches;
 using Xunit;
@@ -15,6 +16,10 @@ public class StrikeDummyStatsTests
     private static readonly MethodInfo BuildStrikeDummyBodyMethod =
         typeof(RelicHoverShowPatch).GetMethod("BuildStrikeDummyBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildStrikeDummyBodyBBCode not found.");
+
+    private static readonly MethodInfo IsStrikeDummyStatsRelicModelMethod =
+        typeof(RelicHoverShowPatch).GetMethod("IsStrikeDummyStatsRelicModel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("IsStrikeDummyStatsRelicModel not found.");
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -71,6 +76,26 @@ public class StrikeDummyStatsTests
         Assert.Equal(2, agg.StrikeDummyStrikesPlayed);
         Assert.Equal(0, agg.StrikeDummyBaseStrikesInDeck);
         Assert.Equal(0, agg.StrikeDummyNonBaseStrikeCardsInDeck);
+    }
+
+    [Fact]
+    public void RunTracker_StrikeDummyStatsRelic_IncludesFakeStrikeDummy()
+    {
+        Assert.True(RunTracker.IsStrikeDummyStatsRelic(new StrikeDummy()));
+        Assert.True(RunTracker.IsStrikeDummyStatsRelic(new FakeStrikeDummy()));
+        Assert.False(RunTracker.IsStrikeDummyStatsRelic(null));
+    }
+
+    [Fact]
+    public void RelicTooltip_StrikeDummyModelRecognition_IncludesFakeStrikeDummy()
+    {
+        var real = (bool)(IsStrikeDummyStatsRelicModelMethod.Invoke(null, new object[] { new StrikeDummy() })
+            ?? throw new InvalidOperationException("IsStrikeDummyStatsRelicModel returned null."));
+        var fake = (bool)(IsStrikeDummyStatsRelicModelMethod.Invoke(null, new object[] { new FakeStrikeDummy() })
+            ?? throw new InvalidOperationException("IsStrikeDummyStatsRelicModel returned null."));
+
+        Assert.True(real);
+        Assert.True(fake);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add Fake Anchor support to Anchor relic stats
- add Fake Strike Dummy support to Strike Dummy relic stats
- clarify the dev-work skill so follow-up issues in one session stay on the current live branch

## Validation
- dotnet test D:\repos\spirelens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug --filter "StrikeDummyStatsTests|OpenBranchRelicStatsTests|HookPatchTargetTests"
- dotnet test D:\repos\spirelens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug
- SpireLens Core hot reload completed successfully on feature branch