### PR TITLE
Add Regalite stats and combat card stats toggle

### DIFF
--- a/Config/SpireLensConfig.cs
+++ b/Config/SpireLensConfig.cs
@@ -15,6 +15,9 @@ public sealed class SpireLensConfig : SimpleModConfig
 
     public static bool UseVerboseHandStats { get; set; }
 
+    [ConfigSection("Performance")]
+    public static bool DisableCardStatsDuringCombat { get; set; }
+
     [ConfigSection("Diagnostics")]
     public static bool EnableDebugLogging { get; set; }
 

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -46,6 +46,9 @@ public static class CardHoverShowPatch
         // we stack above instead.
 
         RuntimeOptionsProvider.Refresh();
+        if (RunTracker.AreCardStatsDisabledForActiveCombat())
+            return;
+
         if (__instance is NHandCardHolder && !RuntimeOptionsProvider.Current.ShowHandTooltips)
             return;
 

--- a/Core/Patches/DigRestSiteOptionShovelStatsPatch.cs
+++ b/Core/Patches/DigRestSiteOptionShovelStatsPatch.cs
@@ -105,11 +105,14 @@ public static class DigRestSiteOptionShovelStatsPatch
 /// Counts rest sites where Shovel's Dig option was available but the local
 /// player exited after choosing something else or skipping the campfire.
 /// </summary>
-[HarmonyPatch(typeof(RestSiteSynchronizer), nameof(RestSiteSynchronizer.BeforeLocalRestSiteExited))]
+[HarmonyPatch]
 public static class RestSiteSynchronizerShovelStatsPatch
 {
     private static readonly FieldInfo? LocalPlayerIdField =
         AccessTools.Field(typeof(RestSiteSynchronizer), "_localPlayerId");
+
+    private static MethodBase? TargetMethod()
+        => AccessTools.Method(typeof(RestSiteSynchronizer), "BeforeLocalRestSiteExited");
 
     [HarmonyPrefix]
     public static void Prefix(RestSiteSynchronizer __instance)

--- a/Core/Patches/RegaliteStatsPatch.cs
+++ b/Core/Patches/RegaliteStatsPatch.cs
@@ -1,0 +1,50 @@
+using System;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Regalite grants block whenever its owner creates a combat card. Count the
+/// created card at the owner callback and let Hook.AfterBlockGained capture the
+/// actual block amount after modifiers.
+/// </summary>
+[HarmonyPatch(typeof(Regalite), nameof(Regalite.AfterCardGeneratedForCombat))]
+public static class RegaliteAfterCardGeneratedForCombatPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Regalite __instance, CardModel card, Player creator)
+    {
+        try
+        {
+            if (__instance?.Owner == null || card == null || creator == null) return;
+            if (!ReferenceEquals(__instance.Owner, creator)) return;
+
+            RunTracker.RecordRegaliteCardCreatedAndArmBlockAttribution(__instance, creator);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RegaliteAfterCardGeneratedForCombatPatch failed: {e.Message}");
+        }
+    }
+}
+
+[HarmonyPatch(typeof(Hook), nameof(Hook.AfterPlayerTurnStart))]
+public static class HookAfterPlayerTurnStartRegalitePatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Player player)
+    {
+        try
+        {
+            RunTracker.RecordRegaliteTurnStarted(player);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"HookAfterPlayerTurnStartRegalitePatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -859,6 +859,9 @@ public static class RelicHoverShowPatch
         if (IsMiniatureCannonStatsRelicModel(relicModel))
             return "RELIC.MINIATURE_CANNON";
 
+        if (IsMrStrugglesStatsRelicModel(relicModel))
+            return "RELIC.MR_STRUGGLES";
+
         return relicModel.Id.ToString();
     }
 
@@ -2795,6 +2798,11 @@ public static class RelicHoverShowPatch
     private static bool IsMiniatureCannonStatsRelicModel(object model)
     {
         return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.MiniatureCannon");
+    }
+
+    private static bool IsMrStrugglesStatsRelicModel(object model)
+    {
+        return IsRelicModel(model, "MegaCrit.Sts2.Core.Models.Relics.MrStruggles");
     }
 
     private static bool IsFakeStrikeDummyRelicModel(object model)

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -388,6 +388,16 @@ public static class RelicHoverShowPatch
                 return;
             }
 
+            if (relicNode.Model is Regalite)
+            {
+                const string relicId = "RELIC.REGALITE";
+                var agg = RelicAgg(relicId);
+
+                var body = BuildRegaliteBodyBBCode(agg);
+                StatsTooltip.Show(tree, __instance, "Regalite", "SpireLens", body);
+                return;
+            }
+
             if (relicNode.Model is CloakClasp)
             {
                 const string relicId = "RELIC.CLOAK_CLASP";
@@ -1156,6 +1166,13 @@ public static class RelicHoverShowPatch
             return true;
         }
 
