### PR TITLE
Add relic stats for Kunai, Ripple Basin, and Tuning Fork

### DIFF
--- a/Core/Patches/KunaiStatsPatch.cs
+++ b/Core/Patches/KunaiStatsPatch.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models.Powers;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Kunai owns its per-turn attack counter in AfterCardPlayed. The prefix records
+/// attack-count pressure and snapshots Dexterity before the activation resolves;
+/// the postfix records the observed Dexterity delta after the async callback.
+/// </summary>
+[HarmonyPatch(typeof(Kunai), nameof(Kunai.AfterCardPlayed))]
+public static class KunaiAfterCardPlayedPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Kunai __instance, PlayerChoiceContext choiceContext, CardPlay cardPlay, out KunaiActivationState? __state)
+    {
+        __state = null;
+
+        try
+        {
+            if (__instance == null || !RunTracker.IsTrackedRelic(__instance)) return;
+            if (!RunTracker.RecordKunaiAttackPlayedAndShouldObserveActivation(
+                    __instance,
+                    cardPlay,
+                    out var ownerCreature,
+                    out var dexterityBefore))
+            {
+                return;
+            }
+
+            if (ownerCreature == null) return;
+            __state = new KunaiActivationState(ownerCreature, dexterityBefore);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KunaiAfterCardPlayedPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(Task __result, KunaiActivationState? __state)
+    {
+        if (__state == null) return;
+
+        try
+        {
+            if (__result == null)
+            {
+                FinalizeActivation(__state);
+                return;
+            }
+
+            if (__result.IsCompleted)
+            {
+                if (__result.IsCompletedSuccessfully)
+                    FinalizeActivation(__state);
+                return;
+            }
+
+            __result.ContinueWith(
+                task =>
+                {
+                    if (task.IsCompletedSuccessfully)
+                        FinalizeActivation(__state);
+                },
+                TaskScheduler.Default);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KunaiAfterCardPlayedPatch.Postfix failed: {e.Message}");
+        }
+    }
+
+    private static void FinalizeActivation(KunaiActivationState state)
+    {
+        try
+        {
+            var dexterityAfter = state.OwnerCreature.GetPower<DexterityPower>()?.Amount ?? 0;
+            RunTracker.RecordKunaiActivation(Math.Max(0, dexterityAfter - state.DexterityBefore));
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KunaiAfterCardPlayedPatch finalize failed: {e.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// Snapshots Kunai's per-turn charge at the end of each player turn while held.
+/// Bound by runtime lookup so a game hook rename does not break build.
+/// </summary>
+[HarmonyPatch]
+public static class HookBeforeSideTurnEndKunaiPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        var hookType = Sts2CoreAssembly()?.GetType("MegaCrit.Sts2.Core.Hooks.Hook", throwOnError: false);
+        if (hookType == null) return null;
+
+        return AccessTools.Method(hookType, "BeforeSideTurnEnd")
+            ?? AccessTools.Method(hookType, "BeforeTurnEnd");
+    }
+
+    private static Assembly? Sts2CoreAssembly()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.GetName().Name == "sts2") return assembly;
+        }
+
+        return null;
+    }
+
+    private static bool Prepare() => TargetMethod() != null;
+
+    [HarmonyPrefix]
+    public static void Prefix(CombatSide side, IEnumerable<Creature> participants)
+    {
+        try
+        {
+            if (side != CombatSide.Player) return;
+            RunTracker.RecordKunaiTurnEnded(participants);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"HookBeforeSideTurnEndKunaiPatch failed: {e.Message}");
+        }
+    }
+}
+
+public sealed class KunaiActivationState
+{
+    public KunaiActivationState(Creature ownerCreature, int dexterityBefore)
+    {
+        OwnerCreature = ownerCreature;
+        DexterityBefore = dexterityBefore;
+    }
+
+    public Creature OwnerCreature { get; }
+    public int DexterityBefore { get; }
+}

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -237,6 +237,16 @@ public static class RelicHoverShowPatch
                 return;
             }
 
+            if (relicNode.Model is Kunai)
+            {
+                const string relicId = "RELIC.KUNAI";
+                var agg = RelicAgg(relicId);
+
+                var body = BuildKunaiBodyBBCode(agg);
+                StatsTooltip.Show(tree, __instance, "Kunai", "SpireLens", body);
+                return;
+            }
+
             if (relicNode.Model is Lantern)
             {
                 const string relicId = "RELIC.LANTERN";
@@ -1047,6 +1057,13 @@ public static class RelicHoverShowPatch
         {
             title = "Vajra";
             body = BuildVajraBodyBBCode(agg);
+            return true;
+        }
+
+        if (relicModel is Kunai)
+        {
+            title = "Kunai";
+            body = BuildKunaiBodyBBCode(agg);
             return true;
         }
 
@@ -2400,6 +2417,22 @@ public static class RelicHoverShowPatch
         var sb = new StringBuilder();
         Row3(sb, "Attacks played", agg.VajraAttacksPlayed.ToString(), "");
         Row3(sb, "Attack hits", agg.VajraAttackHits.ToString(), "");
+        return sb.ToString();
+    }
+
+    private static string BuildKunaiBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        var averageEndCharge = agg.KunaiTurnEndChargeCount <= 0
+            ? 0m
+            : (decimal)agg.KunaiTurnEndChargeTotal / agg.KunaiTurnEndChargeCount;
+
+        Row3(sb, "Attacks played", agg.KunaiAttacksPlayed.ToString(), "");
+        Row3(sb, "Activations", agg.Activations.ToString(), "");
+        Row3(sb, "Dexterity gained", agg.KunaiDexterityGained.ToString(), "");
+        Row3(sb, "Turns ended at 1 charge", agg.KunaiTurnsEndedAt1Charge.ToString(), "");
+        Row3(sb, "Turns ended at 2 charges", agg.KunaiTurnsEndedAt2Charges.ToString(), "");
+        Row3(sb, "Avg charge at turn end", FormatDecimal(averageEndCharge), "");
         return sb.ToString();
     }
 

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -1597,8 +1597,28 @@ public static class RelicHoverShowPatch
     private static string BuildTuningForkBodyBBCode(RelicAggregate agg)
     {
         var sb = new StringBuilder();
+        var blockPerActivation = agg.Activations <= 0
+            ? 0m
+            : (decimal)agg.AdditionalBlockGained / agg.Activations;
+        var skillsPerCombat = agg.TuningForkCombats <= 0
+            ? 0m
+            : (decimal)agg.TuningForkSkillsPlayed / agg.TuningForkCombats;
+        var skillsPerTurn = agg.TuningForkTurns <= 0
+            ? 0m
+            : (decimal)agg.TuningForkSkillsPlayed / agg.TuningForkTurns;
+        var averageEndCharge = agg.TuningForkTurnEndChargeCount <= 0
+            ? 0m
+            : (decimal)agg.TuningForkTurnEndChargeTotal / agg.TuningForkTurnEndChargeCount;
+
+        Row3(sb, "Skills played", agg.TuningForkSkillsPlayed.ToString(), "");
         Row3(sb, "Activations", agg.Activations.ToString(), "");
         Row3(sb, BlockLabel("block gained"), agg.AdditionalBlockGained.ToString(), "");
+        Row3(sb, BlockLabel("block gained per activation"), FormatDecimal(blockPerActivation), "");
+        Row3(sb, "Avg skills played per combat", FormatDecimal(skillsPerCombat), "");
+        Row3(sb, "Avg skills played per turn", FormatDecimal(skillsPerTurn), "");
+        Row3(sb, "Turns ended on 8 charges", agg.TuningForkTurnsEndedOn8Charges.ToString(), "");
+        Row3(sb, "Turns ended on 9 charges", agg.TuningForkTurnsEndedOn9Charges.ToString(), "");
+        Row3(sb, "Avg charge at turn end", FormatDecimal(averageEndCharge), "");
         return sb.ToString();
     }
 

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -126,6 +126,16 @@ public static class RelicHoverShowPatch
                 return;
             }
 
+            if (relicNode.Model is RippleBasin)
+            {
+                const string relicId = "RELIC.RIPPLE_BASIN";
+                var agg = RelicAgg(relicId);
+
+                var body = BuildRippleBasinBodyBBCode(agg);
+                StatsTooltip.Show(tree, __instance, "Ripple Basin", "SpireLens", body);
+                return;
+            }
+
             if (relicNode.Model is TheAbacus)
             {
                 const string relicId = "RELIC.THE_ABACUS";
@@ -983,6 +993,13 @@ public static class RelicHoverShowPatch
             return true;
         }
 
