### PR TITLE
Fix Booming Conch stats and hide reward card stats

### DIFF
--- a/Core/Patches/BoomingConchStatsPatch.cs
+++ b/Core/Patches/BoomingConchStatsPatch.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Hooks;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Rooms;
 
 namespace SpireLens.Core.Patches;
 
@@ -11,26 +15,32 @@ namespace SpireLens.Core.Patches;
 /// energy gained is measured by PlayerCombatState.GainEnergy.
 /// </summary>
 [HarmonyPatch]
-public static class BoomingConchBeforeSideTurnStartPatch
+public static class BoomingConchAfterSideTurnStartPatch
 {
     private static MethodBase? TargetMethod()
     {
         var t = AccessTools.TypeByName("MegaCrit.Sts2.Core.Models.Relics.BoomingConch");
-        return t == null ? null : AccessTools.Method(t, "BeforeSideTurnStart");
+        return t == null ? null : AccessTools.Method(t, "AfterSideTurnStart");
     }
 
     [HarmonyPrefix]
-    public static void Prefix(CombatSide side, ICombatState combatState)
+    public static void Prefix(
+        RelicModel __instance,
+        CombatSide side,
+        IReadOnlyList<Creature> participants,
+        ICombatState combatState)
     {
         try
         {
-            if (side != CombatSide.Player) return;
-            if (combatState == null || combatState.RoundNumber != 1) return;
-            RunTracker.ArmBoomingConchEnergyAttribution();
+            if (!TurnEnergyRelicPatchHelpers.TryGetTrackedOwnerOnPlayerTurn(__instance, side, participants, out var owner)) return;
+            if (owner.PlayerCombatState == null || owner.PlayerCombatState.TurnNumber > 1) return;
+            if (combatState?.RunState?.CurrentRoom?.RoomType != RoomType.Elite) return;
+
+            RunTracker.ArmBoomingConchEnergyAttribution(owner);
         }
         catch (Exception e)
         {
-            CoreMain.LogDebug($"BoomingConchBeforeSideTurnStartPatch failed: {e.Message}");
+            CoreMain.LogDebug($"BoomingConchAfterSideTurnStartPatch failed: {e.Message}");
         }
     }
 }

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -7,6 +7,7 @@ using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
+using MegaCrit.Sts2.Core.Nodes.Screens.CardSelection;
 
 namespace SpireLens.Core.Patches;
 
@@ -51,6 +52,12 @@ public static class CardHoverShowPatch
 
         if (__instance is NHandCardHolder && !RuntimeOptionsProvider.Current.ShowHandTooltips)
             return;
+
+        if (IsCardRewardSelectionSurface(__instance))
+        {
+            StatsTooltip.Hide();
+            return;
+        }
 
         // Gate on our checkbox state. If it's not even injected yet (no deck
         // view opened this session) or unchecked, do nothing.
@@ -114,6 +121,22 @@ public static class CardHoverShowPatch
         {
             CoreMain.Logger.Error($"CardHoverShow failed: {e.Message}");
         }
+    }
+
+    private static bool IsCardRewardSelectionSurface(Node? node)
+    {
+        for (var current = node; current != null; current = current.GetParent())
+        {
+            if (IsCardRewardSelectionSurfaceType(current.GetType()))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static bool IsCardRewardSelectionSurfaceType(Type? nodeType)
+    {
+        return nodeType != null && typeof(NCardRewardSelectionScreen).IsAssignableFrom(nodeType);
     }
 
     /// <summary>

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -6644,21 +6644,48 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// No-op arm/disarm pair kept wired for Booming Conch's Elite combat-start
-    /// energy. The energy-gain consumer that once read the armed flag was
-    /// already unreachable, so Booming Conch's energy attribution is currently
-    /// non-functional (a known bug: it never routed to the registry). Fixing
-    /// it — arm a PlayerEnergyGain window and credit EnergyGenerated, mirroring
-    /// Happy Flower — is a separate, live-verified change; these seams stay so
-    /// it has a home. (Its card-draw stat via RecordBoomingConchDraw still
-    /// works.)
+    /// Arm Booming Conch's owner-specific Elite combat-start energy
+    /// attribution. The actual energy delta is observed later at
+    /// PlayerCombatState.GainEnergy.
     /// </summary>
-    public static void ArmBoomingConchEnergyAttribution()
+    public static void ArmBoomingConchEnergyAttribution(Player owner)
     {
+        if (owner == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedPlayer(owner)) return;
+
+                _pendingCombat ??= new PendingCombat();
+                _pendingCombat.Windows.Arm(
+                    BoomingConchRelicId,
+                    AttributionEventKind.PlayerEnergyGain,
+                    CurrentHistoryCountLocked(),
+                    ownerId: owner,
+                    maxHistoryAdvance: -1);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"ArmBoomingConchEnergyAttribution failed: {e.Message}");
+            }
+        }
     }
 
     public static void DisarmBoomingConchEnergyAttribution()
     {
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat?.Windows.Disarm(BoomingConchRelicId, AttributionEventKind.PlayerEnergyGain);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"DisarmBoomingConchEnergyAttribution failed: {e.Message}");
+            }
+        }
     }
 
     public static void RecordBoomingConchDraw(int cardsDrawn)