+        if (relicModel is Regalite)
+        {
+            title = "Regalite";
+            body = BuildRegaliteBodyBBCode(agg);
+            return true;
+        }
+
         if (relicModel is CursedPearl)
         {
             title = "Cursed Pearl";
@@ -1893,6 +1910,23 @@ public static class RelicHoverShowPatch
             includeAveragePerCombat: true);
 
         AppendRelatedCurseCardStats(sb, "Enthralled", curseAgg);
+        return sb.ToString();
+    }
+
+    private static string BuildRegaliteBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        var blockPerTurn = agg.RegaliteTurns <= 0
+            ? 0m
+            : (decimal)agg.AdditionalBlockGained / agg.RegaliteTurns;
+        var blockPerCombat = agg.RegaliteCombats <= 0
+            ? 0m
+            : (decimal)agg.AdditionalBlockGained / agg.RegaliteCombats;
+
+        Row3(sb, "Cards created", agg.RegaliteCardsCreated.ToString(), "");
+        Row3(sb, BlockLabel("block gained"), agg.AdditionalBlockGained.ToString(), "");
+        Row3(sb, BlockLabel("avg block per turn"), FormatDecimal(blockPerTurn), "");
+        Row3(sb, BlockLabel("avg block per combat"), FormatDecimal(blockPerCombat), "");
         return sb.ToString();
     }
 

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -390,8 +390,8 @@ public class RelicAggregate
 
     // Total block gained from this relic across all combats.
     // Used by Orichalcum, Permafrost, The Abacus, Bone Flute, Cloak Clasp,
-    // Anchor, Horn Cleat, Tuning Fork, and Vambrace's extra block from its
-    // multiplier.
+    // Anchor, Horn Cleat, Tuning Fork, Regalite, and Vambrace's extra block
+    // from its multiplier.
     public int AdditionalBlockGained { get; set; }
 
     // Total times this relic got its own trigger check but was blocked by
@@ -587,6 +587,13 @@ public class RelicAggregate
     public int PaperPhrogEnhancedAttacks { get; set; }
     public int PaperPhrogCombats { get; set; }
     public int PaperPhrogTurns { get; set; }
+
+    // Regalite tracking. Cards created counts owner-created combat cards while
+    // the relic is held; combats and turns are held denominators for block
+    // averages.
+    public int RegaliteCardsCreated { get; set; }
+    public int RegaliteCombats { get; set; }
+    public int RegaliteTurns { get; set; }
 
     // Bookmark tracking. Activations is total cost-reduction activations;
     // BookmarkCombats is the denominator for average activations per combat.

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1641,6 +1641,9 @@ public static class RunTracker
         target.PaperPhrogEnhancedAttacks += source.PaperPhrogEnhancedAttacks;
         target.PaperPhrogCombats += source.PaperPhrogCombats;
         target.PaperPhrogTurns += source.PaperPhrogTurns;
+        target.RegaliteCardsCreated += source.RegaliteCardsCreated;
+        target.RegaliteCombats += source.RegaliteCombats;
+        target.RegaliteTurns += source.RegaliteTurns;
 
         target.BookmarkCombats += source.BookmarkCombats;
         target.BookmarkCommonActivations += source.BookmarkCommonActivations;
@@ -2309,6 +2312,7 @@ public static class RunTracker
     private const string MiniatureCannonRelicId = "RELIC.MINIATURE_CANNON";
     private const string VajraRelicId = "RELIC.VAJRA";
     private const string PaperPhrogRelicId = "RELIC.PAPER_PHROG";
+    private const string RegaliteRelicId = "RELIC.REGALITE";
     private const string BookmarkRelicId = "RELIC.BOOKMARK";
     private const string BrilliantScarfRelicId = "RELIC.BRILLIANT_SCARF";
     private const string JuzuBraceletRelicId = "RELIC.JUZU_BRACELET";
@@ -5762,6 +5766,56 @@ public static class RunTracker
         }
     }
 
+    public static void RecordRegaliteCardCreatedAndArmBlockAttribution(Regalite relic, Player creator)
+    {
+        if (relic?.Owner == null || creator == null) return;
+        if (!ReferenceEquals(relic.Owner, creator)) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedRelic(relic)) return;
+                if (!IsTrackedPlayer(creator)) return;
+
+                _pendingCombat ??= new PendingCombat();
+                RecordRegaliteCombatForPlayerLocked(creator);
+                RecordRegaliteTurnForPlayerLocked(creator);
+
+                var agg = GetOrCreatePendingRelicAggregateLocked(RegaliteRelicId);
+                RecordRegaliteCardCreatedForTest(agg);
+                _pendingCombat.Windows.Arm(
+                    RegaliteRelicId,
+                    AttributionEventKind.PlayerBlockGain,
+                    CurrentHistoryCountLocked(),
+                    maxHistoryAdvance: -1);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordRegaliteCardCreatedAndArmBlockAttribution failed: {e.Message}");
+            }
+        }
+    }
+
+    public static void RecordRegaliteTurnStarted(Player player)
+    {
+        if (player == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedPlayer(player)) return;
+                _pendingCombat ??= new PendingCombat();
+                RecordRegaliteTurnForPlayerLocked(player);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordRegaliteTurnStarted failed: {e.Message}");
+            }
+        }
+    }
+
     internal static void RecordPaperPhrogVulnerableBonusForTest(
         RelicAggregate agg,
         decimal damageAdded,
@@ -5783,6 +5837,24 @@ public static class RunTracker
     {
         if (agg == null) return;
         agg.PaperPhrogTurns += Math.Max(0, count);
+    }
+
+    internal static void RecordRegaliteCardCreatedForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RegaliteCardsCreated += Math.Max(0, count);
+    }
+
+    internal static void RecordRegaliteCombatForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RegaliteCombats += Math.Max(0, count);
+    }
+
+    internal static void RecordRegaliteTurnForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RegaliteTurns += Math.Max(0, count);
     }
 
     internal static void RecordBookmarkCombatForTest(RelicAggregate agg, int count = 1)