+        if (relicModel is RippleBasin)
+        {
+            title = "Ripple Basin";
+            body = BuildRippleBasinBodyBBCode(agg);
+            return true;
+        }
+
         if (relicModel is TheAbacus)
         {
             title = "The Abacus";
@@ -1582,6 +1599,19 @@ public static class RelicHoverShowPatch
         var sb = new StringBuilder();
         Row3(sb, "Activations", agg.Activations.ToString(), "");
         Row3(sb, BlockLabel("block gained"), agg.AdditionalBlockGained.ToString(), "");
+        return sb.ToString();
+    }
+
+    private static string BuildRippleBasinBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        var blockPerActivation = agg.Activations <= 0
+            ? 0m
+            : (decimal)agg.AdditionalBlockGained / agg.Activations;
+
+        Row3(sb, "Activations", agg.Activations.ToString(), "");
+        Row3(sb, BlockLabel("block gained"), agg.AdditionalBlockGained.ToString(), "");
+        Row3(sb, BlockLabel("block gained per activation"), FormatDecimal(blockPerActivation), "");
         return sb.ToString();
     }
 

--- a/Core/Patches/RippleBasinStatsPatch.cs
+++ b/Core/Patches/RippleBasinStatsPatch.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Records Ripple Basin when its owner-specific no-Attack turn-end callback
+/// is about to grant block. The block amount itself is observed later by
+/// Hook.AfterBlockGained, after the game applies block modifiers.
+/// </summary>
+[HarmonyPatch(typeof(RippleBasin), nameof(RippleBasin.BeforeSideTurnEnd))]
+public static class RippleBasinBeforeSideTurnEndPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(
+        RippleBasin __instance,
+        CombatSide side,
+        IEnumerable<Creature> participants,
+        out bool __state)
+    {
+        __state = false;
+
+        try
+        {
+            if (!ShouldArm(__instance, side, participants)) return;
+            RunTracker.RecordRippleBasinActivationAndArmBlockAttribution();
+            __state = true;
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RippleBasinBeforeSideTurnEndPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(bool __state, Task __result)
+    {
+        try
+        {
+            if (!__state) return;
+            if (__result == null)
+            {
+                RunTracker.DisarmRippleBasinBlockAttribution();
+                return;
+            }
+
+            __result.ContinueWith(
+                _ => RunTracker.DisarmRippleBasinBlockAttribution(),
+                TaskScheduler.Default);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RippleBasinBeforeSideTurnEndPatch.Postfix failed: {e.Message}");
+        }
+    }
+
+    private static bool ShouldArm(RippleBasin relic, CombatSide side, IEnumerable<Creature>? participants)
+    {
+        if (relic?.Owner?.Creature == null) return false;
+        if (!RunTracker.IsTrackedRelic(relic)) return false;
+        if (!CombatManager.Instance.IsInProgress) return false;
+        if (side != CombatSide.Player) return false;
+        if (participants == null || !participants.Contains(relic.Owner.Creature)) return false;
+
+        var combatState = relic.Owner.Creature.CombatState;
+        var finishedPlays = CombatManager.Instance?.History?.CardPlaysFinished;
+        if (finishedPlays == null) return false;
+
+        return !finishedPlays.Any(e =>
+            e.CardPlay?.Card != null
+            && e.HappenedThisTurn(combatState)
+            && e.CardPlay.Card.Type == CardType.Attack
+            && ReferenceEquals(e.CardPlay.Card.Owner, relic.Owner));
+    }
+}

--- a/Core/Patches/TuningForkAfterCardPlayedPatch.cs
+++ b/Core/Patches/TuningForkAfterCardPlayedPatch.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.GameActions.Multiplayer;
 using MegaCrit.Sts2.Core.Models.Relics;
 
@@ -27,8 +30,7 @@ public static class TuningForkAfterCardPlayedPatch
 
         try
         {
-            if (!ShouldArm(__instance, cardPlay)) return;
-            RunTracker.RecordTuningForkActivationAndArmBlockAttribution();
+            if (!RunTracker.RecordTuningForkSkillPlayedAndShouldArmBlockAttribution(__instance, cardPlay)) return;
             __state = true;
         }
         catch (Exception e)
@@ -58,15 +60,48 @@ public static class TuningForkAfterCardPlayedPatch
             CoreMain.LogDebug($"TuningForkAfterCardPlayedPatch.Postfix failed: {e.Message}");
         }
     }
+}
 
-    private static bool ShouldArm(TuningFork relic, CardPlay cardPlay)
+/// <summary>
+/// Snapshots Tuning Fork's persistent Skill counter at the end of each player
+/// turn while held. Bound by runtime lookup so a game hook rename does not
+/// break build.
+/// </summary>
+[HarmonyPatch]
+public static class HookBeforeSideTurnEndTuningForkPatch
+{
+    private static MethodBase? TargetMethod()
     {
-        if (relic?.Owner == null || cardPlay?.Card == null) return false;
-        if (!RunTracker.IsTrackedRelic(relic)) return false;
-        if (!CombatManager.Instance.IsInProgress) return false;
-        if (!ReferenceEquals(cardPlay.Card.Owner, relic.Owner)) return false;
-        if (cardPlay.Card.Type != CardType.Skill) return false;
+        var hookType = Sts2CoreAssembly()?.GetType("MegaCrit.Sts2.Core.Hooks.Hook", throwOnError: false);
+        if (hookType == null) return null;
 
-        return relic.SkillsPlayed + 1 >= relic.SkillsThreshold;
+        return AccessTools.Method(hookType, "BeforeSideTurnEnd")
+            ?? AccessTools.Method(hookType, "BeforeTurnEnd");
+    }
+
+    private static Assembly? Sts2CoreAssembly()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.GetName().Name == "sts2") return assembly;
+        }
+
+        return null;
+    }
+
+    private static bool Prepare() => TargetMethod() != null;
+
+    [HarmonyPrefix]
+    public static void Prefix(CombatSide side, IEnumerable<Creature> participants)
+    {
+        try
+        {
+            if (side != CombatSide.Player) return;
+            RunTracker.RecordTuningForkTurnEnded(participants);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"HookBeforeSideTurnEndTuningForkPatch failed: {e.Message}");
+        }
     }
 }

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -517,6 +517,17 @@ public class RelicAggregate
     public int LetterOpenerTurnsEndedAt1Charge { get; set; }
     public int LetterOpenerTurnsEndedAt2Charges { get; set; }
 
+    // Tuning Fork tracking. Counts owner Skill plays, held combats/turns for
+    // averages, and player-turn-end charge snapshots for near-activation
+    // pressure on its persistent 10-Skill counter.
+    public int TuningForkSkillsPlayed { get; set; }
+    public int TuningForkCombats { get; set; }
+    public int TuningForkTurns { get; set; }
+    public int TuningForkTurnsEndedOn8Charges { get; set; }
+    public int TuningForkTurnsEndedOn9Charges { get; set; }
+    public int TuningForkTurnEndChargeTotal { get; set; }
+    public int TuningForkTurnEndChargeCount { get; set; }
+
     // Total potions gained from this relic, split by the potion rarity that
     // was actually claimed. Used by White Beast Statue.
     public int PotionsGained { get; set; }

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -580,6 +580,15 @@ public class RelicAggregate
     public int VajraAttacksPlayed { get; set; }
     public int VajraAttackHits { get; set; }
 
+    // Kunai tracking. Counts owner attack plays, actual Dexterity gained from
+    // activation resolution, and player-turn-end charge snapshots.
+    public int KunaiAttacksPlayed { get; set; }
+    public int KunaiDexterityGained { get; set; }
+    public int KunaiTurnsEndedAt1Charge { get; set; }
+    public int KunaiTurnsEndedAt2Charges { get; set; }
+    public int KunaiTurnEndChargeTotal { get; set; }
+    public int KunaiTurnEndChargeCount { get; set; }
+
     // Paper Phrog tracking. Damage added is the actual current damage amount
     // multiplied by Paper Phrog's extra Vulnerable multiplier. Enhanced attacks
     // count each real damage activation where the relic increased Vulnerable.

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1670,6 +1670,12 @@ public static class RunTracker
         target.MiniatureCannonUpgradedAttackHits += source.MiniatureCannonUpgradedAttackHits;
         target.VajraAttacksPlayed += source.VajraAttacksPlayed;
         target.VajraAttackHits += source.VajraAttackHits;
+        target.KunaiAttacksPlayed += source.KunaiAttacksPlayed;
+        target.KunaiDexterityGained += source.KunaiDexterityGained;
+        target.KunaiTurnsEndedAt1Charge += source.KunaiTurnsEndedAt1Charge;
+        target.KunaiTurnsEndedAt2Charges += source.KunaiTurnsEndedAt2Charges;
+        target.KunaiTurnEndChargeTotal += source.KunaiTurnEndChargeTotal;
+        target.KunaiTurnEndChargeCount += source.KunaiTurnEndChargeCount;
         target.PaperPhrogDamageAdded += source.PaperPhrogDamageAdded;
         target.PaperPhrogEnhancedAttacks += source.PaperPhrogEnhancedAttacks;
         target.PaperPhrogCombats += source.PaperPhrogCombats;