--- a/Tests/SpireLens.Core.Tests/BoomingConchStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/BoomingConchStatsTests.cs
@@ -26,6 +26,7 @@ public class BoomingConchStatsTests
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
+    [Trait("Category", "RequiresLiveGame")]
     [Fact]
     public void EnergyPatch_TargetsAfterSideTurnStart()
     {

--- a/Tests/SpireLens.Core.Tests/BoomingConchStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/BoomingConchStatsTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class BoomingConchStatsTests
+{
+    private const string BoomingConchRelicId = "RELIC.BOOMING_CONCH";
+
+    private static readonly MethodInfo BuildBoomingConchBodyMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildBoomingConchBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildBoomingConchBodyBBCode not found.");
+
+    private static readonly MethodInfo TargetMethod =
+        typeof(BoomingConchAfterSideTurnStartPatch).GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Booming Conch energy TargetMethod not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void EnergyPatch_TargetsAfterSideTurnStart()
+    {
+        var method = TargetMethod.Invoke(null, null) as MethodBase;
+
+        Assert.NotNull(method);
+        Assert.Equal("AfterSideTurnStart", method!.Name);
+    }
+
+    [Fact]
+    public void RelicAggregate_BoomingConchFields_DefaultToZero()
+    {
+        var agg = new RelicAggregate();
+
+        Assert.Equal(0, agg.EnergyGenerated);
+        Assert.Equal(0, agg.AdditionalCardsDrawn);
+    }
+
+    [Fact]
+    public void RelicAggregate_BoomingConchFields_JsonRoundtrip_PreservesFields()
+    {
+        var run = new RunData();
+        run.RelicAggregates[BoomingConchRelicId] = new RelicAggregate
+        {
+            EnergyGenerated = 2,
+            AdditionalCardsDrawn = 4,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("energy_generated", json);
+        Assert.Contains("additional_cards_drawn", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var agg = restored!.RelicAggregates[BoomingConchRelicId];
+        Assert.Equal(2, agg.EnergyGenerated);
+        Assert.Equal(4, agg.AdditionalCardsDrawn);
+    }
+
+    [Fact]
+    public void RelicTooltip_BoomingConch_ShowsEnergyAndCardsDrawn()
+    {
+        var agg = new RelicAggregate
+        {
+            EnergyGenerated = 2,
+            AdditionalCardsDrawn = 4,
+        };
+
+        var body = (string)(BuildBoomingConchBodyMethod.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException("BuildBoomingConchBodyBBCode returned null."));
+
+        Assert.Contains("Energy generated", body);
+        Assert.Contains("Cards drawn", body);
+        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("[b]4[/b]", body);
+    }
+}

--- a/Tests/SpireLens.Core.Tests/CardHoverRewardScreenTests.cs
+++ b/Tests/SpireLens.Core.Tests/CardHoverRewardScreenTests.cs
@@ -1,0 +1,24 @@
+using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
+using MegaCrit.Sts2.Core.Nodes.Screens;
+using MegaCrit.Sts2.Core.Nodes.Screens.CardSelection;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class CardHoverRewardScreenTests
+{
+    [Fact]
+    public void IsCardRewardSelectionSurfaceType_MatchesCardRewardSelectionScreen()
+    {
+        Assert.True(CardHoverShowPatch.IsCardRewardSelectionSurfaceType(typeof(NCardRewardSelectionScreen)));
+    }
+
+    [Fact]
+    public void IsCardRewardSelectionSurfaceType_DoesNotMatchOrdinaryCardSurfaces()
+    {
+        Assert.False(CardHoverShowPatch.IsCardRewardSelectionSurfaceType(typeof(NCardHolder)));
+        Assert.False(CardHoverShowPatch.IsCardRewardSelectionSurfaceType(typeof(NDeckViewScreen)));
+        Assert.False(CardHoverShowPatch.IsCardRewardSelectionSurfaceType(null));
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Booming Conch energy attribution by targeting the actual `AfterSideTurnStart` hook and arming owner-specific observed energy gain attribution.
- Hide SpireLens card stats on card reward selection screens while leaving deck/hand card stats enabled.
- Add focused regression tests for Booming Conch stats and reward-screen hover suppression.

## Validation
- `dotnet test D:\repos\SpireLens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug --filter BoomingConchStatsTests`
- `dotnet test D:\repos\SpireLens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug --filter CardHoverRewardScreenTests`
- `dotnet test D:\repos\SpireLens\Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug`
- SpireLens Core hot reload succeeded; log showed `Core.Initialize complete` and `HOT RELOAD DONE`.