@@ -8253,6 +8325,18 @@ public static class RunTracker
         }
     }
 
+    private static bool PlayerHasRegalite(Player player)
+    {
+        try
+        {
+            return player.Relics.Any(r => r is Regalite);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static bool PlayerHasJuzuBracelet(Player player)
     {
         try
@@ -8304,6 +8388,7 @@ public static class RunTracker
             RecordBookmarkCombatForPlayerLocked(player);
             RecordPaelsEyeCombatForPlayerLocked(player);
             RecordPaperPhrogCombatForPlayerLocked(player);
+            RecordRegaliteCombatForPlayerLocked(player);
         }
         catch (Exception e)
         {
@@ -8427,6 +8512,36 @@ public static class RunTracker
 
         var agg = GetOrCreatePendingRelicAggregateLocked(PaperPhrogRelicId);
         RecordPaperPhrogTurnForTest(agg);
+    }
+
+    private static void RecordRegaliteCombatForPlayerLocked(Player player)
+    {
+        if (_pendingCombat == null) return;
+        if (!PlayerHasRegalite(player)) return;
+        if (!_pendingCombat.RegaliteCombatCountedPlayers.Add(player)) return;
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(RegaliteRelicId);
+        RecordRegaliteCombatForTest(agg);
+    }
+
+    private static void RecordRegaliteTurnForPlayerLocked(Player player)
+    {
+        if (_pendingCombat == null) return;
+        if (!PlayerHasRegalite(player)) return;
+
+        var turnNumber = player.PlayerCombatState?.TurnNumber ?? 0;
+        if (turnNumber <= 0) return;
+        if (_pendingCombat.RegaliteTurnCountedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return;
+        }
+
+        _pendingCombat.RegaliteTurnCountedTurns[player] = turnNumber;
+        RecordRegaliteCombatForPlayerLocked(player);
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(RegaliteRelicId);
+        RecordRegaliteTurnForTest(agg);
     }
 
     private static void RecordNutritiousSoupCombatForPlayerLocked(Player player)
@@ -12172,6 +12287,10 @@ internal class PendingCombat
     public HashSet<Player> PaperPhrogCombatCountedPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Player, int> PaperPhrogTurnCountedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public HashSet<Player> RegaliteCombatCountedPlayers { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> RegaliteTurnCountedTurns { get; }
         = new(ReferenceEqualityComparer.Instance);
     public HashSet<Player> PaelsEyeCombatCountedPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -179,6 +179,31 @@ public static class RunTracker
         get { lock (_lock) return _currentRun; }
     }
 
+    public static bool AreCardStatsDisabledForActiveCombat()
+    {
+        lock (_lock)
+        {
+            return !ShouldTrackCardStatsDuringCombatLocked();
+        }
+    }
+
+    private static bool ShouldTrackCardStatsDuringCombatLocked()
+    {
+        return ShouldTrackCardStatsDuringCombat(
+            RuntimeOptionsProvider.Current.DisableCardStatsDuringCombat,
+            _pendingCombat != null || CombatManager.Instance?.IsInProgress == true);
+    }
+
+    internal static bool ShouldTrackCardStatsDuringCombatForTest(
+        bool disableCardStatsDuringCombat,
+        bool combatActive)
+        => ShouldTrackCardStatsDuringCombat(disableCardStatsDuringCombat, combatActive);
+
+    private static bool ShouldTrackCardStatsDuringCombat(
+        bool disableCardStatsDuringCombat,
+        bool combatActive)
+        => !disableCardStatsDuringCombat || !combatActive;
+
     /// <summary>
     /// Serialize the current run to JSON in the canonical on-disk wire format
     /// (snake_case, WhenWritingNull, IncludeFields) UNDER the lock, so external
@@ -1432,11 +1457,19 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            RuntimeOptionsProvider.Refresh();
             // Fresh pending buffer for this combat. Anything accumulated from a prior
             // combat that didn't get a CombatEnded (shouldn't happen but defensive) is dropped.
             _pendingCombat = new PendingCombat();
             ResetCombatContextState();
-            RecordCombatsInDeckForCurrentDeckLocked();
+            if (ShouldTrackCardStatsDuringCombatLocked())
+            {
+                RecordCombatsInDeckForCurrentDeckLocked();
+            }
+            else
+            {
+                CoreMain.Logger.Info("SpireLens card combat stats are disabled for this combat.");
+            }
             RecordHeldCombatRelicBaselinesForTrackedPlayerLocked(requireActiveCombat: false, createPendingIfNeeded: false);
         }
     }