@@ -2367,6 +2373,7 @@ public static class RunTracker
     private const string NutritiousSoupRelicId = "RELIC.NUTRITIOUS_SOUP";
     private const string MiniatureCannonRelicId = "RELIC.MINIATURE_CANNON";
     private const string VajraRelicId = "RELIC.VAJRA";
+    private const string KunaiRelicId = "RELIC.KUNAI";
     private const string PaperPhrogRelicId = "RELIC.PAPER_PHROG";
     private const string RegaliteRelicId = "RELIC.REGALITE";
     private const string BookmarkRelicId = "RELIC.BOOKMARK";
@@ -5782,6 +5789,139 @@ public static class RunTracker
         agg.VajraAttackHits += Math.Max(0, count);
     }
 
+    /// <summary>
+    /// Record a Kunai-owned attack play and return whether that play is expected
+    /// to activate the relic. The postfix observes the actual Dexterity delta.
+    /// </summary>
+    public static bool RecordKunaiAttackPlayedAndShouldObserveActivation(
+        Kunai relic,
+        CardPlay cardPlay,
+        out Creature? ownerCreature,
+        out int dexterityBefore)
+    {
+        ownerCreature = null;
+        dexterityBefore = 0;
+
+        if (relic?.Owner == null || cardPlay?.Card == null) return false;
+        if (cardPlay.Card.Type != CardType.Attack) return false;
+
+        var owner = relic.Owner;
+        if (cardPlay.Card.Owner != null && !ReferenceEquals(cardPlay.Card.Owner, owner)) return false;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedRelic(relic)) return false;
+                if (!IsTrackedPlayer(owner)) return false;
+
+                _pendingCombat ??= new PendingCombat();
+                var agg = GetOrCreatePendingRelicAggregateLocked(KunaiRelicId);
+                RecordKunaiAttackPlayedForTest(agg);
+
+                var cardsPerActivation = KunaiCardsPerActivation(relic);
+                if (cardsPerActivation <= 0) return false;
+
+                var chargeBefore = KunaiCharge(relic);
+                if (chargeBefore + 1 < cardsPerActivation) return false;
+
+                ownerCreature = owner.Creature;
+                if (ownerCreature == null) return false;
+                dexterityBefore = CurrentDexterity(ownerCreature);
+                return true;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordKunaiAttackPlayedAndShouldObserveActivation failed: {e.Message}");
+                ownerCreature = null;
+                dexterityBefore = 0;
+                return false;
+            }
+        }
+    }
+
+    public static void RecordKunaiActivation(int dexterityGained)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateRelicAggregateForCurrentContextLocked(KunaiRelicId);
+                RecordKunaiActivationForTest(agg, dexterityGained);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordKunaiActivation failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Snapshot Kunai's live attack counter at the end of each tracked player
+    /// turn before the relic resets it at the next player turn start.
+    /// </summary>
+    public static void RecordKunaiTurnEnded(IEnumerable<Creature>? participants)
+    {
+        if (participants == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+
+                foreach (var creature in participants)
+                {
+                    var player = creature?.Player;
+                    if (player == null || !IsTrackedPlayer(player)) continue;
+                    if (!TryGetKunai(player, out var kunai) || kunai == null) continue;
+
+                    var turnNumber = player.PlayerCombatState?.TurnNumber ?? 0;
+                    if (turnNumber <= 0) continue;
+                    if (_pendingCombat.KunaiTurnEndChargeRecordedTurns.TryGetValue(player, out var recordedTurn)
+                        && recordedTurn == turnNumber)
+                    {
+                        continue;
+                    }
+
+                    _pendingCombat.KunaiTurnEndChargeRecordedTurns[player] = turnNumber;
+                    var agg = GetOrCreatePendingRelicAggregateLocked(KunaiRelicId);
+                    RecordKunaiTurnEndChargeForTest(agg, KunaiCharge(kunai));
+                }
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordKunaiTurnEnded failed: {e.Message}");
+            }
+        }
+    }
+
+    internal static void RecordKunaiAttackPlayedForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.KunaiAttacksPlayed += Math.Max(0, count);
+    }
+
+    internal static void RecordKunaiActivationForTest(RelicAggregate agg, int dexterityGained)
+    {
+        if (agg == null) return;
+        agg.Activations += 1;
+        agg.KunaiDexterityGained += Math.Max(0, dexterityGained);
+    }
+
+    internal static void RecordKunaiTurnEndChargeForTest(RelicAggregate agg, int charge)
+    {
+        if (agg == null || charge < 0) return;
+
+        charge %= 3;
+        agg.KunaiTurnEndChargeTotal += charge;
+        agg.KunaiTurnEndChargeCount += 1;
+        if (charge == 1)
+            agg.KunaiTurnsEndedAt1Charge += 1;
+        else if (charge == 2)
+            agg.KunaiTurnsEndedAt2Charges += 1;
+    }
+
     public static void RecordPaperPhrogVulnerableBonus(
         PaperPhrog relic,
         decimal damageAdded,
@@ -8902,6 +9042,53 @@ public static class RunTracker
         catch
         {
             return false;
+        }
+    }
+
+    private static bool TryGetKunai(Player player, out Kunai? kunai)
+    {
+        kunai = null;
+
+        try
+        {
+            kunai = player?.Relics?.OfType<Kunai>().FirstOrDefault();
+            return kunai != null;
+        }
+        catch
+        {
+            kunai = null;
+            return false;
+        }
+    }
+
+    private static int KunaiCharge(Kunai relic)
+    {
+        var threshold = KunaiCardsPerActivation(relic);
+        if (threshold <= 0) return 0;
+        return Math.Max(0, relic.AttacksPlayedThisTurn) % threshold;
+    }
+
+    private static int KunaiCardsPerActivation(Kunai relic)
+    {
+        try
+        {
+            return Math.Max(1, relic.DynamicVars.Cards.IntValue);
+        }
+        catch
+        {
+            return 3;
+        }
+    }
+
+    private static int CurrentDexterity(Creature creature)
+    {
+        try
+        {
+            return creature.GetPower<DexterityPower>()?.Amount ?? 0;
+        }
+        catch
+        {
+            return 0;
         }
     }
 
@@ -12443,6 +12630,8 @@ internal class PendingCombat
     public HashSet<Player> ChandelierThirdTurnExcessRecordedPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Player, int> PenNibTurnEndChargeRecordedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> KunaiTurnEndChargeRecordedTurns { get; }
         = new(ReferenceEqualityComparer.Instance);
     public HashSet<Player> GamblingChipDiscardAttributionPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -2310,6 +2310,7 @@ public static class RunTracker
     private const string OrichalcumRelicId = "RELIC.ORICHALCUM";
     private const string PermafrostRelicId = "RELIC.PERMAFROST";
     private const string TuningForkRelicId = "RELIC.TUNING_FORK";
+    private const string RippleBasinRelicId = "RELIC.RIPPLE_BASIN";
     private const string AnchorRelicId = "RELIC.ANCHOR";
     private const string TheAbacusRelicId = "RELIC.THE_ABACUS";
     private const string LetterOpenerRelicId = "RELIC.LETTER_OPENER";
@@ -2598,6 +2599,41 @@ public static class RunTracker
         lock (_lock)
         {
             _pendingCombat?.Windows.Disarm(TuningForkRelicId, AttributionEventKind.PlayerBlockGain);
+        }
+    }
+
+    /// <summary>
+    /// Record Ripple Basin's no-attack turn-end trigger and arm observed
+    /// block attribution. The actual block amount is observed by
+    /// <see cref="Patches.HookAfterBlockGainedPatch"/>.
+    /// </summary>
+    public static void RecordRippleBasinActivationAndArmBlockAttribution()
+    {
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+                var agg = GetOrCreateRelicAggregateLocked(RippleBasinRelicId);
+                agg.Activations += 1;
+                _pendingCombat.Windows.Arm(
+                    RippleBasinRelicId,
+                    AttributionEventKind.PlayerBlockGain,
+                    CurrentHistoryCountLocked(),
+                    maxHistoryAdvance: -1);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordRippleBasinActivationAndArmBlockAttribution failed: {e.Message}");
+            }
+        }
+    }
+
+    public static void DisarmRippleBasinBlockAttribution()
+    {
+        lock (_lock)
+        {
+            _pendingCombat?.Windows.Disarm(RippleBasinRelicId, AttributionEventKind.PlayerBlockGain);
         }
     }
 

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1518,6 +1518,7 @@ public static class RunTracker
         if (_pendingCombat == null || _currentRun == null) return;
         RecordHeldCombatRelicBaselinesForTrackedPlayerLocked(requireActiveCombat: false, createPendingIfNeeded: false);
         RecordLetterOpenerTurnForTrackedPlayerLocked();
+        RecordTuningForkTurnForTrackedPlayerLocked();
         RecordPaperPhrogTurnForTrackedPlayerLocked();
         RecordPaelsEyeCombatsWithoutActivationForTrackedPlayerLocked();
         RecordTurnEnergyRelicCombatsWithoutEnergyForTrackedPlayerLocked();
@@ -1632,6 +1633,13 @@ public static class RunTracker
         target.LetterOpenerTurns += source.LetterOpenerTurns;
         target.LetterOpenerTurnsEndedAt1Charge += source.LetterOpenerTurnsEndedAt1Charge;
         target.LetterOpenerTurnsEndedAt2Charges += source.LetterOpenerTurnsEndedAt2Charges;
+        target.TuningForkSkillsPlayed += source.TuningForkSkillsPlayed;
+        target.TuningForkCombats += source.TuningForkCombats;
+        target.TuningForkTurns += source.TuningForkTurns;
+        target.TuningForkTurnsEndedOn8Charges += source.TuningForkTurnsEndedOn8Charges;
+        target.TuningForkTurnsEndedOn9Charges += source.TuningForkTurnsEndedOn9Charges;
+        target.TuningForkTurnEndChargeTotal += source.TuningForkTurnEndChargeTotal;
+        target.TuningForkTurnEndChargeCount += source.TuningForkTurnEndChargeCount;
         target.PotionsGained += source.PotionsGained;
         target.CommonPotionsGained += source.CommonPotionsGained;
         target.UncommonPotionsGained += source.UncommonPotionsGained;
@@ -2568,28 +2576,47 @@ public static class RunTracker
     }
 
     /// <summary>
-    /// Record Tuning Fork's every-N-skills trigger and arm observed block
-    /// attribution. The actual block amount is observed by
-    /// <see cref="Patches.HookAfterBlockGainedPatch"/>.
+    /// Record a Tuning Fork-owned Skill play and arm observed block attribution
+    /// if this play will cross the relic's threshold. The actual block amount
+    /// is observed by <see cref="Patches.HookAfterBlockGainedPatch"/>.
     /// </summary>
-    public static void RecordTuningForkActivationAndArmBlockAttribution()
+    public static bool RecordTuningForkSkillPlayedAndShouldArmBlockAttribution(TuningFork relic, CardPlay cardPlay)
     {
+        if (relic?.Owner == null || cardPlay?.Card == null) return false;
+        if (cardPlay.Card.Type != CardType.Skill) return false;
+        if (!ReferenceEquals(cardPlay.Card.Owner, relic.Owner)) return false;
+
         lock (_lock)
         {
             try
             {
+                if (!IsTrackedRelic(relic)) return false;
+                if (!IsTrackedPlayer(relic.Owner)) return false;
+                if (!CombatManager.Instance.IsInProgress) return false;
+
                 _pendingCombat ??= new PendingCombat();
-                var agg = GetOrCreateRelicAggregateLocked(TuningForkRelicId);
+                RecordTuningForkCombatForPlayerLocked(relic.Owner);
+                RecordTuningForkTurnForPlayerLocked(relic.Owner);
+
+                var agg = GetOrCreatePendingRelicAggregateLocked(TuningForkRelicId);
+                RecordTuningForkSkillPlayedForTest(agg);
+
+                var threshold = TuningForkCardsPerActivation(relic);
+                if (threshold <= 0) return false;
+                if (Math.Max(0, relic.SkillsPlayed) + 1 < threshold) return false;
+
                 agg.Activations += 1;
                 _pendingCombat.Windows.Arm(
                     TuningForkRelicId,
                     AttributionEventKind.PlayerBlockGain,
                     CurrentHistoryCountLocked(),
                     maxHistoryAdvance: -1);
+                return true;
             }
             catch (Exception e)
             {
-                CoreMain.LogDebug($"RecordTuningForkActivationAndArmBlockAttribution failed: {e.Message}");
+                CoreMain.LogDebug($"RecordTuningForkSkillPlayedAndShouldArmBlockAttribution failed: {e.Message}");
+                return false;
             }
         }
     }
@@ -2600,6 +2627,103 @@ public static class RunTracker
         {
             _pendingCombat?.Windows.Disarm(TuningForkRelicId, AttributionEventKind.PlayerBlockGain);
         }
+    }
+
+    /// <summary>
+    /// Snapshot Tuning Fork's persistent Skill counter at the end of each
+    /// tracked player turn while held.
+    /// </summary>
+    public static void RecordTuningForkTurnEnded(IEnumerable<Creature>? participants)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+                var recordedParticipant = false;
+
+                if (participants != null)
+                {
+                    foreach (var creature in participants)
+                    {
+                        var player = creature?.Player;
+                        if (player == null || !IsTrackedPlayer(player)) continue;
+
+                        recordedParticipant |= RecordTuningForkTurnEndChargeForPlayerLocked(
+                            player,
+                            player.PlayerCombatState?.TurnNumber ?? 0);
+                    }
+                }
+
+                if (recordedParticipant) return;
+
+                var trackedPlayer = GetTrackedRunPlayerLocked();
+                if (trackedPlayer == null) return;
+                RecordTuningForkTurnEndChargeForPlayerLocked(
+                    trackedPlayer,
+                    trackedPlayer.PlayerCombatState?.TurnNumber ?? 0);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordTuningForkTurnEnded failed: {e.Message}");
+            }
+        }
+    }
+
+    private static bool RecordTuningForkTurnEndChargeForPlayerLocked(
+        Player player,
+        int turnNumber,
+        TuningFork? tuningFork = null)
+    {
+        if (_pendingCombat == null) return false;
+        if (player == null || !IsTrackedPlayer(player)) return false;
+        tuningFork ??= TryGetTuningFork(player, out var foundRelic) ? foundRelic : null;
+        if (tuningFork == null) return false;
+        if (turnNumber <= 0) return false;
+
+        RecordTuningForkTurnForPlayerLocked(player, turnNumber);
+
+        if (_pendingCombat.TuningForkTurnEndChargeRecordedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return true;
+        }
+
+        _pendingCombat.TuningForkTurnEndChargeRecordedTurns[player] = turnNumber;
+        var agg = GetOrCreatePendingRelicAggregateLocked(TuningForkRelicId);
+        RecordTuningForkTurnEndChargeForTest(agg, TuningForkCharge(tuningFork));
+        return true;
+    }
+
+    internal static void RecordTuningForkSkillPlayedForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.TuningForkSkillsPlayed += Math.Max(0, count);
+    }
+
+    internal static void RecordTuningForkCombatForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.TuningForkCombats += Math.Max(0, count);
+    }
+
+    internal static void RecordTuningForkTurnForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.TuningForkTurns += Math.Max(0, count);
+    }
+
+    internal static void RecordTuningForkTurnEndChargeForTest(RelicAggregate agg, int charge)
+    {
+        if (agg == null || charge < 0) return;
+
+        charge %= 10;
+        agg.TuningForkTurnEndChargeTotal += charge;
+        agg.TuningForkTurnEndChargeCount += 1;
+        if (charge == 8)
+            agg.TuningForkTurnsEndedOn8Charges += 1;
+        else if (charge == 9)
+            agg.TuningForkTurnsEndedOn9Charges += 1;
     }
 
     /// <summary>
@@ -8644,6 +8768,7 @@ public static class RunTracker
             if (player == null) return;
 
             RecordLetterOpenerCombatForPlayerLocked(player);
+            RecordTuningForkCombatForPlayerLocked(player);
             RecordHappyFlowerCombatForPlayerLocked(player);
             RecordNunchakuCombatForPlayerLocked(player);
             RecordIronClubCombatForPlayerLocked(player);
@@ -8670,6 +8795,16 @@ public static class RunTracker
 
         var agg = GetOrCreatePendingRelicAggregateLocked(LetterOpenerRelicId);
         RecordLetterOpenerCombatForTest(agg);
+    }
+
+    private static void RecordTuningForkCombatForPlayerLocked(Player player)
+    {
+        if (_pendingCombat == null) return;
+        if (!PlayerHasTuningFork(player)) return;
+        if (!_pendingCombat.TuningForkCombatCountedPlayers.Add(player)) return;
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(TuningForkRelicId);
+        RecordTuningForkCombatForTest(agg);
     }
 
     private static void RecordLetterOpenerTurnForTrackedPlayerLocked()
@@ -8709,6 +8844,45 @@ public static class RunTracker
 
         var agg = GetOrCreatePendingRelicAggregateLocked(LetterOpenerRelicId);
         RecordLetterOpenerTurnForTest(agg);