@@ -1720,11 +1753,17 @@ public static class RunTracker
             // and the backing counter was the one tracker static mutated
             // outside _lock, so it was removed.)
             CoreMain.LogDebug($"Observe #{n}: {entry.GetType().Name}");
+            bool trackCardStats;
+            lock (_lock)
+            {
+                trackCardStats = ShouldTrackCardStatsDuringCombatLocked();
+            }
 
             switch (entry)
             {
                 case CardPlayStartedEntry cps when cps.CardPlay != null:
-                    NoteCardPlayStarted(cps.CardPlay);
+                    if (trackCardStats)
+                        NoteCardPlayStarted(cps.CardPlay);
                     break;
                 case CardPlayFinishedEntry cpf:
                     var card = cpf.CardPlay?.Card;
@@ -1734,23 +1773,26 @@ public static class RunTracker
                     CoreMain.LogDebug($"  -> RecordCardPlay '{card?.Title ?? "?"}' hash={card?.GetHashCode()} canonicalHash={(card == null ? 0 : Canonical(card).GetHashCode())}");
                     if (cpf.CardPlay != null)
                     {
-                        NoteCardPlayFinished(cpf.CardPlay);
+                        if (trackCardStats)
+                            NoteCardPlayFinished(cpf.CardPlay);
                         RecordCardPlay(cpf.CardPlay);
                     }
                     break;
                 case CardDrawnEntry cde:
                     // Draw-hook validation is complete; keep the trace debug-gated.
                     CoreMain.LogDebug($"CardDrawnEntry card='{cde.Card?.Title ?? "null"}' fromHandDraw={cde.FromHandDraw}");
-                    if (cde.Card != null) RecordCardDrawn(cde);
+                    if (trackCardStats && cde.Card != null) RecordCardDrawn(cde);
                     break;
                 case CardDiscardedEntry cdisc when cdisc.Card != null:
                     RecordCardDiscarded(cdisc.Card);
                     break;
                 case CardExhaustedEntry cex when cex.Card != null:
-                    RecordCardExhausted(cex.Card);
+                    if (trackCardStats)
+                        RecordCardExhausted(cex.Card);
                     break;
                 case BlockGainedEntry bge:
-                    RecordBlockGainedEntry(bge);
+                    if (trackCardStats)
+                        RecordBlockGainedEntry(bge);
                     break;
                 case DamageReceivedEntry dre:
                     // Remember the result ref so the combat-ending capture
@@ -1760,17 +1802,19 @@ public static class RunTracker
 
                     if (dre.Receiver.IsPlayer)
                     {
-                        RecordPlayerBlockedDamage(dre);
+                        if (trackCardStats)
+                            RecordPlayerBlockedDamage(dre);
                     }
 
                     RecordEnemyDamage(dre);
 
                     if (dre.CardSource != null)
                     {
-                        CoreMain.LogDebug($"  -> RecordDamage from '{dre.CardSource.Title}' intended={dre.Result.BlockedDamage + dre.Result.UnblockedDamage} canonicalHash={Canonical(dre.CardSource).GetHashCode()}");
+                        if (trackCardStats)
+                            CoreMain.LogDebug($"  -> RecordDamage from '{dre.CardSource.Title}' intended={dre.Result.BlockedDamage + dre.Result.UnblockedDamage} canonicalHash={Canonical(dre.CardSource).GetHashCode()}");
                         RecordDamageFromCard(dre);
                     }
-                    else if (!dre.Receiver.IsPlayer && TryRecordPoisonTickDamage(dre))
+                    else if (trackCardStats && !dre.Receiver.IsPlayer && TryRecordPoisonTickDamage(dre))
                     {
                         break;
                     }
@@ -1815,6 +1859,14 @@ public static class RunTracker
             // Defensive: if CombatSetUp never fired (unusual), allocate lazily.
             _pendingCombat ??= new PendingCombat();
 
+            RecordStrikeDummyStrikePlayedIfOwnedLocked(cardPlay.Card);
+            RecordNutritiousSoupEnchantedStrikePlayedIfOwnedLocked(cardPlay.Card);
+            RecordMiniatureCannonUpgradedAttackPlayedIfOwnedLocked(cardPlay.Card);
+            RecordVajraAttackPlayedIfOwnedLocked(cardPlay.Card);
+            RecordBrilliantScarfDiscountTaken(cardPlay);
+
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             // Per-instance tracking: each physical card in the deck gets its
             // own aggregates bucket. First play assigns its instance id.
             var instanceId = GetOrAssignInstanceId(cardPlay.Card);
@@ -1823,10 +1875,6 @@ public static class RunTracker
             agg.Plays++;
             if (IsEtherealCard(cardPlay.Card))
                 _pendingCombat.EtherealCardsPlayed++;
-            RecordStrikeDummyStrikePlayedIfOwnedLocked(cardPlay.Card);
-            RecordNutritiousSoupEnchantedStrikePlayedIfOwnedLocked(cardPlay.Card);
-            RecordMiniatureCannonUpgradedAttackPlayedIfOwnedLocked(cardPlay.Card);
-            RecordVajraAttackPlayedIfOwnedLocked(cardPlay.Card);
             if (IsReplayExtraPlay(cardPlay))
             {
                 agg.TimesReplayExtraPlayed++;
@@ -1845,7 +1893,6 @@ public static class RunTracker
             // actually cost me on average" analysis.
             agg.TotalEnergySpent += cardPlay.Resources.EnergySpent;
             agg.TotalStarsSpent += cardPlay.Resources.StarsSpent;
-            RecordBrilliantScarfDiscountTaken(cardPlay);
 
             _pendingCombat.CombatEvents.Add(new CardEvent
             {
@@ -1872,6 +1919,7 @@ public static class RunTracker
 
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
             EnqueueReplayExtraPlaySourceLocked(glam.Card, "enchantment:GLAM", "Glam", extra);
         }
     }
@@ -1889,6 +1937,7 @@ public static class RunTracker
 
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
             foreach (var modifier in modifyingModels)
             {
                 if (modifier == null || remaining <= 0) break;
@@ -1909,6 +1958,7 @@ public static class RunTracker
         int count)
     {
         if (card == null || count <= 0) return;
+        if (!ShouldTrackCardStatsDuringCombatLocked()) return;
 
         var key = Canonical(card);
         if (_pendingReplayExtraPlaySeriesStarted.Remove(key))
@@ -2129,6 +2179,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 var causingPlay = FindCurrentlyResolvingCardPlay();
                 if (causingPlay?.Card == null) return;
 
@@ -2171,6 +2223,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 var causingPlay = FindCurrentlyResolvingCardPlay();
                 if (causingPlay?.Card == null) return;
 
@@ -2213,6 +2267,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 if (source is not CardModel sourceCard) return;
                 if (forger != null && sourceCard.Owner != null
                     && !ReferenceEquals(sourceCard.Owner, forger))
@@ -3007,6 +3063,7 @@ public static class RunTracker
             try
             {
                 if (!IsTrackedPlayerCreature(target)) return;
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
 
                 _pendingCombat ??= new PendingCombat();
                 RecordUnmovablePowerExtraBlockForTest(_pendingCombat.MetaStats, extraBlock);
@@ -4203,6 +4260,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 _pendingCombat ??= new PendingCombat();
                 var instanceId = GetOrAssignInstanceId(card);
                 var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
@@ -4230,6 +4289,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 _pendingCombat ??= new PendingCombat();
                 var instanceId = GetOrAssignInstanceId(sourceCard);
                 var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
@@ -4287,6 +4348,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 _pendingCombat ??= new PendingCombat();
                 _pendingCombat.MetaStats.TotalOstyDamageAbsorbed += hpLost;
             }
@@ -9270,6 +9333,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 if (makeItSo.Owner == null || cardPlay?.Card == null) return;
                 if (!ReferenceEquals(cardPlay.Card.Owner, makeItSo.Owner)) return;
                 if (cardPlay.Card.Type != CardType.Skill) return;
@@ -9302,6 +9367,8 @@ public static class RunTracker
 
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return false;
+
                 threshold = GetMakeItSoThreshold(card);
                 if (threshold <= 0) return false;
                 if (card.Owner == null || card.CombatState == null) return false;
@@ -9689,6 +9756,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             _pendingCombat ??= new PendingCombat();
             var instanceId = GetOrAssignInstanceId(entry.Card);
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
@@ -9721,6 +9790,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             _pendingCombat ??= new PendingCombat();
             var instanceId = GetOrAssignInstanceId(card);
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
@@ -9736,9 +9807,12 @@ public static class RunTracker
         lock (_lock)
         {
             _pendingCombat ??= new PendingCombat();
-            var instanceId = GetOrAssignInstanceId(card);
-            var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
-            agg.TimesDiscarded++;
+            if (ShouldTrackCardStatsDuringCombatLocked())
+            {
+                var instanceId = GetOrAssignInstanceId(card);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                agg.TimesDiscarded++;
+            }
 
             if (card.Owner is Player player
                 && IsTrackedPlayer(player)
@@ -9761,6 +9835,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             _pendingCombat ??= new PendingCombat();
             var exhaustedId = GetOrAssignInstanceId(exhaustedCard);
             var exhaustedAgg = GetOrCreateAggregate(_pendingCombat, exhaustedId);
@@ -9816,6 +9892,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             if (fromHandDraw)
             {
                 _pendingDrawSourceCard = null;
@@ -9851,6 +9929,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             if (source is CardModel sourceCard)
             {
                 _pendingEffectSourceCard = Canonical(sourceCard);
@@ -9865,6 +9945,8 @@ public static class RunTracker
 
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             if (!string.Equals(Canonical(card).Id.ToString(), ShivDefinitionId, StringComparison.Ordinal))
                 return;
 
@@ -9894,6 +9976,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 var target = TryResolvePoisonPowerTarget(poisonPower);
                 if (target == null || target.IsPlayer) return;
 
@@ -9924,6 +10008,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 if (noxiousFumesPower is not PowerModel power) return;
 
                 var owner = GetPowerReceiverCreature(power);
@@ -9991,6 +10077,8 @@ public static class RunTracker
 
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             var canonical = Canonical(card);
             var definitionId = canonical.Id.ToString();
 
@@ -10035,6 +10123,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             _sovereignBladeAvailableThisRun = true;
 
             EnsureLazyCurrentRunLocked();
@@ -10064,6 +10154,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             _pendingPowerChangeAttempts.Add(new PendingPowerChangeAttempt
             {
                 Power = power,
@@ -10085,6 +10177,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             var attempt = TakePendingPowerChangeAttemptLocked(canonicalPower, target, applier, requestedAmount);
 
             if (modifiedAmount != 0m) return;
@@ -10773,6 +10867,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             _pendingCombat ??= new PendingCombat();
             var instanceId = GetOrAssignInstanceId(card);
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
@@ -10819,6 +10915,8 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             if (fromHandDraw) return;
 
             _pendingCombat ??= new PendingCombat();
@@ -10851,6 +10949,8 @@ public static class RunTracker
         {
             try
             {
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
                 if (_pendingMakeItSoSummons.Count > 0
                     && card is MakeItSo
                     && oldPile != PileType.Hand)
@@ -10944,6 +11044,8 @@ public static class RunTracker
                 var target = TryResolvePowerReceivedTarget(entry);
                 if (target != null && entry.Amount > 0m)
                     RecordUnsettlingLampPowerReceivedLocked(entry.Power, target, entry.Applier, entry.Amount);
+
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
 
                 var causingPlay = FindCurrentlyResolvingCardPlay();
                 if (causingPlay?.Card == null)
@@ -11254,6 +11356,7 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
             if (!creature.IsPlayer) return;
             _pendingPlayerBlockClearAmount = Math.Max(0, creature.Block);
             _pendingPlayerBlockClearArmed = _pendingPlayerBlockClearAmount > 0;
@@ -11264,6 +11367,7 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
             if (!creature.IsPlayer) return;
             ClearPendingPlayerBlockClearLocked();
         }
@@ -11273,6 +11377,7 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
             if (!creature.IsPlayer) return;
 
             if (_pendingCombat == null)
@@ -11435,6 +11540,14 @@ public static class RunTracker
         lock (_lock)
         {
             _pendingCombat ??= new PendingCombat();
+            if (!entry.Receiver.IsPlayer)
+            {
+                RecordMiniatureCannonUpgradedAttackHitIfOwnedLocked(entry.CardSource!);
+                RecordVajraAttackHitIfOwnedLocked(entry.CardSource!);
+            }
+
+            if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
             var instanceId = GetOrAssignInstanceId(entry.CardSource!);
             var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
             MarkReplayAttackDamageLocked(entry.CardSource!);
@@ -11477,8 +11590,6 @@ public static class RunTracker
                 agg.TotalOverkill += result.OverkillDamage;
                 agg.TotalEffective += damageTotals.EffectiveDamage;
                 if (result.WasTargetKilled) agg.Kills++;
-                RecordMiniatureCannonUpgradedAttackHitIfOwnedLocked(entry.CardSource!);
-                RecordVajraAttackHitIfOwnedLocked(entry.CardSource!);
 
                 _pendingCombat.CombatEvents.Add(new CardEvent
                 {

--- a/Core/RuntimeOptions.cs
+++ b/Core/RuntimeOptions.cs
@@ -11,6 +11,7 @@ public sealed class RuntimeOptions
     public bool ShowRemovedCardsInDeckView { get; set; } = true;
     public bool ShowHandTooltips { get; set; } = true;
     public bool UseVerboseHandStats { get; set; }
+    public bool DisableCardStatsDuringCombat { get; set; }
     public bool EnableDebugLogging { get; set; }
     public string BuildTimeZoneId { get; set; } = "America/Los_Angeles";
 }

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -216,6 +216,9 @@ New fixtures added going forward do not need a `v*-` prefix.
 - `vambrace-relic-run.json`
   Adds Vambrace activation tracking plus extra block gained from the block
   packets its 2x multiplier actually modified.
+- `regalite-relic-run.json`
+  Adds Regalite tracking for owner-created combat cards, observed block gained,
+  and held turn/combat denominators for average block rows.
 - `tuning-fork-relic-run.json`
   Adds Tuning Fork trigger count and observed block gained tracking.
 - `war-paint-relic-run.json`

--- a/Fixtures/RunSchema/regalite-relic-run.json
+++ b/Fixtures/RunSchema/regalite-relic-run.json
@@ -1,0 +1,30 @@
+{
+  "run_id": "regalite-relic-fixture",
+  "started_at": "2026-07-07T00:00:00Z",
+  "updated_at": "2026-07-07T00:08:00Z",
+  "outcome": "in_progress",
+  "aggregates": {
+    "CARD.SHIV#1": {
+      "plays": 2,
+      "total_block_gained": 0
+    }
+  },
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.REGALITE": {
+      "regalite_cards_created": 6,
+      "additional_block_gained": 12,
+      "regalite_turns": 4,
+      "regalite_combats": 2
+    }
+  },
+  "meta_stats": {},
+  "instance_numbers_by_def": {
+    "CARD.SHIV": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.SHIV": 1
+  }
+}

--- a/Loader/RuntimeOptionsBridge.cs
+++ b/Loader/RuntimeOptionsBridge.cs
@@ -14,6 +14,7 @@ public sealed class RuntimeOptionsSnapshot
     public bool ShowRemovedCardsInDeckView { get; set; } = true;
     public bool ShowHandTooltips { get; set; } = true;
     public bool UseVerboseHandStats { get; set; }
+    public bool DisableCardStatsDuringCombat { get; set; }
     public bool EnableDebugLogging { get; set; }
     public string BuildTimeZoneId { get; set; } = "America/Los_Angeles";
 }
@@ -68,6 +69,7 @@ public static class RuntimeOptionsBridge
             ShowRemovedCardsInDeckView = SpireLensConfig.ShowRemovedCardsInDeckView,
             ShowHandTooltips = SpireLensConfig.ShowHandTooltips,
             UseVerboseHandStats = SpireLensConfig.UseVerboseHandStats,
+            DisableCardStatsDuringCombat = SpireLensConfig.DisableCardStatsDuringCombat,
             EnableDebugLogging = SpireLensConfig.EnableDebugLogging,
             BuildTimeZoneId = BuildMetadataFormatter.GetTimeZoneId(SpireLensConfig.BuildTimeZone),
         };

--- a/Tests/SpireLens.Core.Tests/MrStrugglesStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/MrStrugglesStatsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MegaCrit.Sts2.Core.Models.Relics;
@@ -112,7 +113,9 @@ public class MrStrugglesStatsTests
     [Fact]
     public void RelicTooltip_MrStrugglesModelRecognition_UsesGameRelicId()
     {
-        Assert.Equal(MrStrugglesRelicId, RelicHoverShowPatch.GetStatsAggregateId(new MrStruggles()));
+        var relic = (MrStruggles)RuntimeHelpers.GetUninitializedObject(typeof(MrStruggles));
+
+        Assert.Equal(MrStrugglesRelicId, RelicHoverShowPatch.GetStatsAggregateId(relic));
     }
 
     private static string BuildBody(RelicAggregate agg)

--- a/Tests/SpireLens.Core.Tests/RegaliteStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/RegaliteStatsTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class RegaliteStatsTests
+{
+    private const string RegaliteRelicId = "RELIC.REGALITE";
+
+    private static readonly MethodInfo BuildRegaliteBodyMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildRegaliteBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRegaliteBodyBBCode not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void RelicAggregate_RegaliteFields_DefaultToZero()
+    {
+        var agg = new RelicAggregate();
+
+        Assert.Equal(0, agg.RegaliteCardsCreated);
+        Assert.Equal(0, agg.AdditionalBlockGained);
+        Assert.Equal(0, agg.RegaliteTurns);
+        Assert.Equal(0, agg.RegaliteCombats);
+    }
+
+    [Fact]
+    public void RelicAggregate_RegaliteFields_JsonRoundtrip_PreservesFields()
+    {
+        var run = new RunData();
+        run.RelicAggregates[RegaliteRelicId] = new RelicAggregate
+        {
+            RegaliteCardsCreated = 6,
+            AdditionalBlockGained = 12,
+            RegaliteTurns = 4,
+            RegaliteCombats = 2,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("regalite_cards_created", json);
+        Assert.Contains("additional_block_gained", json);
+        Assert.Contains("regalite_turns", json);
+        Assert.Contains("regalite_combats", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var restoredAgg = restored!.RelicAggregates[RegaliteRelicId];
+        Assert.Equal(6, restoredAgg.RegaliteCardsCreated);
+        Assert.Equal(12, restoredAgg.AdditionalBlockGained);
+        Assert.Equal(4, restoredAgg.RegaliteTurns);
+        Assert.Equal(2, restoredAgg.RegaliteCombats);
+    }
+
+    [Fact]
+    public void RunTracker_RegaliteHelpers_AccumulateAndClamp()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordRegaliteCardCreatedForTest(agg, 6);
+        RunTracker.RecordRegaliteCombatForTest(agg, 2);
+        RunTracker.RecordRegaliteTurnForTest(agg, 4);
+        RunTracker.RecordRegaliteCardCreatedForTest(agg, -1);
+        RunTracker.RecordRegaliteCombatForTest(agg, -2);
+        RunTracker.RecordRegaliteTurnForTest(agg, -4);
+
+        Assert.Equal(6, agg.RegaliteCardsCreated);
+        Assert.Equal(2, agg.RegaliteCombats);
+        Assert.Equal(4, agg.RegaliteTurns);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_RegaliteFields_Accumulates()
+    {
+        var target = new RelicAggregate
+        {
+            RegaliteCardsCreated = 4,
+            AdditionalBlockGained = 8,
+            RegaliteTurns = 3,
+            RegaliteCombats = 1,
+        };
+        var source = new RelicAggregate
+        {
+            RegaliteCardsCreated = 2,
+            AdditionalBlockGained = 4,
+            RegaliteTurns = 1,
+            RegaliteCombats = 1,
+        };
+
+        RunTracker.MergeRelicAggregateInto(target, source);
+
+        Assert.Equal(6, target.RegaliteCardsCreated);
+        Assert.Equal(12, target.AdditionalBlockGained);
+        Assert.Equal(4, target.RegaliteTurns);
+        Assert.Equal(2, target.RegaliteCombats);
+    }
+
+    [Fact]
+    public void RelicTooltip_Regalite_ShowsTotalsAndAverages()
+    {
+        var body = BuildBody(new RelicAggregate
+        {
+            RegaliteCardsCreated = 6,
+            AdditionalBlockGained = 12,
+            RegaliteTurns = 4,
+            RegaliteCombats = 2,
+        });
+
+        Assert.Contains("Cards created", body);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] block gained", body);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] avg block per turn", body);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] avg block per combat", body);
+        Assert.Contains("[b]6[/b]", body);
+        Assert.Contains("[b]12[/b]", body);
+        Assert.Contains("[b]3[/b]", body);
+        Assert.Contains("[b]6[/b]", body);
+    }
+
+    [Fact]
+    public void RelicTooltip_Regalite_ShowsZeroRows()
+    {
+        var body = BuildBody(new RelicAggregate());
+
+        Assert.Contains("Cards created", body);
+        Assert.Contains("block gained", body);
+        Assert.Contains("avg block per turn", body);
+        Assert.Contains("avg block per combat", body);
+        Assert.Contains("[b]0[/b]", body);
+    }
+
+    private static string BuildBody(RelicAggregate agg)
+        => (string)(BuildRegaliteBodyMethod.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException("BuildRegaliteBodyBBCode returned null."));
+}

--- a/Tests/SpireLens.Core.Tests/RuntimeOptionsTests.cs
+++ b/Tests/SpireLens.Core.Tests/RuntimeOptionsTests.cs
@@ -1,0 +1,24 @@
+using SpireLens.Core;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class RuntimeOptionsTests
+{
+    [Fact]
+    public void DisableCardStatsDuringCombat_OnlyPausesActiveCombatCardTracking()
+    {
+        Assert.True(RunTracker.ShouldTrackCardStatsDuringCombatForTest(
+            disableCardStatsDuringCombat: false,
+            combatActive: false));
+        Assert.True(RunTracker.ShouldTrackCardStatsDuringCombatForTest(
+            disableCardStatsDuringCombat: false,
+            combatActive: true));
+        Assert.True(RunTracker.ShouldTrackCardStatsDuringCombatForTest(
+            disableCardStatsDuringCombat: true,
+            combatActive: false));
+        Assert.False(RunTracker.ShouldTrackCardStatsDuringCombatForTest(
+            disableCardStatsDuringCombat: true,
+            combatActive: true));
+    }
+}

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2094,6 +2094,33 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsRegaliteRelicFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("regalite-relic-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        var relicAgg = loaded.Data.RelicAggregates["RELIC.REGALITE"];
+        Assert.Equal(6, relicAgg.RegaliteCardsCreated);
+        Assert.Equal(12, relicAgg.AdditionalBlockGained);
+        Assert.Equal(4, relicAgg.RegaliteTurns);
+        Assert.Equal(2, relicAgg.RegaliteCombats);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsRegaliteRelicFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("regalite-relic-run.json"));
+
+        Assert.NotNull(resumed);
+        var relicAgg = resumed!.RelicAggregates["RELIC.REGALITE"];
+        Assert.Equal(6, relicAgg.RegaliteCardsCreated);
+        Assert.Equal(12, relicAgg.AdditionalBlockGained);
+        Assert.Equal(4, relicAgg.RegaliteTurns);
+        Assert.Equal(2, relicAgg.RegaliteCombats);
+    }
+
+    [Fact]
     public void HistoricalLoad_AcceptsTuningForkRelicFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("tuning-fork-relic-run.json"));


### PR DESCRIPTION
## Summary
- add Regalite relic stats for created cards and block averages
- add a Performance option to disable card-instance stats during combat
- keep relic/enemy stats active while card combat tracking is paused

## Validation
- dotnet test D:\repos\spirelens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug
- dotnet build D:\repos\spirelens\SpireLens.csproj -c Debug
- SpireLens Core hot reload validated before loader redeploy