+    }
+
+    private static void RecordTuningForkTurnForTrackedPlayerLocked()
+    {
+        try
+        {
+            var player = GetTrackedRunPlayerLocked();
+            if (player == null) return;
+            RecordTuningForkTurnForPlayerLocked(player);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RecordTuningForkTurnForTrackedPlayerLocked failed: {e.Message}");
+        }
+    }
+
+    private static void RecordTuningForkTurnForPlayerLocked(Player player)
+    {
+        var turnNumber = player.PlayerCombatState?.TurnNumber ?? 0;
+        RecordTuningForkTurnForPlayerLocked(player, turnNumber);
+    }
+
+    private static void RecordTuningForkTurnForPlayerLocked(Player player, int turnNumber)
+    {
+        if (_pendingCombat == null) return;
+        if (!PlayerHasTuningFork(player)) return;
+        if (turnNumber <= 0) return;
+
+        if (_pendingCombat.TuningForkTurnCountedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return;
+        }
+
+        _pendingCombat.TuningForkTurnCountedTurns[player] = turnNumber;
+        RecordTuningForkCombatForPlayerLocked(player);
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(TuningForkRelicId);
+        RecordTuningForkTurnForTest(agg);
     }
 
     private static void RecordMiniatureCannonCombatForTrackedPlayerLocked()
@@ -9078,6 +9252,46 @@ public static class RunTracker
         catch
         {
             return false;
+        }
+    }
+
+    private static bool PlayerHasTuningFork(Player player)
+    {
+        return TryGetTuningFork(player, out _);
+    }
+
+    private static bool TryGetTuningFork(Player player, out TuningFork? tuningFork)
+    {
+        tuningFork = null;
+
+        try
+        {
+            tuningFork = player?.Relics?.OfType<TuningFork>().FirstOrDefault();
+            return tuningFork != null;
+        }
+        catch
+        {
+            tuningFork = null;
+            return false;
+        }
+    }
+
+    private static int TuningForkCharge(TuningFork relic)
+    {
+        var threshold = TuningForkCardsPerActivation(relic);
+        if (threshold <= 0) return 0;
+        return Math.Max(0, relic.SkillsPlayed) % threshold;
+    }
+
+    private static int TuningForkCardsPerActivation(TuningFork relic)
+    {
+        try
+        {
+            return Math.Max(1, relic.DynamicVars.Cards.IntValue);
+        }
+        catch
+        {
+            return 10;
         }
     }
 
@@ -12624,6 +12838,12 @@ internal class PendingCombat
     public Dictionary<Player, int> LetterOpenerTurnCountedTurns { get; }
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Player, int> LetterOpenerTurnEndChargeRecordedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public HashSet<Player> TuningForkCombatCountedPlayers { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> TuningForkTurnCountedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> TuningForkTurnEndChargeRecordedTurns { get; }
         = new(ReferenceEqualityComparer.Instance);
     public HashSet<Player> HappyFlowerCombatCountedPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -224,6 +224,9 @@ New fixtures added going forward do not need a `v*-` prefix.
   Dexterity gained, and 1/2 charge turn-end buckets with average charge samples.
 - `tuning-fork-relic-run.json`
   Adds Tuning Fork trigger count and observed block gained tracking.
+- `ripple-basin-relic-run.json`
+  Adds Ripple Basin no-attack turn-end activation tracking plus observed block
+  gained.
 - `war-paint-relic-run.json`
   Adds War Paint pickup tracking: the actual skill cards upgraded by the relic.
 - `unmovable-power-meta-run.json`

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -219,6 +219,9 @@ New fixtures added going forward do not need a `v*-` prefix.
 - `regalite-relic-run.json`
   Adds Regalite tracking for owner-created combat cards, observed block gained,
   and held turn/combat denominators for average block rows.
+- `kunai-relic-run.json`
+  Adds Kunai attack-counter tracking: owner attack plays, activations, observed
+  Dexterity gained, and 1/2 charge turn-end buckets with average charge samples.
 - `tuning-fork-relic-run.json`
   Adds Tuning Fork trigger count and observed block gained tracking.
 - `war-paint-relic-run.json`

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -223,7 +223,8 @@ New fixtures added going forward do not need a `v*-` prefix.
   Adds Kunai attack-counter tracking: owner attack plays, activations, observed
   Dexterity gained, and 1/2 charge turn-end buckets with average charge samples.
 - `tuning-fork-relic-run.json`
-  Adds Tuning Fork trigger count and observed block gained tracking.
+  Adds Tuning Fork owner Skill-play count, trigger count, observed block
+  gained, held combat/turn denominators, and turn-end charge buckets.
 - `ripple-basin-relic-run.json`
   Adds Ripple Basin no-attack turn-end activation tracking plus observed block
   gained.

--- a/Fixtures/RunSchema/kunai-relic-run.json
+++ b/Fixtures/RunSchema/kunai-relic-run.json
@@ -1,0 +1,22 @@
+{
+  "run_id": "kunai-relic-fixture",
+  "started_at": "2026-07-08T18:00:00Z",
+  "updated_at": "2026-07-08T18:08:00Z",
+  "outcome": "in_progress",
+  "aggregates": {},
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.KUNAI": {
+      "kunai_attacks_played": 14,
+      "activations": 4,
+      "kunai_dexterity_gained": 4,
+      "kunai_turns_ended_at1_charge": 2,
+      "kunai_turns_ended_at2_charges": 3,
+      "kunai_turn_end_charge_total": 11,
+      "kunai_turn_end_charge_count": 7
+    }
+  },
+  "meta_stats": {},
+  "instance_numbers_by_def": {},
+  "def_counters": {}
+}

--- a/Fixtures/RunSchema/ripple-basin-relic-run.json
+++ b/Fixtures/RunSchema/ripple-basin-relic-run.json
@@ -1,0 +1,17 @@
+{
+  "run_id": "ripple-basin-relic-fixture",
+  "started_at": "2026-07-08T19:00:00Z",
+  "updated_at": "2026-07-08T19:04:00Z",
+  "outcome": "in_progress",
+  "aggregates": {},
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.RIPPLE_BASIN": {
+      "activations": 3,
+      "additional_block_gained": 12
+    }
+  },
+  "meta_stats": {},
+  "instance_numbers_by_def": {},
+  "def_counters": {}
+}

--- a/Fixtures/RunSchema/tuning-fork-relic-run.json
+++ b/Fixtures/RunSchema/tuning-fork-relic-run.json
@@ -17,8 +17,15 @@
   "events": [],
   "relic_aggregates": {
     "RELIC.TUNING_FORK": {
+      "tuning_fork_skills_played": 27,
       "activations": 3,
-      "additional_block_gained": 18
+      "additional_block_gained": 18,
+      "tuning_fork_combats": 2,
+      "tuning_fork_turns": 7,
+      "tuning_fork_turns_ended_on8_charges": 2,
+      "tuning_fork_turns_ended_on9_charges": 1,
+      "tuning_fork_turn_end_charge_total": 31,
+      "tuning_fork_turn_end_charge_count": 5
     }
   },
   "meta_stats": {},

--- a/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
+++ b/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
@@ -131,6 +131,29 @@ public class HookPatchTargetTests
 
     [Fact]
     [Trait("Category", "RequiresLiveGame")]
+    public void RippleBasinPatch_ResolvesBeforeSideTurnEnd()
+    {
+        var target = AccessTools.Method(typeof(RippleBasin), nameof(RippleBasin.BeforeSideTurnEnd));
+
+        Assert.NotNull(target);
+        Assert.Equal("MegaCrit.Sts2.Core.Models.Relics.RippleBasin", target!.DeclaringType?.FullName);
+        Assert.Equal("BeforeSideTurnEnd", target.Name);
+        Assert.Equal(
+            new[]
+            {
+                "choiceContext",
+                "side",
+                "participants",
+            },
+            target.GetParameters().Select(p => p.Name).ToArray());
+
+        var sideParameter = target.GetParameters().SingleOrDefault(p => p.Name == "side");
+        Assert.NotNull(sideParameter);
+        Assert.Equal("MegaCrit.Sts2.Core.Combat.CombatSide", sideParameter!.ParameterType.FullName);
+    }
+
+    [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void LetterOpenerTurnEndPatch_ResolvesBeforeSideTurnEnd()
     {
         var target = InvokeTargetMethod(typeof(HookBeforeSideTurnEndLetterOpenerPatch));

--- a/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
+++ b/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
@@ -131,6 +131,21 @@ public class HookPatchTargetTests
 
     [Fact]
     [Trait("Category", "RequiresLiveGame")]
+    public void TuningForkTurnEndPatch_ResolvesBeforeSideTurnEnd()
+    {
+        var target = InvokeTargetMethod(typeof(HookBeforeSideTurnEndTuningForkPatch));
+
+        Assert.NotNull(target);
+        Assert.Equal("MegaCrit.Sts2.Core.Hooks.Hook", target!.DeclaringType?.FullName);
+        Assert.Contains(target.Name, new[] { "BeforeSideTurnEnd", "BeforeTurnEnd" });
+
+        var sideParameter = target.GetParameters().SingleOrDefault(p => p.Name == "side");
+        Assert.NotNull(sideParameter);
+        Assert.Equal("MegaCrit.Sts2.Core.Combat.CombatSide", sideParameter!.ParameterType.FullName);
+    }
+
+    [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void RippleBasinPatch_ResolvesBeforeSideTurnEnd()
     {
         var target = AccessTools.Method(typeof(RippleBasin), nameof(RippleBasin.BeforeSideTurnEnd));

--- a/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
+++ b/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
@@ -116,6 +116,21 @@ public class HookPatchTargetTests
 
     [Fact]
     [Trait("Category", "RequiresLiveGame")]
+    public void KunaiTurnEndPatch_ResolvesBeforeSideTurnEnd()
+    {
+        var target = InvokeTargetMethod(typeof(HookBeforeSideTurnEndKunaiPatch));
+
+        Assert.NotNull(target);
+        Assert.Equal("MegaCrit.Sts2.Core.Hooks.Hook", target!.DeclaringType?.FullName);
+        Assert.Contains(target.Name, new[] { "BeforeSideTurnEnd", "BeforeTurnEnd" });
+
+        var sideParameter = target.GetParameters().SingleOrDefault(p => p.Name == "side");
+        Assert.NotNull(sideParameter);
+        Assert.Equal("MegaCrit.Sts2.Core.Combat.CombatSide", sideParameter!.ParameterType.FullName);
+    }
+
+    [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void LetterOpenerTurnEndPatch_ResolvesBeforeSideTurnEnd()
     {
         var target = InvokeTargetMethod(typeof(HookBeforeSideTurnEndLetterOpenerPatch));

--- a/Tests/SpireLens.Core.Tests/KunaiStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/KunaiStatsTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class KunaiStatsTests
+{
+    private const string KunaiRelicId = "RELIC.KUNAI";
+
+    private static readonly MethodInfo BuildKunaiBodyMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildKunaiBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildKunaiBodyBBCode not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void RelicAggregate_KunaiFields_DefaultToZero()
+    {
+        var agg = new RelicAggregate();
+
+        Assert.Equal(0, agg.KunaiAttacksPlayed);
+        Assert.Equal(0, agg.Activations);
+        Assert.Equal(0, agg.KunaiDexterityGained);
+        Assert.Equal(0, agg.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(0, agg.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(0, agg.KunaiTurnEndChargeTotal);
+        Assert.Equal(0, agg.KunaiTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void RelicAggregate_KunaiFields_JsonRoundtrip_PreservesFields()
+    {
+        var run = new RunData();
+        run.RelicAggregates[KunaiRelicId] = new RelicAggregate
+        {
+            KunaiAttacksPlayed = 14,
+            Activations = 4,
+            KunaiDexterityGained = 4,
+            KunaiTurnsEndedAt1Charge = 2,
+            KunaiTurnsEndedAt2Charges = 3,
+            KunaiTurnEndChargeTotal = 11,
+            KunaiTurnEndChargeCount = 7,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("kunai_attacks_played", json);
+        Assert.Contains("activations", json);
+        Assert.Contains("kunai_dexterity_gained", json);
+        Assert.Contains("kunai_turns_ended_at1_charge", json);
+        Assert.Contains("kunai_turns_ended_at2_charges", json);
+        Assert.Contains("kunai_turn_end_charge_total", json);
+        Assert.Contains("kunai_turn_end_charge_count", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var agg = restored!.RelicAggregates[KunaiRelicId];
+        Assert.Equal(14, agg.KunaiAttacksPlayed);
+        Assert.Equal(4, agg.Activations);
+        Assert.Equal(4, agg.KunaiDexterityGained);
+        Assert.Equal(2, agg.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(3, agg.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(11, agg.KunaiTurnEndChargeTotal);
+        Assert.Equal(7, agg.KunaiTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void RunTracker_KunaiHelpers_AccumulateAndClamp()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordKunaiAttackPlayedForTest(agg, 14);
+        RunTracker.RecordKunaiAttackPlayedForTest(agg, -2);
+        RunTracker.RecordKunaiActivationForTest(agg, 4);
+        RunTracker.RecordKunaiActivationForTest(agg, -3);
+        RunTracker.RecordKunaiTurnEndChargeForTest(agg, 1);
+        RunTracker.RecordKunaiTurnEndChargeForTest(agg, 2);
+        RunTracker.RecordKunaiTurnEndChargeForTest(agg, 5);
+        RunTracker.RecordKunaiTurnEndChargeForTest(agg, -1);
+
+        Assert.Equal(14, agg.KunaiAttacksPlayed);
+        Assert.Equal(2, agg.Activations);
+        Assert.Equal(4, agg.KunaiDexterityGained);
+        Assert.Equal(1, agg.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(2, agg.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(5, agg.KunaiTurnEndChargeTotal);
+        Assert.Equal(3, agg.KunaiTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_KunaiFields_Accumulates()
+    {
+        var target = new RelicAggregate
+        {
+            KunaiAttacksPlayed = 5,
+            Activations = 1,
+            KunaiDexterityGained = 1,
+            KunaiTurnsEndedAt1Charge = 1,
+            KunaiTurnEndChargeTotal = 1,
+            KunaiTurnEndChargeCount = 1,
+        };
+        var source = new RelicAggregate
+        {
+            KunaiAttacksPlayed = 9,
+            Activations = 3,
+            KunaiDexterityGained = 3,
+            KunaiTurnsEndedAt2Charges = 2,
+            KunaiTurnEndChargeTotal = 4,
+            KunaiTurnEndChargeCount = 2,
+        };
+
+        RunTracker.MergeRelicAggregateInto(target, source);
+
+        Assert.Equal(14, target.KunaiAttacksPlayed);
+        Assert.Equal(4, target.Activations);
+        Assert.Equal(4, target.KunaiDexterityGained);
+        Assert.Equal(1, target.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(2, target.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(5, target.KunaiTurnEndChargeTotal);
+        Assert.Equal(3, target.KunaiTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void RelicTooltip_Kunai_ShowsAttackActivationAndChargeRows()
+    {
+        var body = BuildBody(new RelicAggregate
+        {
+            KunaiAttacksPlayed = 14,
+            Activations = 4,
+            KunaiDexterityGained = 4,
+            KunaiTurnsEndedAt1Charge = 2,
+            KunaiTurnsEndedAt2Charges = 3,
+            KunaiTurnEndChargeTotal = 11,
+            KunaiTurnEndChargeCount = 7,
+        });
+
+        Assert.Contains("Attacks played", body);
+        Assert.Contains("Activations", body);
+        Assert.Contains("Dexterity gained", body);
+        Assert.Contains("Turns ended at 1 charge", body);
+        Assert.Contains("Turns ended at 2 charges", body);
+        Assert.Contains("Avg charge at turn end", body);
+        Assert.Contains("[b]14[/b]", body);
+        Assert.Contains("[b]4[/b]", body);
+        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("[b]3[/b]", body);
+        Assert.Contains("[b]1.57[/b]", body);
+    }
+
+    [Fact]
+    public void RelicTooltip_Kunai_ShowsZeroRowsForEmptyAggregate()
+    {
+        var body = BuildBody(new RelicAggregate());
+
+        Assert.Contains("Attacks played", body);
+        Assert.Contains("Activations", body);
+        Assert.Contains("Dexterity gained", body);
+        Assert.Contains("Turns ended at 1 charge", body);
+        Assert.Contains("Turns ended at 2 charges", body);
+        Assert.Contains("Avg charge at turn end", body);
+        Assert.Equal(6, CountOccurrences(body, "[b]0[/b]"));
+    }
+
+    [Fact]
+    public void RunData_OlderShapeWithoutKunaiFields_DeserializesWithZeroDefaults()
+    {
+        const string json = """
+            {
+              "run_id": "test",
+              "started_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-01-01T00:00:00Z",
+              "outcome": "in_progress",
+              "aggregates": {},
+              "events": [],
+              "instance_numbers_by_def": {},
+              "def_counters": {},
+              "relic_aggregates": {
+                "RELIC.KUNAI": {}
+              }
+            }
+            """;
+
+        var run = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(run);
+        var agg = run!.RelicAggregates[KunaiRelicId];
+        Assert.Equal(0, agg.KunaiAttacksPlayed);
+        Assert.Equal(0, agg.Activations);
+        Assert.Equal(0, agg.KunaiDexterityGained);
+        Assert.Equal(0, agg.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(0, agg.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(0, agg.KunaiTurnEndChargeTotal);
+        Assert.Equal(0, agg.KunaiTurnEndChargeCount);
+    }
+
+    private static string BuildBody(RelicAggregate agg)
+        => (string)(BuildKunaiBodyMethod.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException("BuildKunaiBodyBBCode returned null."));
+
+    private static int CountOccurrences(string value, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/Tests/SpireLens.Core.Tests/RippleBasinStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/RippleBasinStatsTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class RippleBasinStatsTests
+{
+    private const string RippleBasinRelicId = "RELIC.RIPPLE_BASIN";
+
+    private static readonly MethodInfo BuildRippleBasinBodyMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildRippleBasinBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRippleBasinBodyBBCode not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void RelicAggregate_RippleBasinFields_DefaultToZero()
+    {
+        var agg = new RelicAggregate();
+
+        Assert.Equal(0, agg.Activations);
+        Assert.Equal(0, agg.AdditionalBlockGained);
+    }
+
+    [Fact]
+    public void RelicAggregate_RippleBasinFields_JsonRoundtrip_PreservesFields()
+    {
+        var run = new RunData();
+        run.RelicAggregates[RippleBasinRelicId] = new RelicAggregate
+        {
+            Activations = 3,
+            AdditionalBlockGained = 12,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("activations", json);
+        Assert.Contains("additional_block_gained", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        var agg = restored!.RelicAggregates[RippleBasinRelicId];
+        Assert.Equal(3, agg.Activations);
+        Assert.Equal(12, agg.AdditionalBlockGained);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_RippleBasinFields_Accumulates()
+    {
+        var target = new RelicAggregate
+        {
+            Activations = 1,
+            AdditionalBlockGained = 4,
+        };
+        var source = new RelicAggregate
+        {
+            Activations = 2,
+            AdditionalBlockGained = 8,
+        };
+
+        RunTracker.MergeRelicAggregateInto(target, source);
+
+        Assert.Equal(3, target.Activations);
+        Assert.Equal(12, target.AdditionalBlockGained);
+    }
+
+    [Fact]
+    public void RelicTooltip_RippleBasin_ShowsActivationBlockAndAverageRows()
+    {
+        var body = BuildBody(new RelicAggregate
+        {
+            Activations = 3,
+            AdditionalBlockGained = 12,
+        });
+
+        Assert.Contains("Activations", body);
+        Assert.Contains("[b]3[/b]", body);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] block gained", body);
+        Assert.Contains("[b]12[/b]", body);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] block gained per activation", body);
+        Assert.Contains("[b]4[/b]", body);
+    }
+
+    [Fact]
+    public void RelicTooltip_RippleBasin_ShowsZeroRows()
+    {
+        var body = BuildBody(new RelicAggregate());
+
+        Assert.Contains("Activations", body);
+        Assert.Contains("block gained", body);
+        Assert.Contains("block gained per activation", body);
+        Assert.Equal(3, CountOccurrences(body, "[b]0[/b]"));
+    }
+
+    [Fact]
+    public void RunData_OlderShapeWithoutRippleBasinFields_DeserializesWithZeroDefaults()
+    {
+        const string json = """
+            {
+              "run_id": "test",
+              "started_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-01-01T00:00:00Z",
+              "outcome": "in_progress",
+              "aggregates": {},
+              "events": [],
+              "instance_numbers_by_def": {},
+              "def_counters": {},
+              "relic_aggregates": {
+                "RELIC.RIPPLE_BASIN": {}
+              }
+            }
+            """;
+
+        var run = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(run);
+        var agg = run!.RelicAggregates[RippleBasinRelicId];
+        Assert.Equal(0, agg.Activations);
+        Assert.Equal(0, agg.AdditionalBlockGained);
+    }
+
+    private static string BuildBody(RelicAggregate agg)
+        => (string)(BuildRippleBasinBodyMethod.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException("BuildRippleBasinBodyBBCode returned null."));
+
+    private static int CountOccurrences(string value, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2128,8 +2128,15 @@ public class SchemaLoadingTests
         Assert.NotNull(loaded);
         Assert.True(loaded!.SupportsResume);
         var relicAgg = loaded.Data.RelicAggregates["RELIC.TUNING_FORK"];
+        Assert.Equal(27, relicAgg.TuningForkSkillsPlayed);
         Assert.Equal(3, relicAgg.Activations);
         Assert.Equal(18, relicAgg.AdditionalBlockGained);
+        Assert.Equal(2, relicAgg.TuningForkCombats);
+        Assert.Equal(7, relicAgg.TuningForkTurns);
+        Assert.Equal(2, relicAgg.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(1, relicAgg.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(31, relicAgg.TuningForkTurnEndChargeTotal);
+        Assert.Equal(5, relicAgg.TuningForkTurnEndChargeCount);
     }
 
     [Fact]
@@ -2178,8 +2185,15 @@ public class SchemaLoadingTests
 
         Assert.NotNull(resumed);
         var relicAgg = resumed!.RelicAggregates["RELIC.TUNING_FORK"];
+        Assert.Equal(27, relicAgg.TuningForkSkillsPlayed);
         Assert.Equal(3, relicAgg.Activations);
         Assert.Equal(18, relicAgg.AdditionalBlockGained);
+        Assert.Equal(2, relicAgg.TuningForkCombats);
+        Assert.Equal(7, relicAgg.TuningForkTurns);
+        Assert.Equal(2, relicAgg.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(1, relicAgg.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(31, relicAgg.TuningForkTurnEndChargeTotal);
+        Assert.Equal(5, relicAgg.TuningForkTurnEndChargeCount);
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2244,6 +2244,39 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsKunaiRelicFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("kunai-relic-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        var relicAgg = loaded.Data.RelicAggregates["RELIC.KUNAI"];
+        Assert.Equal(14, relicAgg.KunaiAttacksPlayed);
+        Assert.Equal(4, relicAgg.Activations);
+        Assert.Equal(4, relicAgg.KunaiDexterityGained);
+        Assert.Equal(2, relicAgg.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(3, relicAgg.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(11, relicAgg.KunaiTurnEndChargeTotal);
+        Assert.Equal(7, relicAgg.KunaiTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsKunaiRelicFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("kunai-relic-run.json"));
+
+        Assert.NotNull(resumed);
+        var relicAgg = resumed!.RelicAggregates["RELIC.KUNAI"];
+        Assert.Equal(14, relicAgg.KunaiAttacksPlayed);
+        Assert.Equal(4, relicAgg.Activations);
+        Assert.Equal(4, relicAgg.KunaiDexterityGained);
+        Assert.Equal(2, relicAgg.KunaiTurnsEndedAt1Charge);
+        Assert.Equal(3, relicAgg.KunaiTurnsEndedAt2Charges);
+        Assert.Equal(11, relicAgg.KunaiTurnEndChargeTotal);
+        Assert.Equal(7, relicAgg.KunaiTurnEndChargeCount);
+    }
+
+    [Fact]
     public void HistoricalLoad_AcceptsPaperPhrogRelicFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("paper-phrog-relic-run.json"));

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2133,6 +2133,18 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsRippleBasinRelicFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("ripple-basin-relic-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        var relicAgg = loaded.Data.RelicAggregates["RELIC.RIPPLE_BASIN"];
+        Assert.Equal(3, relicAgg.Activations);
+        Assert.Equal(12, relicAgg.AdditionalBlockGained);
+    }
+
+    [Fact]
     public void HistoricalLoad_AcceptsPaelsEyeRelicFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("paels-eye-relic-run.json"));
@@ -2168,6 +2180,17 @@ public class SchemaLoadingTests
         var relicAgg = resumed!.RelicAggregates["RELIC.TUNING_FORK"];
         Assert.Equal(3, relicAgg.Activations);
         Assert.Equal(18, relicAgg.AdditionalBlockGained);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsRippleBasinRelicFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("ripple-basin-relic-run.json"));
+
+        Assert.NotNull(resumed);
+        var relicAgg = resumed!.RelicAggregates["RELIC.RIPPLE_BASIN"];
+        Assert.Equal(3, relicAgg.Activations);
+        Assert.Equal(12, relicAgg.AdditionalBlockGained);
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/TuningForkStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/TuningForkStatsTests.cs
@@ -27,8 +27,15 @@ public class TuningForkStatsTests
     {
         var agg = new RelicAggregate();
 
+        Assert.Equal(0, agg.TuningForkSkillsPlayed);
         Assert.Equal(0, agg.Activations);
         Assert.Equal(0, agg.AdditionalBlockGained);
+        Assert.Equal(0, agg.TuningForkCombats);
+        Assert.Equal(0, agg.TuningForkTurns);
+        Assert.Equal(0, agg.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(0, agg.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(0, agg.TuningForkTurnEndChargeTotal);
+        Assert.Equal(0, agg.TuningForkTurnEndChargeCount);
     }
 
     [Fact]
@@ -37,36 +44,142 @@ public class TuningForkStatsTests
         var run = new RunData();
         run.RelicAggregates[TuningForkRelicId] = new RelicAggregate
         {
+            TuningForkSkillsPlayed = 27,
             Activations = 3,
             AdditionalBlockGained = 18,
+            TuningForkCombats = 2,
+            TuningForkTurns = 7,
+            TuningForkTurnsEndedOn8Charges = 2,
+            TuningForkTurnsEndedOn9Charges = 1,
+            TuningForkTurnEndChargeTotal = 31,
+            TuningForkTurnEndChargeCount = 5,
         };
 
         var json = JsonSerializer.Serialize(run, SerializerOptions);
 
+        Assert.Contains("tuning_fork_skills_played", json);
         Assert.Contains("activations", json);
         Assert.Contains("additional_block_gained", json);
+        Assert.Contains("tuning_fork_combats", json);
+        Assert.Contains("tuning_fork_turns", json);
+        Assert.Contains("tuning_fork_turns_ended_on8_charges", json);
+        Assert.Contains("tuning_fork_turns_ended_on9_charges", json);
+        Assert.Contains("tuning_fork_turn_end_charge_total", json);
+        Assert.Contains("tuning_fork_turn_end_charge_count", json);
 
         var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
 
         Assert.NotNull(restored);
         var agg = restored!.RelicAggregates[TuningForkRelicId];
+        Assert.Equal(27, agg.TuningForkSkillsPlayed);
         Assert.Equal(3, agg.Activations);
         Assert.Equal(18, agg.AdditionalBlockGained);
+        Assert.Equal(2, agg.TuningForkCombats);
+        Assert.Equal(7, agg.TuningForkTurns);
+        Assert.Equal(2, agg.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(1, agg.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(31, agg.TuningForkTurnEndChargeTotal);
+        Assert.Equal(5, agg.TuningForkTurnEndChargeCount);
     }
 
     [Fact]
-    public void RelicTooltip_TuningFork_ShowsActivationsAndBlockGained()
+    public void RunTracker_TuningForkHelpers_AccumulateAndClamp()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordTuningForkSkillPlayedForTest(agg, 27);
+        RunTracker.RecordTuningForkSkillPlayedForTest(agg, -2);
+        RunTracker.RecordTuningForkCombatForTest(agg, 2);
+        RunTracker.RecordTuningForkCombatForTest(agg, -2);
+        RunTracker.RecordTuningForkTurnForTest(agg, 7);
+        RunTracker.RecordTuningForkTurnForTest(agg, -4);
+        RunTracker.RecordTuningForkTurnEndChargeForTest(agg, 8);
+        RunTracker.RecordTuningForkTurnEndChargeForTest(agg, 9);
+        RunTracker.RecordTuningForkTurnEndChargeForTest(agg, 14);
+        RunTracker.RecordTuningForkTurnEndChargeForTest(agg, -1);
+
+        Assert.Equal(27, agg.TuningForkSkillsPlayed);
+        Assert.Equal(2, agg.TuningForkCombats);
+        Assert.Equal(7, agg.TuningForkTurns);
+        Assert.Equal(1, agg.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(1, agg.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(21, agg.TuningForkTurnEndChargeTotal);
+        Assert.Equal(3, agg.TuningForkTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_TuningForkFields_Accumulates()
+    {
+        var target = new RelicAggregate
+        {
+            TuningForkSkillsPlayed = 12,
+            Activations = 1,
+            AdditionalBlockGained = 7,
+            TuningForkCombats = 1,
+            TuningForkTurns = 3,
+            TuningForkTurnsEndedOn8Charges = 1,
+            TuningForkTurnEndChargeTotal = 8,
+            TuningForkTurnEndChargeCount = 1,
+        };
+        var source = new RelicAggregate
+        {
+            TuningForkSkillsPlayed = 15,
+            Activations = 2,
+            AdditionalBlockGained = 11,
+            TuningForkCombats = 1,
+            TuningForkTurns = 4,
+            TuningForkTurnsEndedOn9Charges = 1,
+            TuningForkTurnEndChargeTotal = 23,
+            TuningForkTurnEndChargeCount = 4,
+        };
+
+        RunTracker.MergeRelicAggregateInto(target, source);
+
+        Assert.Equal(27, target.TuningForkSkillsPlayed);
+        Assert.Equal(3, target.Activations);
+        Assert.Equal(18, target.AdditionalBlockGained);
+        Assert.Equal(2, target.TuningForkCombats);
+        Assert.Equal(7, target.TuningForkTurns);
+        Assert.Equal(1, target.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(1, target.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(31, target.TuningForkTurnEndChargeTotal);
+        Assert.Equal(5, target.TuningForkTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void RelicTooltip_TuningFork_ShowsCounterActivationBlockAndChargeRows()
     {
         var body = BuildBody(new RelicAggregate
         {
+            TuningForkSkillsPlayed = 27,
             Activations = 3,
             AdditionalBlockGained = 18,
+            TuningForkCombats = 2,
+            TuningForkTurns = 7,
+            TuningForkTurnsEndedOn8Charges = 2,
+            TuningForkTurnsEndedOn9Charges = 1,
+            TuningForkTurnEndChargeTotal = 31,
+            TuningForkTurnEndChargeCount = 5,
         });
 
+        Assert.Contains("Skills played", body);
         Assert.Contains("Activations", body);
-        Assert.Contains("[b]3[/b]", body);
         Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] block gained", body);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] block gained per activation", body);
+        Assert.Contains("Avg skills played per combat", body);
+        Assert.Contains("Avg skills played per turn", body);
+        Assert.Contains("Turns ended on 8 charges", body);
+        Assert.Contains("Turns ended on 9 charges", body);
+        Assert.Contains("Avg charge at turn end", body);
+        Assert.Contains("[b]27[/b]", body);
+        Assert.Contains("[b]3[/b]", body);
         Assert.Contains("[b]18[/b]", body);
+        Assert.Contains("[b]6[/b]", body);
+        Assert.Contains("[b]13.5[/b]", body);
+        Assert.Contains("[b]3.86[/b]", body);
+        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("[b]1[/b]", body);
+        Assert.Contains("[b]6.2[/b]", body);
     }
 
     [Fact]
@@ -75,11 +188,68 @@ public class TuningForkStatsTests
         var body = BuildBody(new RelicAggregate());
 
         Assert.Contains("Activations", body);
+        Assert.Contains("Skills played", body);
         Assert.Contains("block gained", body);
-        Assert.Contains("[b]0[/b]", body);
+        Assert.Contains("block gained per activation", body);
+        Assert.Contains("Avg skills played per combat", body);
+        Assert.Contains("Avg skills played per turn", body);
+        Assert.Contains("Turns ended on 8 charges", body);
+        Assert.Contains("Turns ended on 9 charges", body);
+        Assert.Contains("Avg charge at turn end", body);
+        Assert.Equal(9, CountOccurrences(body, "[b]0[/b]"));
+    }
+
+    [Fact]
+    public void RunData_OlderShapeWithoutTuningForkFields_DeserializesWithZeroDefaults()
+    {
+        const string json = """
+            {
+              "run_id": "test",
+              "started_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-01-01T00:00:00Z",
+              "outcome": "in_progress",
+              "aggregates": {},
+              "events": [],
+              "instance_numbers_by_def": {},
+              "def_counters": {},
+              "relic_aggregates": {
+                "RELIC.TUNING_FORK": {
+                  "activations": 3,
+                  "additional_block_gained": 18
+                }
+              }
+            }
+            """;
+
+        var run = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(run);
+        var agg = run!.RelicAggregates[TuningForkRelicId];
+        Assert.Equal(0, agg.TuningForkSkillsPlayed);
+        Assert.Equal(3, agg.Activations);
+        Assert.Equal(18, agg.AdditionalBlockGained);
+        Assert.Equal(0, agg.TuningForkCombats);
+        Assert.Equal(0, agg.TuningForkTurns);
+        Assert.Equal(0, agg.TuningForkTurnsEndedOn8Charges);
+        Assert.Equal(0, agg.TuningForkTurnsEndedOn9Charges);
+        Assert.Equal(0, agg.TuningForkTurnEndChargeTotal);
+        Assert.Equal(0, agg.TuningForkTurnEndChargeCount);
     }
 
     private static string BuildBody(RelicAggregate agg)
         => (string)(BuildTuningForkBodyMethod.Invoke(null, new object?[] { agg })
             ?? throw new InvalidOperationException("BuildTuningForkBodyBBCode returned null."));
+
+    private static int CountOccurrences(string value, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
 }


### PR DESCRIPTION
## Summary
- add Kunai attack-counter, activation, Dexterity, and turn-end charge stats
- add Ripple Basin activation and observed block-gain stats
- expand Tuning Fork counter stats with Skill plays, held combat/turn denominators, charge buckets, averages, and observed block gained

## Validation
- dotnet test Tests\SpireLens.Core.Tests\SpireLens.Core.Tests.csproj -c Debug
- SpireLens core hot reload succeeded after each pushed iteration