### PR TITLE
Consolidate relic Compendium and attribution work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,19 +2,21 @@
 
 This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attribution: not just what a card says it should do, but what it actually caused in the run.
 
-## User-Owned Validation
+## User-Owned Verification
 
-During interactive Codex development work, the user owns validation. Unless the
-user explicitly requests validation in the current task, do **not** run tests,
-build or deploy the mod, hot-reload SpireLens, inspect game logs for validation,
-manipulate live game/MCP scenarios, or capture validation screenshots. Implement
-the requested change, commit/push it when the active workflow calls for that,
-and clearly report that validation was not run.
+During interactive Codex development work, the user owns test execution and
+behavioral verification. Unless the user explicitly requests verification in
+the current task, do **not** run tests, set up or manipulate live game/MCP test
+scenarios, capture verification screenshots, or otherwise attempt to prove the
+feature's behavior. Implement the requested change and clearly report that
+tests and behavioral verification were not run.
 
-This preference overrides any repo skill or workflow default that would
-otherwise automatically validate an implementation. Explicitly assigned
-verification tasks (for example, a Glimmung verification phase) still count as
-an explicit request and should follow their own validation contract.
+Normal implementation and handoff steps are still expected: Codex may build and
+deploy the mod, hot-reload SpireLens, commit, and push. This preference overrides
+only the automatic test/live-verification parts of repo skills or workflows, not
+their build/deploy/reload flow. Explicitly assigned verification tasks (for
+example, a Glimmung verification phase) still count as an explicit request and
+should follow their own validation contract.
 
 ## Mod Policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,20 @@
 
 This repo is a hot-reloadable Slay the Spire 2 mod focused on per-card attribution: not just what a card says it should do, but what it actually caused in the run.
 
+## User-Owned Validation
+
+During interactive Codex development work, the user owns validation. Unless the
+user explicitly requests validation in the current task, do **not** run tests,
+build or deploy the mod, hot-reload SpireLens, inspect game logs for validation,
+manipulate live game/MCP scenarios, or capture validation screenshots. Implement
+the requested change, commit/push it when the active workflow calls for that,
+and clearly report that validation was not run.
+
+This preference overrides any repo skill or workflow default that would
+otherwise automatically validate an implementation. Explicitly assigned
+verification tasks (for example, a Glimmung verification phase) still count as
+an explicit request and should follow their own validation contract.
+
 ## Mod Policy
 
 The Slay the Spire 2 install (`D:\SteamLibrary\steamapps\common\Slay the Spire 2\mods\`) runs **only** the user's own mods plus their required prereqs. No third-party mods.

--- a/Core/CardAggregatePooler.cs
+++ b/Core/CardAggregatePooler.cs
@@ -51,6 +51,7 @@ internal static class CardAggregatePooler
         target.TimesExhaustedOtherCards += source.TimesExhaustedOtherCards;
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
+        target.TotalMaxHpLost += source.TotalMaxHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
         target.TimesCardsDrawAttempted += source.TimesCardsDrawAttempted;
         target.TimesCardsDrawBlocked += source.TimesCardsDrawBlocked;

--- a/Core/CoreMain.cs
+++ b/Core/CoreMain.cs
@@ -137,6 +137,7 @@ public static class CoreMain
         // the user would see the checkbox disappear until they close and
         // reopen the deck view.
         Patches.ViewStatsInjectorPatch.ReinjectIntoActiveDeckView();
+        Patches.RelicCompendiumFilterUi.ReinjectIntoActiveCollections();
         Patches.RelicCompendiumStatsSignals.ReattachToActiveEntries();
 
         // Visible confirmation on screen so hot reload has immediate feedback.
@@ -173,6 +174,9 @@ public static class CoreMain
 
         try { RelicCompendiumStatsSignals.TeardownAttachedSignals(); }
         catch (Exception e) { Logger.Error($"Shutdown: relic compendium signal teardown failed: {e}"); }
+
+        try { RelicCompendiumFilterUi.TeardownInjectedUI(); }
+        catch (Exception e) { Logger.Error($"Shutdown: relic compendium filter teardown failed: {e}"); }
 
         try { StatsTooltip.Destroy(); }
         catch (Exception e) { Logger.Error($"Shutdown: StatsTooltip teardown failed: {e}"); }

--- a/Core/CoreMain.cs
+++ b/Core/CoreMain.cs
@@ -137,6 +137,7 @@ public static class CoreMain
         // the user would see the checkbox disappear until they close and
         // reopen the deck view.
         Patches.ViewStatsInjectorPatch.ReinjectIntoActiveDeckView();
+        Patches.RelicCompendiumStatsSignals.ReattachToActiveEntries();
 
         // Visible confirmation on screen so hot reload has immediate feedback.
         // Kept in Core (not Loader) so toast text/style can be tweaked and
@@ -169,6 +170,9 @@ public static class CoreMain
         // later cleanup. A half-cleaned state is better than a no-cleaned state.
         try { ViewStatsInjectorPatch.TeardownInjectedUI(); }
         catch (Exception e) { Logger.Error($"Shutdown: UI teardown failed: {e}"); }
+
+        try { RelicCompendiumStatsSignals.TeardownAttachedSignals(); }
+        catch (Exception e) { Logger.Error($"Shutdown: relic compendium signal teardown failed: {e}"); }
 
         try { StatsTooltip.Destroy(); }
         catch (Exception e) { Logger.Error($"Shutdown: StatsTooltip teardown failed: {e}"); }

--- a/Core/Patches/BrightestFlameOnPlayPatch.cs
+++ b/Core/Patches/BrightestFlameOnPlayPatch.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models.Cards;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Records the maximum HP Brightest Flame actually removes. Its LoseMaxHp
+/// command is the final awaited action in OnPlay, so wrapping that exact
+/// callback's returned task gives us the completed before/after delta while
+/// preserving the card instance that caused it.
+/// </summary>
+[HarmonyPatch]
+public static class BrightestFlameOnPlayPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        return AccessTools.Method(
+            typeof(BrightestFlame),
+            "OnPlay",
+            new[] { typeof(PlayerChoiceContext), typeof(CardPlay) });
+    }
+
+    [HarmonyPrefix]
+    public static void Prefix(BrightestFlame __instance, out MaxHpState __state)
+    {
+        __state = default;
+
+        try
+        {
+            var creature = __instance?.Owner?.Creature;
+            if (creature == null) return;
+            __state = new MaxHpState(__instance, creature, creature.MaxHp);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"BrightestFlameOnPlayPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(ref Task __result, MaxHpState __state)
+    {
+        try
+        {
+            if (__result == null || __state.Card == null || __state.Creature == null) return;
+            __result = ObserveAsync(__result, __state);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"BrightestFlameOnPlayPatch.Postfix failed: {e.Message}");
+        }
+    }
+
+    private static async Task ObserveAsync(Task inner, MaxHpState state)
+    {
+        await inner.ConfigureAwait(false);
+
+        try
+        {
+            RunTracker.RecordBrightestFlameMaxHpLost(
+                state.Card!,
+                state.InitialMaxHp,
+                state.Creature!.MaxHp);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"BrightestFlameOnPlayPatch.ObserveAsync failed: {e.Message}");
+        }
+    }
+
+    public readonly record struct MaxHpState(
+        BrightestFlame? Card,
+        Creature? Creature,
+        int InitialMaxHp);
+}

--- a/Core/Patches/CardHoverTooltipPatch.cs
+++ b/Core/Patches/CardHoverTooltipPatch.cs
@@ -492,6 +492,8 @@ public static class CardHoverShowPatch
         // show as reduced HP loss, which is the true cost signal.
         if (agg.TotalHpLost > 0)
             Row3(sb, "HP lost", agg.TotalHpLost.ToString(), "");
+        if (agg.TotalMaxHpLost > 0)
+            Row3(sb, "Max HP lost", agg.TotalMaxHpLost.ToString(), "");
     }
 
     /// <summary>
@@ -572,6 +574,8 @@ public static class CardHoverShowPatch
 
         if (agg.TotalHpLost > 0)
             Row3(sb, "HP lost", agg.TotalHpLost.ToString(), "");
+        if (agg.TotalMaxHpLost > 0)
+            Row3(sb, "Max HP lost", agg.TotalMaxHpLost.ToString(), "");
     }
 
     /// <summary>

--- a/Core/Patches/RazorToothStatsPatch.cs
+++ b/Core/Patches/RazorToothStatsPatch.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Counts cards Razor Tooth actually upgrades. Its owner-specific callback
+/// calls CardCmd.Upgrade synchronously before returning Task.CompletedTask, so
+/// comparing the same played card before and after captures successful upgrades
+/// without inferring them from card type or eligibility.
+/// </summary>
+[HarmonyPatch]
+public static class RazorToothAfterCardPlayedPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        return AccessTools.Method(
+            typeof(RazorTooth),
+            nameof(RazorTooth.AfterCardPlayed),
+            new[] { typeof(PlayerChoiceContext), typeof(CardPlay) });
+    }
+
+    [HarmonyPrefix]
+    public static void Prefix(RazorTooth __instance, CardPlay cardPlay, out UpgradeState __state)
+    {
+        __state = default;
+
+        try
+        {
+            var card = cardPlay?.Card;
+            if (__instance == null || card == null) return;
+            if (!RunTracker.IsTrackedRelic(__instance)) return;
+
+            __state = new UpgradeState(card, card.CurrentUpgradeLevel);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RazorToothAfterCardPlayedPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(UpgradeState __state)
+    {
+        try
+        {
+            if (__state.Card == null) return;
+            RunTracker.RecordRazorToothUpgrade(
+                __state.PreviousUpgradeLevel,
+                __state.Card.CurrentUpgradeLevel);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RazorToothAfterCardPlayedPatch.Postfix failed: {e.Message}");
+        }
+    }
+
+    public readonly record struct UpgradeState(CardModel? Card, int PreviousUpgradeLevel);
+}

--- a/Core/Patches/RazorToothStatsPatch.cs
+++ b/Core/Patches/RazorToothStatsPatch.cs
@@ -2,7 +2,9 @@ using System;
 using System.Reflection;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Hooks;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Relics;
 
@@ -12,7 +14,9 @@ namespace SpireLens.Core.Patches;
 /// Counts cards Razor Tooth actually upgrades. Its owner-specific callback
 /// calls CardCmd.Upgrade synchronously before returning Task.CompletedTask, so
 /// comparing the same played card before and after captures successful upgrades
-/// without inferring them from card type or eligibility.
+/// without inferring them from card type or eligibility. Successfully upgraded
+/// combat cards are then tracked by raw reference so later plays and draws can
+/// be counted without conflating generated or copied cards.
 /// </summary>
 [HarmonyPatch]
 public static class RazorToothAfterCardPlayedPatch
@@ -45,12 +49,14 @@ public static class RazorToothAfterCardPlayedPatch
     }
 
     [HarmonyPostfix]
-    public static void Postfix(UpgradeState __state)
+    public static void Postfix(RazorTooth __instance, UpgradeState __state)
     {
         try
         {
             if (__state.Card == null) return;
             RunTracker.RecordRazorToothUpgrade(
+                __instance,
+                __state.Card,
                 __state.PreviousUpgradeLevel,
                 __state.Card.CurrentUpgradeLevel);
         }
@@ -61,4 +67,21 @@ public static class RazorToothAfterCardPlayedPatch
     }
 
     public readonly record struct UpgradeState(CardModel? Card, int PreviousUpgradeLevel);
+}
+
+[HarmonyPatch(typeof(Hook), nameof(Hook.AfterPlayerTurnStart))]
+public static class HookAfterPlayerTurnStartRazorToothPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Player player)
+    {
+        try
+        {
+            RunTracker.RecordRazorToothTurnStarted(player);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"HookAfterPlayerTurnStartRazorToothPatch failed: {e.Message}");
+        }
+    }
 }

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.UI;
@@ -51,6 +52,33 @@ public static class RelicCompendiumFilterCollectionOpenedPatch
     }
 }
 
+[HarmonyPatch(typeof(NRelicCollection), "AddRelics")]
+public static class RelicCompendiumFilterCollectionAddRelicsPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NRelicCollection __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumFilterCollectionAddRelicsPatch), () =>
+        {
+            RelicCompendiumFilterUi.ApplyLayoutToCollection(__instance);
+            RelicCompendiumFilterUi.ApplyToActiveEntries();
+        });
+    }
+}
+
+[HarmonyPatch(typeof(NRelicCollection), "ClearRelics")]
+public static class RelicCompendiumFilterCollectionClearRelicsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(NRelicCollection __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumFilterCollectionClearRelicsPatch), () =>
+        {
+            RelicCompendiumFilterUi.RestoreCollectionLayout(__instance);
+        });
+    }
+}
+
 internal static class RelicCompendiumFilterContext
 {
     public static CompendiumRelicEntryVisualAction GetVisualAction(
@@ -79,15 +107,41 @@ internal static class RelicCompendiumFilterContext
 internal static class RelicCompendiumFilterUi
 {
     private const string PanelName = "SpireLensRelicFilterPanel";
+    private const string FlatGridName = "SpireLensFlatRelicGrid";
     private const float DimmedAlpha = 0.5f;
+    private const int FallbackFlatGridColumns = 8;
+    private static readonly string[] CategoryFieldNames =
+    [
+        "_starter",
+        "_common",
+        "_uncommon",
+        "_rare",
+        "_shop",
+        "_ancient",
+        "_event",
+    ];
+
+    private static readonly FieldInfo[] CategoryFields = CategoryFieldNames
+        .Select(name => AccessTools.Field(typeof(NRelicCollection), name))
+        .Where(field => field != null)
+        .Cast<FieldInfo>()
+        .ToArray();
+
+    private static readonly FieldInfo? CategoryRelicsContainerField =
+        AccessTools.Field(typeof(NRelicCollectionCategory), "_relicsContainer");
+
+    private static readonly FieldInfo? CategorySubCategoriesField =
+        AccessTools.Field(typeof(NRelicCollectionCategory), "_subCategories");
 
     private static readonly List<InjectedPanel> InjectedPanels = new();
     private static readonly List<EntryOriginalVisual> EntryOriginals = new();
+    private static readonly List<FlatCollectionLayout> FlatLayouts = new();
     private static readonly HashSet<string> SelectedCategoryIds =
         new(RelicTaxonomy.Categories.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
 
     private static CompendiumRelicFilterMode _mode = CompendiumRelicFilterMode.Off;
     private static bool _showUndiscoveredRelics = true;
+    private static bool _useSingleRelicGrid;
     private static bool _syncingControls;
 
     public static void Inject(NRelicCollection? collection)
@@ -100,6 +154,7 @@ internal static class RelicCompendiumFilterUi
             if (existing.IsFor(collection))
             {
                 SyncPanelControls(existing);
+                ApplyLayoutToCollection(collection);
                 return;
             }
         }
@@ -111,6 +166,7 @@ internal static class RelicCompendiumFilterUi
         var injectedPanel = panel with { Collection = collection };
         InjectedPanels.Add(injectedPanel);
         SyncPanelControls(injectedPanel);
+        ApplyLayoutToCollection(collection);
         CoreMain.Logger.Info("RelicCompendiumFilter: injected filter panel");
     }
 
@@ -122,7 +178,10 @@ internal static class RelicCompendiumFilterUi
             if (tree == null) return;
 
             foreach (var collection in FindRelicCollections(tree.Root))
+            {
                 Inject(collection);
+                ApplyLayoutToCollection(collection);
+            }
             ApplyToActiveEntries();
         }
         catch (Exception e)
@@ -133,6 +192,7 @@ internal static class RelicCompendiumFilterUi
 
     public static void TeardownInjectedUI()
     {
+        RestoreAllCollectionLayouts();
         RestoreAllEntries();
 
         foreach (var panel in InjectedPanels.ToArray())
@@ -184,6 +244,7 @@ internal static class RelicCompendiumFilterUi
     {
         _mode = CompendiumRelicFilterMode.Off;
         _showUndiscoveredRelics = true;
+        _useSingleRelicGrid = false;
         SelectedCategoryIds.Clear();
         foreach (var category in RelicTaxonomy.Categories)
             SelectedCategoryIds.Add(category.Id);
@@ -259,7 +320,20 @@ internal static class RelicCompendiumFilterUi
             Callable.From<bool>(OnShowUndiscoveredToggled));
         vbox.AddChild(showUndiscovered);
 
-        var categoriesLabel = NewLabel("Categories", 13, new Color(0.78f, 0.73f, 0.64f, 1f));
+        var singleRelicGrid = new CheckBox
+        {
+            Name = "SingleRelicGrid",
+            Text = "Single relic grid",
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+        };
+        singleRelicGrid.AddThemeFontSizeOverride("font_size", 14);
+        singleRelicGrid.Connect(
+            BaseButton.SignalName.Toggled,
+            Callable.From<bool>(OnSingleRelicGridToggled));
+        vbox.AddChild(singleRelicGrid);
+
+        var categoriesLabel = NewLabel("SpireLens categories", 13, new Color(0.78f, 0.73f, 0.64f, 1f));
         vbox.AddChild(categoriesLabel);
 
         var checkboxByCategory = new Dictionary<string, CheckBox>(StringComparer.OrdinalIgnoreCase);
@@ -297,7 +371,13 @@ internal static class RelicCompendiumFilterUi
         clearAll.Connect(BaseButton.SignalName.Pressed, Callable.From(ClearAllCategories));
         buttons.AddChild(clearAll);
 
-        return new InjectedPanel(null, root, modeDropdown, showUndiscovered, checkboxByCategory);
+        return new InjectedPanel(
+            null,
+            root,
+            modeDropdown,
+            showUndiscovered,
+            singleRelicGrid,
+            checkboxByCategory);
     }
 
     private static Label NewLabel(string text, int fontSize, Color color)
@@ -359,6 +439,15 @@ internal static class RelicCompendiumFilterUi
         ApplyToActiveEntries();
     }
 
+    private static void OnSingleRelicGridToggled(bool selected)
+    {
+        if (_syncingControls) return;
+
+        _useSingleRelicGrid = selected;
+        ApplyLayoutToActiveCollections();
+        ApplyToActiveEntries();
+    }
+
     private static void SelectAllCategories()
     {
         foreach (var category in RelicTaxonomy.Categories)
@@ -398,6 +487,229 @@ internal static class RelicCompendiumFilterUi
         finally
         {
             _syncingControls = false;
+        }
+    }
+
+    public static void ApplyLayoutToCollection(NRelicCollection? collection)
+    {
+        if (collection == null || !GodotObject.IsInstanceValid(collection)) return;
+
+        try
+        {
+            if (_useSingleRelicGrid)
+                FlattenCollectionLayout(collection);
+            else
+                RestoreCollectionLayout(collection);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RelicCompendiumFilter.ApplyLayoutToCollection failed: {e}");
+        }
+    }
+
+    public static void RestoreCollectionLayout(NRelicCollection? collection)
+    {
+        if (collection == null) return;
+
+        for (var i = FlatLayouts.Count - 1; i >= 0; i--)
+        {
+            var layout = FlatLayouts[i];
+            if (!layout.IsFor(collection)) continue;
+
+            layout.Restore();
+            FlatLayouts.RemoveAt(i);
+        }
+    }
+
+    private static void ApplyLayoutToActiveCollections()
+    {
+        try
+        {
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree == null) return;
+
+            foreach (var collection in FindRelicCollections(tree.Root))
+                ApplyLayoutToCollection(collection);
+            CleanupInvalidFlatLayouts();
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RelicCompendiumFilter.ApplyLayoutToActiveCollections failed: {e}");
+        }
+    }
+
+    private static void FlattenCollectionLayout(NRelicCollection collection)
+    {
+        CleanupInvalidFlatLayouts();
+
+        foreach (var existing in FlatLayouts)
+        {
+            if (existing.IsFor(collection) && existing.IsValid)
+                return;
+        }
+
+        RestoreCollectionLayout(collection);
+
+        var categories = GetBuiltInCategories(collection).ToList();
+        if (categories.Count == 0) return;
+
+        var firstCategory = categories.FirstOrDefault(category => category.GetParent() != null);
+        var hostParent = firstCategory?.GetParent();
+        if (hostParent == null || !GodotObject.IsInstanceValid(hostParent)) return;
+
+        RemoveExistingFlatGrid(hostParent);
+
+        var entries = GetEntriesForCategories(categories);
+        if (entries.Count == 0) return;
+
+        var firstIndex = firstCategory != null
+            ? GetChildIndex(hostParent, firstCategory)
+            : hostParent.GetChildCount();
+
+        var flatGrid = new GridContainer
+        {
+            Name = FlatGridName,
+            Columns = GetFlatGridColumns(categories),
+            MouseFilter = Control.MouseFilterEnum.Pass,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+            SizeFlagsVertical = Control.SizeFlags.Fill,
+        };
+        hostParent.AddChild(flatGrid);
+        hostParent.MoveChild(flatGrid, Math.Clamp(firstIndex, 0, hostParent.GetChildCount() - 1));
+
+        var categoryStates = categories
+            .Select(category => new OriginalCategoryState(category, category.Visible))
+            .ToList();
+        var entryStates = new List<OriginalEntryState>();
+
+        foreach (var entry in entries)
+        {
+            var parent = entry.GetParent();
+            if (parent == null || !GodotObject.IsInstanceValid(parent)) continue;
+
+            entryStates.Add(new OriginalEntryState(entry, parent, GetChildIndex(parent, entry)));
+            parent.RemoveChild(entry);
+            flatGrid.AddChild(entry);
+        }
+
+        if (entryStates.Count == 0)
+        {
+            flatGrid.QueueFree();
+            return;
+        }
+
+        foreach (var categoryState in categoryStates)
+            categoryState.Category.Visible = false;
+
+        FlatLayouts.Add(new FlatCollectionLayout(collection, flatGrid, categoryStates, entryStates));
+        CoreMain.Logger.Info($"RelicCompendiumFilter: flattened {entryStates.Count} relic entries");
+    }
+
+    private static void RestoreAllCollectionLayouts()
+    {
+        foreach (var layout in FlatLayouts.ToArray())
+            layout.Restore();
+        FlatLayouts.Clear();
+    }
+
+    private static IEnumerable<NRelicCollectionCategory> GetBuiltInCategories(NRelicCollection collection)
+    {
+        var seen = new HashSet<NRelicCollectionCategory>(ReferenceEqualityComparer.Instance);
+        foreach (var field in CategoryFields)
+        {
+            if (field.GetValue(collection) is not NRelicCollectionCategory category) continue;
+
+            foreach (var found in GetCategoryAndSubcategories(category))
+            {
+                if (seen.Add(found))
+                    yield return found;
+            }
+        }
+    }
+
+    private static IEnumerable<NRelicCollectionCategory> GetCategoryAndSubcategories(
+        NRelicCollectionCategory category)
+    {
+        if (!GodotObject.IsInstanceValid(category)) yield break;
+
+        yield return category;
+
+        if (CategorySubCategoriesField?.GetValue(category) is not IEnumerable<NRelicCollectionCategory> subCategories)
+            yield break;
+
+        foreach (var subCategory in subCategories)
+        {
+            foreach (var found in GetCategoryAndSubcategories(subCategory))
+                yield return found;
+        }
+    }
+
+    private static List<NRelicCollectionEntry> GetEntriesForCategories(
+        IEnumerable<NRelicCollectionCategory> categories)
+    {
+        var result = new List<NRelicCollectionEntry>();
+        var seen = new HashSet<NRelicCollectionEntry>(ReferenceEqualityComparer.Instance);
+
+        foreach (var category in categories)
+        {
+            if (CategoryRelicsContainerField?.GetValue(category) is not GridContainer relicsContainer)
+                continue;
+
+            foreach (var entry in FindEntries(relicsContainer))
+            {
+                if (!GodotObject.IsInstanceValid(entry) || !seen.Add(entry)) continue;
+                result.Add(entry);
+            }
+        }
+
+        return result;
+    }
+
+    private static int GetFlatGridColumns(IEnumerable<NRelicCollectionCategory> categories)
+    {
+        foreach (var category in categories)
+        {
+            if (CategoryRelicsContainerField?.GetValue(category) is GridContainer relicsContainer
+                && relicsContainer.Columns > 0)
+            {
+                return relicsContainer.Columns;
+            }
+        }
+
+        return FallbackFlatGridColumns;
+    }
+
+    private static void RemoveExistingFlatGrid(Node hostParent)
+    {
+        for (var i = hostParent.GetChildCount() - 1; i >= 0; i--)
+        {
+            var child = hostParent.GetChild(i);
+            if (!string.Equals(child.Name.ToString(), FlatGridName, StringComparison.Ordinal))
+                continue;
+
+            hostParent.RemoveChild(child);
+            child.QueueFree();
+        }
+    }
+
+    private static int GetChildIndex(Node parent, Node child)
+    {
+        var count = parent.GetChildCount();
+        for (var i = 0; i < count; i++)
+        {
+            if (ReferenceEquals(parent.GetChild(i), child))
+                return i;
+        }
+
+        return count;
+    }
+
+    private static void CleanupInvalidFlatLayouts()
+    {
+        for (var i = FlatLayouts.Count - 1; i >= 0; i--)
+        {
+            if (FlatLayouts[i].IsValid) continue;
+            FlatLayouts.RemoveAt(i);
         }
     }
 
@@ -522,6 +834,7 @@ internal static class RelicCompendiumFilterUi
         PanelContainer Root,
         OptionButton ModeDropdown,
         CheckBox ShowUndiscoveredCheckbox,
+        CheckBox SingleRelicGridCheckbox,
         IReadOnlyDictionary<string, CheckBox> Checkboxes)
     {
         public bool IsValid =>
@@ -552,6 +865,9 @@ internal static class RelicCompendiumFilterUi
 
             if (ShowUndiscoveredCheckbox != null && GodotObject.IsInstanceValid(ShowUndiscoveredCheckbox))
                 ShowUndiscoveredCheckbox.SetPressedNoSignal(_showUndiscoveredRelics);
+
+            if (SingleRelicGridCheckbox != null && GodotObject.IsInstanceValid(SingleRelicGridCheckbox))
+                SingleRelicGridCheckbox.SetPressedNoSignal(_useSingleRelicGrid);
 
             foreach (var (categoryId, checkbox) in Checkboxes)
             {
@@ -585,6 +901,91 @@ internal static class RelicCompendiumFilterUi
             if (!IsValid) return;
             _entry.Modulate = Modulate;
             _entry.Visible = Visible;
+        }
+    }
+
+    private sealed class FlatCollectionLayout
+    {
+        private readonly NRelicCollection _collection;
+        private readonly GridContainer _flatGrid;
+        private readonly IReadOnlyList<OriginalCategoryState> _categories;
+        private readonly IReadOnlyList<OriginalEntryState> _entries;
+
+        public FlatCollectionLayout(
+            NRelicCollection collection,
+            GridContainer flatGrid,
+            IReadOnlyList<OriginalCategoryState> categories,
+            IReadOnlyList<OriginalEntryState> entries)
+        {
+            _collection = collection;
+            _flatGrid = flatGrid;
+            _categories = categories;
+            _entries = entries;
+        }
+
+        public bool IsValid => GodotObject.IsInstanceValid(_collection);
+
+        public bool IsFor(NRelicCollection collection) => ReferenceEquals(_collection, collection);
+
+        public void Restore()
+        {
+            foreach (var category in _categories)
+                category.Restore();
+
+            foreach (var entry in _entries)
+                entry.Restore();
+
+            if (GodotObject.IsInstanceValid(_flatGrid))
+                _flatGrid.QueueFree();
+        }
+    }
+
+    private sealed class OriginalCategoryState
+    {
+        public OriginalCategoryState(NRelicCollectionCategory category, bool visible)
+        {
+            Category = category;
+            Visible = visible;
+        }
+
+        public NRelicCollectionCategory Category { get; }
+
+        private bool Visible { get; }
+
+        public void Restore()
+        {
+            if (!GodotObject.IsInstanceValid(Category)) return;
+            Category.Visible = Visible;
+        }
+    }
+
+    private sealed class OriginalEntryState
+    {
+        private readonly NRelicCollectionEntry _entry;
+        private readonly Node _parent;
+        private readonly int _index;
+
+        public OriginalEntryState(NRelicCollectionEntry entry, Node parent, int index)
+        {
+            _entry = entry;
+            _parent = parent;
+            _index = index;
+        }
+
+        public void Restore()
+        {
+            if (!GodotObject.IsInstanceValid(_entry) || !GodotObject.IsInstanceValid(_parent))
+                return;
+
+            var currentParent = _entry.GetParent();
+            if (!ReferenceEquals(currentParent, _parent))
+            {
+                currentParent?.RemoveChild(_entry);
+                _parent.AddChild(_entry);
+            }
+
+            var targetIndex = Math.Clamp(_index, 0, Math.Max(0, _parent.GetChildCount() - 1));
+            _parent.MoveChild(_entry, targetIndex);
         }
     }
 }

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -1,0 +1,556 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.UI;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+using MegaCrit.Sts2.Core.Nodes.Screens.RelicCollection;
+
+namespace SpireLens.Core.Patches;
+
+internal enum CompendiumRelicFilterMode
+{
+    Off = 0,
+    Compare = 1,
+    Filter = 2,
+}
+
+internal enum CompendiumRelicEntryVisualAction
+{
+    Normal,
+    Dim,
+    Hidden,
+}
+
+[HarmonyPatch(typeof(NRelicCollection), "_Ready")]
+public static class RelicCompendiumFilterCollectionReadyPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NRelicCollection __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumFilterCollectionReadyPatch), () =>
+        {
+            RelicCompendiumFilterUi.Inject(__instance);
+        });
+    }
+}
+
+[HarmonyPatch(typeof(NRelicCollection), "OnSubmenuOpened")]
+public static class RelicCompendiumFilterCollectionOpenedPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NRelicCollection __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumFilterCollectionOpenedPatch), () =>
+        {
+            RelicCompendiumFilterUi.Inject(__instance);
+            RelicCompendiumFilterUi.ApplyToActiveEntries();
+        });
+    }
+}
+
+internal static class RelicCompendiumFilterContext
+{
+    public static CompendiumRelicEntryVisualAction GetVisualAction(
+        CompendiumRelicFilterMode mode,
+        bool canApplyCategoryVisuals,
+        bool matchesSelectedCategories)
+    {
+        if (!canApplyCategoryVisuals || mode == CompendiumRelicFilterMode.Off)
+            return CompendiumRelicEntryVisualAction.Normal;
+
+        if (matchesSelectedCategories)
+            return CompendiumRelicEntryVisualAction.Normal;
+
+        return mode == CompendiumRelicFilterMode.Filter
+            ? CompendiumRelicEntryVisualAction.Hidden
+            : CompendiumRelicEntryVisualAction.Dim;
+    }
+}
+
+internal static class RelicCompendiumFilterUi
+{
+    private const string PanelName = "SpireLensRelicFilterPanel";
+    private const float DimmedAlpha = 0.5f;
+
+    private static readonly List<InjectedPanel> InjectedPanels = new();
+    private static readonly List<EntryOriginalVisual> EntryOriginals = new();
+    private static readonly HashSet<string> SelectedCategoryIds =
+        new(RelicTaxonomy.Categories.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
+
+    private static CompendiumRelicFilterMode _mode = CompendiumRelicFilterMode.Off;
+    private static bool _syncingControls;
+
+    public static void Inject(NRelicCollection? collection)
+    {
+        if (collection == null || !GodotObject.IsInstanceValid(collection)) return;
+        CleanupInvalidPanels();
+
+        foreach (var existing in InjectedPanels)
+        {
+            if (existing.IsFor(collection))
+            {
+                SyncPanelControls(existing);
+                return;
+            }
+        }
+
+        RemoveExistingPanel(collection);
+
+        var panel = BuildPanel();
+        collection.AddChild(panel.Root);
+        var injectedPanel = panel with { Collection = collection };
+        InjectedPanels.Add(injectedPanel);
+        SyncPanelControls(injectedPanel);
+        CoreMain.Logger.Info("RelicCompendiumFilter: injected filter panel");
+    }
+
+    public static void ReinjectIntoActiveCollections()
+    {
+        try
+        {
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree == null) return;
+
+            foreach (var collection in FindRelicCollections(tree.Root))
+                Inject(collection);
+            ApplyToActiveEntries();
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RelicCompendiumFilter.ReinjectIntoActiveCollections failed: {e}");
+        }
+    }
+
+    public static void TeardownInjectedUI()
+    {
+        RestoreAllEntries();
+
+        foreach (var panel in InjectedPanels.ToArray())
+            panel.QueueFree();
+        InjectedPanels.Clear();
+    }
+
+    public static void ApplyToEntry(NRelicCollectionEntry? entry)
+    {
+        if (entry == null || !GodotObject.IsInstanceValid(entry)) return;
+        RememberOriginal(entry);
+
+        var canApplyCategoryVisuals = entry.ModelVisibility == ModelVisibility.Visible;
+        var matches = false;
+        if (canApplyCategoryVisuals
+            && CompendiumRelicStatsContext.TryGetRelicModel(entry, out var relicModel))
+        {
+            var relicId = GetRelicId(relicModel);
+            matches = RelicTaxonomy.IsRelicInAnySelectedCategory(relicId, SelectedCategoryIds);
+        }
+
+        var action = RelicCompendiumFilterContext.GetVisualAction(
+            _mode,
+            canApplyCategoryVisuals,
+            matches);
+
+        ApplyVisualAction(entry, action);
+    }
+
+    public static void ApplyToActiveEntries()
+    {
+        try
+        {
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree == null) return;
+
+            foreach (var entry in FindEntries(tree.Root))
+                ApplyToEntry(entry);
+            CleanupInvalidEntryOriginals();
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RelicCompendiumFilter.ApplyToActiveEntries failed: {e}");
+        }
+    }
+
+    internal static void ResetForTests()
+    {
+        _mode = CompendiumRelicFilterMode.Off;
+        SelectedCategoryIds.Clear();
+        foreach (var category in RelicTaxonomy.Categories)
+            SelectedCategoryIds.Add(category.Id);
+    }
+
+    private static InjectedPanel BuildPanel()
+    {
+        var root = new PanelContainer
+        {
+            Name = PanelName,
+            Position = new Vector2(34f, 126f),
+            CustomMinimumSize = new Vector2(218f, 0f),
+            ZIndex = 200,
+            MouseFilter = Control.MouseFilterEnum.Stop,
+        };
+        root.AddThemeStyleboxOverride("panel", new StyleBoxFlat
+        {
+            BgColor = new Color(0.055f, 0.049f, 0.043f, 0.84f),
+            BorderColor = new Color(0.56f, 0.46f, 0.25f, 0.72f),
+            BorderWidthLeft = 1,
+            BorderWidthRight = 1,
+            BorderWidthTop = 1,
+            BorderWidthBottom = 1,
+            ContentMarginLeft = 10,
+            ContentMarginRight = 10,
+            ContentMarginTop = 8,
+            ContentMarginBottom = 8,
+            CornerRadiusTopLeft = 4,
+            CornerRadiusTopRight = 4,
+            CornerRadiusBottomLeft = 4,
+            CornerRadiusBottomRight = 4,
+        });
+
+        var vbox = new VBoxContainer
+        {
+            Name = "Contents",
+            MouseFilter = Control.MouseFilterEnum.Pass,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+        };
+        vbox.AddThemeConstantOverride("separation", 6);
+        root.AddChild(vbox);
+
+        var title = NewLabel("SpireLens relic view", 16, new Color(0.918f, 0.745f, 0.318f, 1f));
+        vbox.AddChild(title);
+
+        var modeLabel = NewLabel("Mode", 13, new Color(0.78f, 0.73f, 0.64f, 1f));
+        vbox.AddChild(modeLabel);
+
+        var modeDropdown = new OptionButton
+        {
+            Name = "ModeDropdown",
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+        };
+        modeDropdown.AddItem("Off", (int)CompendiumRelicFilterMode.Off);
+        modeDropdown.AddItem("Compare", (int)CompendiumRelicFilterMode.Compare);
+        modeDropdown.AddItem("Filter", (int)CompendiumRelicFilterMode.Filter);
+        modeDropdown.Connect(
+            OptionButton.SignalName.ItemSelected,
+            Callable.From<long>(index => OnModeSelected(modeDropdown, index)));
+        vbox.AddChild(modeDropdown);
+
+        var categoriesLabel = NewLabel("Categories", 13, new Color(0.78f, 0.73f, 0.64f, 1f));
+        vbox.AddChild(categoriesLabel);
+
+        var checkboxByCategory = new Dictionary<string, CheckBox>(StringComparer.OrdinalIgnoreCase);
+        foreach (var category in RelicTaxonomy.Categories)
+        {
+            var checkbox = new CheckBox
+            {
+                Name = $"Category_{category.Id}",
+                Text = category.DisplayName,
+                MouseFilter = Control.MouseFilterEnum.Stop,
+                SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+            };
+            checkbox.AddThemeFontSizeOverride("font_size", 14);
+            checkbox.Connect(
+                BaseButton.SignalName.Toggled,
+                Callable.From<bool>(pressed => OnCategoryToggled(category.Id, pressed)));
+            checkboxByCategory[category.Id] = checkbox;
+            vbox.AddChild(checkbox);
+        }
+
+        var buttons = new HBoxContainer
+        {
+            Name = "BulkButtons",
+            MouseFilter = Control.MouseFilterEnum.Pass,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+        };
+        buttons.AddThemeConstantOverride("separation", 6);
+        vbox.AddChild(buttons);
+
+        var selectAll = NewButton("Select All");
+        selectAll.Connect(BaseButton.SignalName.Pressed, Callable.From(SelectAllCategories));
+        buttons.AddChild(selectAll);
+
+        var clearAll = NewButton("Clear All");
+        clearAll.Connect(BaseButton.SignalName.Pressed, Callable.From(ClearAllCategories));
+        buttons.AddChild(clearAll);
+
+        return new InjectedPanel(null, root, modeDropdown, checkboxByCategory);
+    }
+
+    private static Label NewLabel(string text, int fontSize, Color color)
+    {
+        var label = new Label
+        {
+            Text = text,
+            MouseFilter = Control.MouseFilterEnum.Ignore,
+            AutowrapMode = TextServer.AutowrapMode.WordSmart,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+        };
+        label.AddThemeFontSizeOverride("font_size", fontSize);
+        label.AddThemeColorOverride("font_color", color);
+        return label;
+    }
+
+    private static Button NewButton(string text)
+    {
+        var button = new Button
+        {
+            Text = text,
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+            CustomMinimumSize = new Vector2(0f, 28f),
+        };
+        button.AddThemeFontSizeOverride("font_size", 13);
+        return button;
+    }
+
+    private static void OnModeSelected(OptionButton modeDropdown, long selectedIndex)
+    {
+        if (_syncingControls) return;
+
+        var selectedId = modeDropdown.GetItemId((int)selectedIndex);
+        _mode = Enum.IsDefined(typeof(CompendiumRelicFilterMode), selectedId)
+            ? (CompendiumRelicFilterMode)selectedId
+            : CompendiumRelicFilterMode.Off;
+
+        ApplyToActiveEntries();
+    }
+
+    private static void OnCategoryToggled(string categoryId, bool selected)
+    {
+        if (_syncingControls) return;
+
+        if (selected)
+            SelectedCategoryIds.Add(categoryId);
+        else
+            SelectedCategoryIds.Remove(categoryId);
+
+        ApplyToActiveEntries();
+    }
+
+    private static void SelectAllCategories()
+    {
+        foreach (var category in RelicTaxonomy.Categories)
+            SelectedCategoryIds.Add(category.Id);
+        SyncAllControls();
+        ApplyToActiveEntries();
+    }
+
+    private static void ClearAllCategories()
+    {
+        SelectedCategoryIds.Clear();
+        SyncAllControls();
+        ApplyToActiveEntries();
+    }
+
+    private static void SyncAllControls()
+    {
+        _syncingControls = true;
+        try
+        {
+            foreach (var panel in InjectedPanels)
+                panel.SyncFromState();
+        }
+        finally
+        {
+            _syncingControls = false;
+        }
+    }
+
+    private static void SyncPanelControls(InjectedPanel panel)
+    {
+        _syncingControls = true;
+        try
+        {
+            panel.SyncFromState();
+        }
+        finally
+        {
+            _syncingControls = false;
+        }
+    }
+
+    private static void ApplyVisualAction(
+        NRelicCollectionEntry entry,
+        CompendiumRelicEntryVisualAction action)
+    {
+        var original = RememberOriginal(entry);
+        switch (action)
+        {
+            case CompendiumRelicEntryVisualAction.Hidden:
+                entry.Modulate = original.Modulate with { A = 1f };
+                entry.Visible = false;
+                StatsTooltip.HideIfAnchoredTo(entry);
+                break;
+            case CompendiumRelicEntryVisualAction.Dim:
+                entry.Visible = original.Visible;
+                entry.Modulate = original.Modulate with { A = original.Modulate.A * DimmedAlpha };
+                break;
+            default:
+                entry.Visible = original.Visible;
+                entry.Modulate = original.Modulate;
+                break;
+        }
+    }
+
+    private static EntryOriginalVisual RememberOriginal(NRelicCollectionEntry entry)
+    {
+        CleanupInvalidEntryOriginals();
+
+        foreach (var original in EntryOriginals)
+        {
+            if (original.IsFor(entry))
+                return original;
+        }
+
+        var added = new EntryOriginalVisual(entry, entry.Modulate, entry.Visible);
+        EntryOriginals.Add(added);
+        return added;
+    }
+
+    private static void RestoreAllEntries()
+    {
+        foreach (var original in EntryOriginals.ToArray())
+            original.Restore();
+        EntryOriginals.Clear();
+    }
+
+    private static string GetRelicId(RelicModel relicModel)
+    {
+        try
+        {
+            return RelicHoverShowPatch.GetStatsAggregateId(relicModel);
+        }
+        catch
+        {
+            return relicModel.Id.ToString();
+        }
+    }
+
+    private static void RemoveExistingPanel(NRelicCollection collection)
+    {
+        for (var i = collection.GetChildCount() - 1; i >= 0; i--)
+        {
+            var child = collection.GetChild(i);
+            if (!string.Equals(child.Name.ToString(), PanelName, StringComparison.Ordinal))
+                continue;
+
+            collection.RemoveChild(child);
+            child.QueueFree();
+        }
+    }
+
+    private static void CleanupInvalidPanels()
+    {
+        for (var i = InjectedPanels.Count - 1; i >= 0; i--)
+        {
+            if (InjectedPanels[i].IsValid) continue;
+            InjectedPanels.RemoveAt(i);
+        }
+    }
+
+    private static void CleanupInvalidEntryOriginals()
+    {
+        for (var i = EntryOriginals.Count - 1; i >= 0; i--)
+        {
+            if (EntryOriginals[i].IsValid) continue;
+            EntryOriginals.RemoveAt(i);
+        }
+    }
+
+    private static IEnumerable<NRelicCollection> FindRelicCollections(Node? node)
+    {
+        if (node == null) yield break;
+        if (node is NRelicCollection collection && GodotObject.IsInstanceValid(collection))
+            yield return collection;
+
+        var count = node.GetChildCount();
+        for (var i = 0; i < count; i++)
+        {
+            foreach (var child in FindRelicCollections(node.GetChild(i)))
+                yield return child;
+        }
+    }
+
+    private static IEnumerable<NRelicCollectionEntry> FindEntries(Node? node)
+    {
+        if (node == null) yield break;
+        if (node is NRelicCollectionEntry entry && GodotObject.IsInstanceValid(entry))
+            yield return entry;
+
+        var count = node.GetChildCount();
+        for (var i = 0; i < count; i++)
+        {
+            foreach (var childEntry in FindEntries(node.GetChild(i)))
+                yield return childEntry;
+        }
+    }
+
+    private sealed record InjectedPanel(
+        NRelicCollection? Collection,
+        PanelContainer Root,
+        OptionButton ModeDropdown,
+        IReadOnlyDictionary<string, CheckBox> Checkboxes)
+    {
+        public bool IsValid =>
+            Root != null
+            && GodotObject.IsInstanceValid(Root)
+            && Collection != null
+            && GodotObject.IsInstanceValid(Collection);
+
+        public bool IsFor(NRelicCollection collection) =>
+            Collection != null && ReferenceEquals(Collection, collection);
+
+        public void QueueFree()
+        {
+            if (Root != null && GodotObject.IsInstanceValid(Root))
+                Root.QueueFree();
+        }
+
+        public void SyncFromState()
+        {
+            var selectedIndex = 0;
+            for (var i = 0; i < ModeDropdown.ItemCount; i++)
+            {
+                if (ModeDropdown.GetItemId(i) != (int)_mode) continue;
+                selectedIndex = i;
+                break;
+            }
+            ModeDropdown.Selected = selectedIndex;
+
+            foreach (var (categoryId, checkbox) in Checkboxes)
+            {
+                if (checkbox == null || !GodotObject.IsInstanceValid(checkbox)) continue;
+                checkbox.SetPressedNoSignal(SelectedCategoryIds.Contains(categoryId));
+            }
+        }
+    }
+
+    private sealed class EntryOriginalVisual
+    {
+        private readonly NRelicCollectionEntry _entry;
+
+        public EntryOriginalVisual(NRelicCollectionEntry entry, Color modulate, bool visible)
+        {
+            _entry = entry;
+            Modulate = modulate;
+            Visible = visible;
+        }
+
+        public Color Modulate { get; }
+
+        public bool Visible { get; }
+
+        public bool IsValid => GodotObject.IsInstanceValid(_entry);
+
+        public bool IsFor(NRelicCollectionEntry entry) => ReferenceEquals(_entry, entry);
+
+        public void Restore()
+        {
+            if (!IsValid) return;
+            _entry.Modulate = Modulate;
+            _entry.Visible = Visible;
+        }
+    }
+}

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -55,11 +55,17 @@ internal static class RelicCompendiumFilterContext
 {
     public static CompendiumRelicEntryVisualAction GetVisualAction(
         CompendiumRelicFilterMode mode,
-        bool canApplyCategoryVisuals,
+        bool isVisibleRelic,
+        bool showUndiscoveredRelics,
         bool matchesSelectedCategories)
     {
-        if (!canApplyCategoryVisuals || mode == CompendiumRelicFilterMode.Off)
+        if (mode == CompendiumRelicFilterMode.Off)
             return CompendiumRelicEntryVisualAction.Normal;
+
+        if (!isVisibleRelic)
+            return showUndiscoveredRelics
+                ? CompendiumRelicEntryVisualAction.Normal
+                : CompendiumRelicEntryVisualAction.Hidden;
 
         if (matchesSelectedCategories)
             return CompendiumRelicEntryVisualAction.Normal;
@@ -81,6 +87,7 @@ internal static class RelicCompendiumFilterUi
         new(RelicTaxonomy.Categories.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
 
     private static CompendiumRelicFilterMode _mode = CompendiumRelicFilterMode.Off;
+    private static bool _showUndiscoveredRelics = true;
     private static bool _syncingControls;
 
     public static void Inject(NRelicCollection? collection)
@@ -138,9 +145,9 @@ internal static class RelicCompendiumFilterUi
         if (entry == null || !GodotObject.IsInstanceValid(entry)) return;
         RememberOriginal(entry);
 
-        var canApplyCategoryVisuals = entry.ModelVisibility == ModelVisibility.Visible;
+        var isVisibleRelic = entry.ModelVisibility == ModelVisibility.Visible;
         var matches = false;
-        if (canApplyCategoryVisuals
+        if (isVisibleRelic
             && CompendiumRelicStatsContext.TryGetRelicModel(entry, out var relicModel))
         {
             var relicId = GetRelicId(relicModel);
@@ -149,7 +156,8 @@ internal static class RelicCompendiumFilterUi
 
         var action = RelicCompendiumFilterContext.GetVisualAction(
             _mode,
-            canApplyCategoryVisuals,
+            isVisibleRelic,
+            _showUndiscoveredRelics,
             matches);
 
         ApplyVisualAction(entry, action);
@@ -175,6 +183,7 @@ internal static class RelicCompendiumFilterUi
     internal static void ResetForTests()
     {
         _mode = CompendiumRelicFilterMode.Off;
+        _showUndiscoveredRelics = true;
         SelectedCategoryIds.Clear();
         foreach (var category in RelicTaxonomy.Categories)
             SelectedCategoryIds.Add(category.Id);
@@ -237,6 +246,19 @@ internal static class RelicCompendiumFilterUi
             Callable.From<long>(index => OnModeSelected(modeDropdown, index)));
         vbox.AddChild(modeDropdown);
 
+        var showUndiscovered = new CheckBox
+        {
+            Name = "ShowUndiscovered",
+            Text = "Show undiscovered",
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+        };
+        showUndiscovered.AddThemeFontSizeOverride("font_size", 14);
+        showUndiscovered.Connect(
+            BaseButton.SignalName.Toggled,
+            Callable.From<bool>(OnShowUndiscoveredToggled));
+        vbox.AddChild(showUndiscovered);
+
         var categoriesLabel = NewLabel("Categories", 13, new Color(0.78f, 0.73f, 0.64f, 1f));
         vbox.AddChild(categoriesLabel);
 
@@ -275,7 +297,7 @@ internal static class RelicCompendiumFilterUi
         clearAll.Connect(BaseButton.SignalName.Pressed, Callable.From(ClearAllCategories));
         buttons.AddChild(clearAll);
 
-        return new InjectedPanel(null, root, modeDropdown, checkboxByCategory);
+        return new InjectedPanel(null, root, modeDropdown, showUndiscovered, checkboxByCategory);
     }
 
     private static Label NewLabel(string text, int fontSize, Color color)
@@ -326,6 +348,14 @@ internal static class RelicCompendiumFilterUi
         else
             SelectedCategoryIds.Remove(categoryId);
 
+        ApplyToActiveEntries();
+    }
+
+    private static void OnShowUndiscoveredToggled(bool selected)
+    {
+        if (_syncingControls) return;
+
+        _showUndiscoveredRelics = selected;
         ApplyToActiveEntries();
     }
 
@@ -491,6 +521,7 @@ internal static class RelicCompendiumFilterUi
         NRelicCollection? Collection,
         PanelContainer Root,
         OptionButton ModeDropdown,
+        CheckBox ShowUndiscoveredCheckbox,
         IReadOnlyDictionary<string, CheckBox> Checkboxes)
     {
         public bool IsValid =>
@@ -518,6 +549,9 @@ internal static class RelicCompendiumFilterUi
                 break;
             }
             ModeDropdown.Selected = selectedIndex;
+
+            if (ShowUndiscoveredCheckbox != null && GodotObject.IsInstanceValid(ShowUndiscoveredCheckbox))
+                ShowUndiscoveredCheckbox.SetPressedNoSignal(_showUndiscoveredRelics);
 
             foreach (var (categoryId, checkbox) in Checkboxes)
             {

--- a/Core/Patches/RelicCompendiumStatsPatch.cs
+++ b/Core/Patches/RelicCompendiumStatsPatch.cs
@@ -85,6 +85,7 @@ internal static class CompendiumRelicStatsContext
 {
     private const string EnthralledDefinitionId = "CARD.ENTHRALLED";
     private const string CursedPearlCurseDefinitionId = "CARD.GREED";
+    private const string BrightestFlameDefinitionId = "CARD.BRIGHTEST_FLAME";
     private static readonly FieldInfo? RelicField =
         AccessTools.Field(typeof(NRelicCollectionEntry), "relic");
 
@@ -157,6 +158,9 @@ internal static class CompendiumRelicStatsContext
         var cursedPearlCurseAgg = relicModel is CursedPearl
             ? CardAggregatePooler.PoolByDefinition(run.Aggregates, CursedPearlCurseDefinitionId) ?? new CardAggregate()
             : null;
+        var storybookBrightestFlameAgg = relicModel is Storybook
+            ? CardAggregatePooler.PoolByDefinition(run.Aggregates, BrightestFlameDefinitionId) ?? new CardAggregate()
+            : null;
         IReadOnlyDictionary<string, CardAggregate>? neowsBonesCurseAggs = null;
         if (relicModel is NeowsBones)
             neowsBonesCurseAggs = BuildGrantedCurseAggregates(run, aggregate);
@@ -168,6 +172,7 @@ internal static class CompendiumRelicStatsContext
             bloodSoakedRoseCurseAgg,
             cursedPearlCurseAgg,
             neowsBonesCurseAggs,
+            storybookBrightestFlameAgg,
             out title,
             out body);
     }

--- a/Core/Patches/RelicCompendiumStatsPatch.cs
+++ b/Core/Patches/RelicCompendiumStatsPatch.cs
@@ -40,6 +40,7 @@ public static class RelicCompendiumStatsReadyPatch
         PatchGuard.Run(nameof(RelicCompendiumStatsReadyPatch), () =>
         {
             RelicCompendiumStatsSignals.Attach(__instance);
+            RelicCompendiumFilterUi.ApplyToEntry(__instance);
         });
     }
 }
@@ -94,7 +95,7 @@ internal static class CompendiumRelicStatsContext
     {
         if (entry == null || !GodotObject.IsInstanceValid(entry)) return;
         if (!ShouldShowStatsForVisibility(entry.ModelVisibility)) return;
-        if (RelicField?.GetValue(entry) is not RelicModel relicModel) return;
+        if (!TryGetRelicModel(entry, out var relicModel)) return;
 
         var tree = Engine.GetMainLoop() as SceneTree;
         if (tree == null) return;
@@ -103,6 +104,18 @@ internal static class CompendiumRelicStatsContext
             return;
 
         StatsTooltip.Show(tree, entry, title, "SpireLens", body);
+    }
+
+    internal static bool TryGetRelicModel(
+        NRelicCollectionEntry? entry,
+        out RelicModel relicModel)
+    {
+        relicModel = null!;
+        if (entry == null || !GodotObject.IsInstanceValid(entry)) return false;
+        if (RelicField?.GetValue(entry) is not RelicModel found) return false;
+
+        relicModel = found;
+        return true;
     }
 
     public static bool TryBuildRelicTooltip(

--- a/Core/Patches/RelicCompendiumStatsPatch.cs
+++ b/Core/Patches/RelicCompendiumStatsPatch.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.UI;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Nodes.Screens.RelicCollection;
+using MegaCrit.Sts2.Core.Runs;
+using MegaCrit.Sts2.Core.Saves;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Adds SpireLens relic stat hovers to the relic compendium. In-run hovers use
+/// the live tracker, including pending combat data; main-menu hovers use the
+/// saved continue-run start time to load the matching in-progress run file.
+/// </summary>
+[HarmonyPatch(typeof(NRelicCollectionEntry), "OnFocus")]
+public static class RelicCompendiumStatsShowPatch
+{
+    private static readonly FieldInfo? RelicField =
+        AccessTools.Field(typeof(NRelicCollectionEntry), "relic");
+
+    [HarmonyPostfix]
+    public static void Postfix(NRelicCollectionEntry __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumStatsShowPatch), () =>
+        {
+            if (!CompendiumRelicStatsContext.ShouldShowStatsForVisibility(__instance.ModelVisibility))
+                return;
+
+            if (RelicField?.GetValue(__instance) is not RelicModel relicModel)
+                return;
+
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree == null) return;
+
+            if (!CompendiumRelicStatsContext.TryBuildRelicTooltip(relicModel, out var title, out var body))
+                return;
+
+            StatsTooltip.Show(tree, __instance, title, "SpireLens", body);
+        });
+    }
+}
+
+[HarmonyPatch(typeof(NRelicCollectionEntry), "OnUnfocus")]
+public static class RelicCompendiumStatsHidePatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NRelicCollectionEntry __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumStatsHidePatch), () =>
+        {
+            StatsTooltip.HideIfAnchoredTo(__instance);
+        });
+    }
+}
+
+[HarmonyPatch(typeof(NContinueRunInfo), "ShowInfo")]
+public static class MainMenuContinueRunStatsContextShowInfoPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(SerializableRun save)
+    {
+        PatchGuard.Run(nameof(MainMenuContinueRunStatsContextShowInfoPatch), () =>
+        {
+            MainMenuContinueRunStatsContext.SetContinueRun(save);
+        });
+    }
+}
+
+[HarmonyPatch(typeof(NContinueRunInfo), "ShowError")]
+public static class MainMenuContinueRunStatsContextShowErrorPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix()
+    {
+        PatchGuard.Run(nameof(MainMenuContinueRunStatsContextShowErrorPatch), MainMenuContinueRunStatsContext.Clear);
+    }
+}
+
+internal static class CompendiumRelicStatsContext
+{
+    private const string EnthralledDefinitionId = "CARD.ENTHRALLED";
+    private const string CursedPearlCurseDefinitionId = "CARD.GREED";
+
+    public static bool ShouldShowStatsForVisibility(ModelVisibility visibility)
+        => visibility == ModelVisibility.Visible;
+
+    public static bool TryBuildRelicTooltip(
+        RelicModel relicModel,
+        out string title,
+        out string body)
+    {
+        title = "";
+        body = "";
+        if (relicModel == null) return false;
+
+        if (RunTracker.Current != null)
+            return RelicHoverShowPatch.TryBuildInventoryBodyBBCode(null, relicModel, out title, out body);
+
+        if (!MainMenuContinueRunStatsContext.TryGetCurrentRun(out var run))
+            return false;
+
+        return TryBuildRelicTooltipForRun(relicModel, run, out title, out body);
+    }
+
+    internal static bool TryBuildRelicTooltipForRun(
+        RelicModel relicModel,
+        RunData run,
+        out string title,
+        out string body)
+    {
+        title = "";
+        body = "";
+        if (relicModel == null || run == null) return false;
+
+        var relicId = RelicHoverShowPatch.GetStatsAggregateId(relicModel);
+        var aggregate = CloneRelicAggregate(run.RelicAggregates.TryGetValue(relicId, out var saved)
+            ? saved
+            : null);
+
+        var bloodSoakedRoseCurseAgg = relicModel is BloodSoakedRose
+            ? CardAggregatePooler.PoolByDefinition(run.Aggregates, EnthralledDefinitionId) ?? new CardAggregate()
+            : null;
+        var cursedPearlCurseAgg = relicModel is CursedPearl
+            ? CardAggregatePooler.PoolByDefinition(run.Aggregates, CursedPearlCurseDefinitionId) ?? new CardAggregate()
+            : null;
+        IReadOnlyDictionary<string, CardAggregate>? neowsBonesCurseAggs = null;
+        if (relicModel is NeowsBones)
+            neowsBonesCurseAggs = BuildGrantedCurseAggregates(run, aggregate);
+
+        return RelicHoverShowPatch.TryBuildBodyBBCode(
+            relicModel,
+            aggregate,
+            run.FloorReached,
+            bloodSoakedRoseCurseAgg,
+            cursedPearlCurseAgg,
+            neowsBonesCurseAggs,
+            out title,
+            out body);
+    }
+
+    private static RelicAggregate CloneRelicAggregate(RelicAggregate? source)
+    {
+        var result = new RelicAggregate();
+        if (source != null)
+            RunTracker.MergeRelicAggregateInto(result, source);
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, CardAggregate> BuildGrantedCurseAggregates(
+        RunData run,
+        RelicAggregate aggregate)
+    {
+        var result = new Dictionary<string, CardAggregate>(StringComparer.Ordinal);
+        foreach (var card in aggregate.CardsGranted.Values)
+        {
+            if (card.Count <= 0 || string.IsNullOrWhiteSpace(card.CardId)) continue;
+            result[card.CardId] =
+                CardAggregatePooler.PoolByDefinition(run.Aggregates, card.CardId) ?? new CardAggregate();
+        }
+
+        return result;
+    }
+}
+
+internal static class MainMenuContinueRunStatsContext
+{
+    private static long? _gameStartTime;
+    private static RunData? _cachedRun;
+    private static long? _cachedGameStartTime;
+
+    public static void SetContinueRun(SerializableRun? save)
+    {
+        var startTime = save?.StartTime ?? 0;
+        if (startTime <= 0)
+        {
+            Clear();
+            return;
+        }
+
+        if (_gameStartTime == startTime) return;
+
+        _gameStartTime = startTime;
+        _cachedRun = null;
+        _cachedGameStartTime = null;
+    }
+
+    public static void Clear()
+    {
+        _gameStartTime = null;
+        _cachedRun = null;
+        _cachedGameStartTime = null;
+    }
+
+    public static bool TryGetCurrentRun(out RunData run)
+    {
+        run = null!;
+        var gameStartTime = _gameStartTime ?? TryGetLiveGameStartTime();
+        if (!gameStartTime.HasValue) return false;
+
+        if (_cachedRun != null && _cachedGameStartTime == gameStartTime)
+        {
+            run = _cachedRun;
+            return true;
+        }
+
+        var loaded = RunStorage.FindByGameStartTime(
+            gameStartTime.Value,
+            out _,
+            requireInProgress: true);
+        if (loaded == null) return false;
+
+        _cachedRun = loaded;
+        _cachedGameStartTime = gameStartTime;
+        run = loaded;
+        return true;
+    }
+
+    private static long? TryGetLiveGameStartTime()
+    {
+        try
+        {
+            var startTime = RunManager.Instance?._startTime ?? 0;
+            return startTime > 0 ? startTime : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Core/Patches/RelicCompendiumStatsPatch.cs
+++ b/Core/Patches/RelicCompendiumStatsPatch.cs
@@ -21,27 +21,25 @@ namespace SpireLens.Core.Patches;
 [HarmonyPatch(typeof(NRelicCollectionEntry), "OnFocus")]
 public static class RelicCompendiumStatsShowPatch
 {
-    private static readonly FieldInfo? RelicField =
-        AccessTools.Field(typeof(NRelicCollectionEntry), "relic");
-
     [HarmonyPostfix]
     public static void Postfix(NRelicCollectionEntry __instance)
     {
         PatchGuard.Run(nameof(RelicCompendiumStatsShowPatch), () =>
         {
-            if (!CompendiumRelicStatsContext.ShouldShowStatsForVisibility(__instance.ModelVisibility))
-                return;
+            CompendiumRelicStatsContext.ShowForEntry(__instance);
+        });
+    }
+}
 
-            if (RelicField?.GetValue(__instance) is not RelicModel relicModel)
-                return;
-
-            var tree = Engine.GetMainLoop() as SceneTree;
-            if (tree == null) return;
-
-            if (!CompendiumRelicStatsContext.TryBuildRelicTooltip(relicModel, out var title, out var body))
-                return;
-
-            StatsTooltip.Show(tree, __instance, title, "SpireLens", body);
+[HarmonyPatch(typeof(NRelicCollectionEntry), "_Ready")]
+public static class RelicCompendiumStatsReadyPatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NRelicCollectionEntry __instance)
+    {
+        PatchGuard.Run(nameof(RelicCompendiumStatsReadyPatch), () =>
+        {
+            RelicCompendiumStatsSignals.Attach(__instance);
         });
     }
 }
@@ -86,9 +84,26 @@ internal static class CompendiumRelicStatsContext
 {
     private const string EnthralledDefinitionId = "CARD.ENTHRALLED";
     private const string CursedPearlCurseDefinitionId = "CARD.GREED";
+    private static readonly FieldInfo? RelicField =
+        AccessTools.Field(typeof(NRelicCollectionEntry), "relic");
 
     public static bool ShouldShowStatsForVisibility(ModelVisibility visibility)
         => visibility == ModelVisibility.Visible;
+
+    public static void ShowForEntry(NRelicCollectionEntry? entry)
+    {
+        if (entry == null || !GodotObject.IsInstanceValid(entry)) return;
+        if (!ShouldShowStatsForVisibility(entry.ModelVisibility)) return;
+        if (RelicField?.GetValue(entry) is not RelicModel relicModel) return;
+
+        var tree = Engine.GetMainLoop() as SceneTree;
+        if (tree == null) return;
+
+        if (!TryBuildRelicTooltip(relicModel, out var title, out var body))
+            return;
+
+        StatsTooltip.Show(tree, entry, title, "SpireLens", body);
+    }
 
     public static bool TryBuildRelicTooltip(
         RelicModel relicModel,
@@ -165,6 +180,151 @@ internal static class CompendiumRelicStatsContext
         }
 
         return result;
+    }
+}
+
+internal static class RelicCompendiumStatsSignals
+{
+    private static readonly List<AttachedHandlers> AttachedEntries = new();
+
+    public static void Attach(NRelicCollectionEntry? entry)
+    {
+        if (entry == null || !GodotObject.IsInstanceValid(entry)) return;
+        CleanupInvalidHandlers();
+
+        foreach (var handlers in AttachedEntries)
+        {
+            if (handlers.IsFor(entry))
+                return;
+        }
+
+        var attached = new AttachedHandlers(entry);
+        attached.Attach();
+        AttachedEntries.Add(attached);
+    }
+
+    public static void Detach(NRelicCollectionEntry? entry)
+    {
+        if (entry == null) return;
+
+        for (var i = AttachedEntries.Count - 1; i >= 0; i--)
+        {
+            var handlers = AttachedEntries[i];
+            if (!handlers.IsFor(entry)) continue;
+
+            handlers.Detach();
+            AttachedEntries.RemoveAt(i);
+        }
+    }
+
+    public static void ReattachToActiveEntries()
+    {
+        try
+        {
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree == null) return;
+
+            foreach (var entry in FindEntries(tree.Root))
+                Attach(entry);
+        }
+        catch (Exception e)
+        {
+            CoreMain.Logger.Error($"RelicCompendiumStatsSignals.ReattachToActiveEntries failed: {e}");
+        }
+    }
+
+    public static void TeardownAttachedSignals()
+    {
+        foreach (var handlers in AttachedEntries.ToArray())
+            handlers.Detach();
+        AttachedEntries.Clear();
+    }
+
+    private static void CleanupInvalidHandlers()
+    {
+        for (var i = AttachedEntries.Count - 1; i >= 0; i--)
+        {
+            if (AttachedEntries[i].IsValid) continue;
+            AttachedEntries[i].Detach();
+            AttachedEntries.RemoveAt(i);
+        }
+    }
+
+    private static IEnumerable<NRelicCollectionEntry> FindEntries(Node? node)
+    {
+        if (node == null) yield break;
+        if (node is NRelicCollectionEntry entry && GodotObject.IsInstanceValid(entry))
+            yield return entry;
+
+        var count = node.GetChildCount();
+        for (var i = 0; i < count; i++)
+        {
+            foreach (var childEntry in FindEntries(node.GetChild(i)))
+                yield return childEntry;
+        }
+    }
+
+    private sealed class AttachedHandlers
+    {
+        private readonly NRelicCollectionEntry _entry;
+        private bool _attached;
+
+        public AttachedHandlers(NRelicCollectionEntry entry)
+        {
+            _entry = entry;
+        }
+
+        public bool IsValid => GodotObject.IsInstanceValid(_entry);
+
+        public bool IsFor(NRelicCollectionEntry entry) => ReferenceEquals(_entry, entry);
+
+        public void Attach()
+        {
+            if (_attached || !IsValid) return;
+
+            _entry.MouseEntered += OnMouseEntered;
+            _entry.MouseExited += OnMouseExited;
+            _entry.TreeExiting += OnTreeExiting;
+            _attached = true;
+        }
+
+        public void Detach()
+        {
+            if (!_attached) return;
+            _attached = false;
+
+            if (!IsValid) return;
+            try { _entry.MouseEntered -= OnMouseEntered; }
+            catch { }
+            try { _entry.MouseExited -= OnMouseExited; }
+            catch { }
+            try { _entry.TreeExiting -= OnTreeExiting; }
+            catch { }
+        }
+
+        private void OnMouseEntered()
+        {
+            PatchGuard.Run("RelicCompendiumStatsSignals.MouseEntered", () =>
+            {
+                CompendiumRelicStatsContext.ShowForEntry(_entry);
+            });
+        }
+
+        private void OnMouseExited()
+        {
+            PatchGuard.Run("RelicCompendiumStatsSignals.MouseExited", () =>
+            {
+                StatsTooltip.HideIfAnchoredTo(_entry);
+            });
+        }
+
+        private void OnTreeExiting()
+        {
+            PatchGuard.Run("RelicCompendiumStatsSignals.TreeExiting", () =>
+            {
+                RelicCompendiumStatsSignals.Detach(_entry);
+            });
+        }
     }
 }
 

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -458,6 +458,16 @@ public static class RelicHoverShowPatch
                 return;
             }
 
+            if (relicNode.Model is RazorTooth)
+            {
+                const string relicId = "RELIC.RAZOR_TOOTH";
+                var agg = RelicAgg(relicId);
+
+                var body = BuildRazorToothBodyBBCode(agg);
+                StatsTooltip.Show(tree, __instance, "Razor Tooth", "SpireLens", body);
+                return;
+            }
+
             if (relicNode.Model is Whetstone)
             {
                 const string relicId = "RELIC.WHETSTONE";
@@ -1249,6 +1259,13 @@ public static class RelicHoverShowPatch
         {
             title = "Stone Cracker";
             body = BuildStoneCrackerBodyBBCode(agg);
+            return true;
+        }
+
+        if (relicModel is RazorTooth)
+        {
+            title = "Razor Tooth";
+            body = BuildRazorToothBodyBBCode(agg);
             return true;
         }
 
@@ -2120,6 +2137,13 @@ public static class RelicHoverShowPatch
     {
         var sb = new StringBuilder();
         Row3(sb, "Activations", agg.Activations.ToString(), "");
+        Row3(sb, "Cards upgraded", agg.CardsUpgraded.ToString(), "");
+        return sb.ToString();
+    }
+
+    private static string BuildRazorToothBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
         Row3(sb, "Cards upgraded", agg.CardsUpgraded.ToString(), "");
         return sb.ToString();
     }

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -2144,7 +2144,34 @@ public static class RelicHoverShowPatch
     private static string BuildRazorToothBodyBBCode(RelicAggregate agg)
     {
         var sb = new StringBuilder();
+        var upgradedPerTurn = agg.RazorToothTurns <= 0
+            ? 0m
+            : (decimal)agg.CardsUpgraded / agg.RazorToothTurns;
+        var upgradedPerCombat = agg.RazorToothCombats <= 0
+            ? 0m
+            : (decimal)agg.CardsUpgraded / agg.RazorToothCombats;
+        var upgradedPlaysPerTurn = agg.RazorToothTurns <= 0
+            ? 0m
+            : (decimal)agg.RazorToothUpgradedCardPlays / agg.RazorToothTurns;
+        var upgradedPlaysPerCombat = agg.RazorToothCombats <= 0
+            ? 0m
+            : (decimal)agg.RazorToothUpgradedCardPlays / agg.RazorToothCombats;
+        var upgradedDrawsPerTurn = agg.RazorToothTurns <= 0
+            ? 0m
+            : (decimal)agg.RazorToothUpgradedCardDraws / agg.RazorToothTurns;
+        var upgradedDrawsPerCombat = agg.RazorToothCombats <= 0
+            ? 0m
+            : (decimal)agg.RazorToothUpgradedCardDraws / agg.RazorToothCombats;
+
         Row3(sb, "Cards upgraded", agg.CardsUpgraded.ToString(), "");
+        Row3(sb, "Avg cards upgraded/turn", FormatDecimal(upgradedPerTurn), "");
+        Row3(sb, "Avg cards upgraded/combat", FormatDecimal(upgradedPerCombat), "");
+        Row3(sb, "Upgraded-card plays", agg.RazorToothUpgradedCardPlays.ToString(), "");
+        Row3(sb, "Avg upgraded plays/turn", FormatDecimal(upgradedPlaysPerTurn), "");
+        Row3(sb, "Avg upgraded plays/combat", FormatDecimal(upgradedPlaysPerCombat), "");
+        Row3(sb, "Upgraded-card draws", agg.RazorToothUpgradedCardDraws.ToString(), "");
+        Row3(sb, "Avg upgraded draws/turn", FormatDecimal(upgradedDrawsPerTurn), "");
+        Row3(sb, "Avg upgraded draws/combat", FormatDecimal(upgradedDrawsPerCombat), "");
         return sb.ToString();
     }
 

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -20,10 +20,12 @@ public static class RelicHoverShowPatch
 {
     private const string EnthralledDefinitionId = "CARD.ENTHRALLED";
     private const string CursedPearlCurseDefinitionId = "CARD.GREED";
+    private const string BrightestFlameDefinitionId = "CARD.BRIGHTEST_FLAME";
     private const string GameOverScreenNamespace = "MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen";
     private const string VulnerableIconPath = "res://images/atlases/power_atlas.sprites/vulnerable_power.tres";
     private const string WeakIconPath = "res://images/atlases/power_atlas.sprites/weak_power.tres";
     private const string BlockIconPath = "res://images/ui/combat/block.png";
+    private const string DrawIconPath = "res://images/atlases/power_atlas.sprites/draw_cards_next_turn_power.tres";
     private const string EnergyIconPath = "res://images/atlases/potion_atlas.sprites/energy_potion.tres";
     private const string StarIconPath = "res://images/packed/sprite_fonts/star_icon.png";
     private const string VigorIconPath = "res://images/atlases/power_atlas.sprites/vigor_power.tres";
@@ -819,6 +821,7 @@ public static class RelicHoverShowPatch
         RelicAggregate? aggregate = null;
         CardAggregate? bloodSoakedRoseCurseAgg = null;
         CardAggregate? cursedPearlCurseAgg = null;
+        CardAggregate? storybookBrightestFlameAgg = null;
         IReadOnlyDictionary<string, CardAggregate>? neowsBonesCurseAggs = null;
         int? floorCount = null;
 
@@ -837,6 +840,12 @@ public static class RelicHoverShowPatch
             {
                 cursedPearlCurseAgg =
                     RunTracker.GetLastEndedPooledCardAggregateByDefinition(CursedPearlCurseDefinitionId)
+                    ?? new CardAggregate();
+            }
+            else if (relicModel is Storybook)
+            {
+                storybookBrightestFlameAgg =
+                    RunTracker.GetLastEndedPooledCardAggregateByDefinition(BrightestFlameDefinitionId)
                     ?? new CardAggregate();
             }
             else if (relicModel is NeowsBones && aggregate != null)
@@ -858,6 +867,8 @@ public static class RelicHoverShowPatch
             bloodSoakedRoseCurseAgg = RunTracker.GetEnthralledCurseAggregate();
         if (relicModel is CursedPearl && cursedPearlCurseAgg == null)
             cursedPearlCurseAgg = RunTracker.GetCursedPearlCurseAggregate();
+        if (relicModel is Storybook && storybookBrightestFlameAgg == null)
+            storybookBrightestFlameAgg = RunTracker.GetPooledCardAggregateByDefinition(BrightestFlameDefinitionId);
         if (relicModel is NeowsBones && neowsBonesCurseAggs == null)
         {
             neowsBonesCurseAggs = BuildGrantedCurseAggregates(
@@ -874,6 +885,7 @@ public static class RelicHoverShowPatch
             bloodSoakedRoseCurseAgg,
             cursedPearlCurseAgg,
             neowsBonesCurseAggs,
+            storybookBrightestFlameAgg,
             out title,
             out body);
     }
@@ -930,7 +942,7 @@ public static class RelicHoverShowPatch
         out string title,
         out string body)
     {
-        return TryBuildBodyBBCode(relicModel, agg, floorCount, null, null, null, out title, out body);
+        return TryBuildBodyBBCode(relicModel, agg, floorCount, null, null, null, null, out title, out body);
     }
 
     internal static bool TryBuildBodyBBCode(
@@ -940,6 +952,29 @@ public static class RelicHoverShowPatch
         CardAggregate? bloodSoakedRoseCurseAgg,
         CardAggregate? cursedPearlCurseAgg,
         IReadOnlyDictionary<string, CardAggregate>? neowsBonesCurseAggs,
+        out string title,
+        out string body)
+    {
+        return TryBuildBodyBBCode(
+            relicModel,
+            agg,
+            floorCount,
+            bloodSoakedRoseCurseAgg,
+            cursedPearlCurseAgg,
+            neowsBonesCurseAggs,
+            null,
+            out title,
+            out body);
+    }
+
+    internal static bool TryBuildBodyBBCode(
+        RelicModel relicModel,
+        RelicAggregate agg,
+        int? floorCount,
+        CardAggregate? bloodSoakedRoseCurseAgg,
+        CardAggregate? cursedPearlCurseAgg,
+        IReadOnlyDictionary<string, CardAggregate>? neowsBonesCurseAggs,
+        CardAggregate? storybookBrightestFlameAgg,
         out string title,
         out string body)
     {
@@ -1210,6 +1245,13 @@ public static class RelicHoverShowPatch
         {
             title = "Blood-Soaked Rose";
             body = BuildBloodSoakedRoseBodyBBCode(agg, bloodSoakedRoseCurseAgg ?? new CardAggregate());
+            return true;
+        }
+
+        if (relicModel is Storybook)
+        {
+            title = "Storybook";
+            body = BuildStorybookBodyBBCode(storybookBrightestFlameAgg ?? new CardAggregate());
             return true;
         }
 
@@ -1997,6 +2039,19 @@ public static class RelicHoverShowPatch
             includeAveragePerCombat: true);
 
         AppendRelatedCurseCardStats(sb, "Enthralled", curseAgg);
+        return sb.ToString();
+    }
+
+    private static string BuildStorybookBodyBBCode(CardAggregate brightestFlameAgg)
+    {
+        brightestFlameAgg ??= new CardAggregate();
+
+        var sb = new StringBuilder();
+        Row3(sb, "Brightest Flame played", brightestFlameAgg.Plays.ToString(), "");
+        Row3(sb, DrawLabel("Brightest Flame drawn"), brightestFlameAgg.TimesDrawn.ToString(), "");
+        Row3(sb, EnergyLabel("gained by Flame"), brightestFlameAgg.TotalEnergyGenerated.ToString(), "");
+        Row3(sb, DrawLabel("Cards drawn by Flame"), brightestFlameAgg.TimesCardsDrawn.ToString(), "");
+        Row3(sb, "Max HP lost to Flame", brightestFlameAgg.TotalMaxHpLost.ToString(), "");
         return sb.ToString();
     }
 
@@ -2828,6 +2883,12 @@ public static class RelicHoverShowPatch
     private static string EnergyLabel(string suffix)
     {
         var path = NormalizeResourcePath(EnergyIconPath);
+        return $"[img={InlineIconSize}x{InlineIconSize}]{path}[/img] {suffix}";
+    }
+
+    private static string DrawLabel(string suffix)
+    {
+        var path = NormalizeResourcePath(DrawIconPath);
         return $"[img={InlineIconSize}x{InlineIconSize}]{path}[/img] {suffix}";
     }
 

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -12,6 +12,7 @@ internal sealed record RelicTaxonomyCategory(
 internal static class RelicTaxonomy
 {
     public const string EnergyCategoryId = "energy";
+    public const string ChargeCategoryId = "charge";
 
     private static readonly RelicTaxonomyCategory EnergyCategory = new(
         EnergyCategoryId,
@@ -42,9 +43,53 @@ internal static class RelicTaxonomy
             "RELIC.VERY_HOT_COCOA",
         });
 
+    private static readonly RelicTaxonomyCategory ChargeCategory = new(
+        ChargeCategoryId,
+        "Charge relics",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "RELIC.BOOK_OF_FIVE_RINGS",
+            "RELIC.BRILLIANT_SCARF",
+            "RELIC.DIAMOND_DIADEM",
+            "RELIC.FAKE_HAPPY_FLOWER",
+            "RELIC.FISHING_ROD",
+            "RELIC.GALACTIC_DUST",
+            "RELIC.GIRYA",
+            "RELIC.HAPPY_FLOWER",
+            "RELIC.IRON_CLUB",
+            "RELIC.JOSS_PAPER",
+            "RELIC.KUNAI",
+            "RELIC.KUSARIGAMA",
+            "RELIC.LASTING_CANDY",
+            "RELIC.LETTER_OPENER",
+            "RELIC.METRONOME",
+            "RELIC.NUNCHAKU",
+            "RELIC.ORNAMENTAL_FAN",
+            "RELIC.PAELS_FLESH",
+            "RELIC.PAELS_LEGION",
+            "RELIC.PAELS_TOOTH",
+            "RELIC.PAELS_WING",
+            "RELIC.PENDULUM",
+            "RELIC.PEN_NIB",
+            "RELIC.POCKETWATCH",
+            "RELIC.POLLINOUS_CORE",
+            "RELIC.PUMPKIN_CANDLE",
+            "RELIC.RAINBOW_RING",
+            "RELIC.SHURIKEN",
+            "RELIC.SILVER_CRUCIBLE",
+            "RELIC.STONE_CALENDAR",
+            "RELIC.SWORD_OF_STONE",
+            "RELIC.TOY_BOX",
+            "RELIC.TUNING_FORK",
+            "RELIC.VELVET_CHOKER",
+            "RELIC.WINGED_BOOTS",
+            "RELIC.WONGOS_MYSTERY_TICKET",
+        });
+
     public static IReadOnlyList<RelicTaxonomyCategory> Categories { get; } =
     [
         EnergyCategory,
+        ChargeCategory,
     ];
 
     public static bool IsRelicInAnySelectedCategory(

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SpireLens.Core;
+
+internal sealed record RelicTaxonomyCategory(
+    string Id,
+    string DisplayName,
+    IReadOnlySet<string> RelicIds);
+
+internal static class RelicTaxonomy
+{
+    public const string EnergyCategoryId = "energy";
+
+    private static readonly RelicTaxonomyCategory EnergyCategory = new(
+        EnergyCategoryId,
+        "Energy relics",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "RELIC.ART_OF_WAR",
+            "RELIC.BLOOD_SOAKED_ROSE",
+            "RELIC.BOOMING_CONCH",
+            "RELIC.BOOKMARK",
+            "RELIC.BRILLIANT_SCARF",
+            "RELIC.CANDELABRA",
+            "RELIC.CHANDELIER",
+            "RELIC.ECTOPLASM",
+            "RELIC.FAKE_HAPPY_FLOWER",
+            "RELIC.FAKE_VENERABLE_TEA_SET",
+            "RELIC.GREMLIN_HORN",
+            "RELIC.HAPPY_FLOWER",
+            "RELIC.ICE_CREAM",
+            "RELIC.LANTERN",
+            "RELIC.MUMMIFIED_HAND",
+            "RELIC.NUNCHAKU",
+            "RELIC.PHILOSOPHERS_STONE",
+            "RELIC.PRISMATIC_GEM",
+            "RELIC.SOZU",
+            "RELIC.VELVET_CHOKER",
+            "RELIC.VENERABLE_TEA_SET",
+            "RELIC.VERY_HOT_COCOA",
+        });
+
+    public static IReadOnlyList<RelicTaxonomyCategory> Categories { get; } =
+    [
+        EnergyCategory,
+    ];
+
+    public static bool IsRelicInAnySelectedCategory(
+        string? relicId,
+        IEnumerable<string> selectedCategoryIds)
+    {
+        if (string.IsNullOrWhiteSpace(relicId)) return false;
+
+        var selected = new HashSet<string>(
+            selectedCategoryIds ?? Array.Empty<string>(),
+            StringComparer.OrdinalIgnoreCase);
+        if (selected.Count == 0) return false;
+
+        return Categories.Any(category =>
+            selected.Contains(category.Id)
+            && category.RelicIds.Contains(relicId));
+    }
+}

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -12,7 +12,8 @@ internal sealed record RelicTaxonomyCategory(
 internal static class RelicTaxonomy
 {
     public const string EnergyCategoryId = "energy";
-    public const string ChargeCategoryId = "charge";
+    public const string ChargeAcrossTurnsCategoryId = "charge_across_turns";
+    public const string ChargeResetsEachTurnCategoryId = "charge_resets_each_turn";
 
     private static readonly RelicTaxonomyCategory EnergyCategory = new(
         EnergyCategoryId,
@@ -43,14 +44,12 @@ internal static class RelicTaxonomy
             "RELIC.VERY_HOT_COCOA",
         });
 
-    private static readonly RelicTaxonomyCategory ChargeCategory = new(
-        ChargeCategoryId,
-        "Charge relics",
+    private static readonly RelicTaxonomyCategory ChargeAcrossTurnsCategory = new(
+        ChargeAcrossTurnsCategoryId,
+        "Charge: across turns",
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "RELIC.BOOK_OF_FIVE_RINGS",
-            "RELIC.BRILLIANT_SCARF",
-            "RELIC.DIAMOND_DIADEM",
             "RELIC.FAKE_HAPPY_FLOWER",
             "RELIC.FISHING_ROD",
             "RELIC.GALACTIC_DUST",
@@ -58,38 +57,48 @@ internal static class RelicTaxonomy
             "RELIC.HAPPY_FLOWER",
             "RELIC.IRON_CLUB",
             "RELIC.JOSS_PAPER",
-            "RELIC.KUNAI",
-            "RELIC.KUSARIGAMA",
             "RELIC.LASTING_CANDY",
-            "RELIC.LETTER_OPENER",
             "RELIC.METRONOME",
             "RELIC.NUNCHAKU",
-            "RELIC.ORNAMENTAL_FAN",
             "RELIC.PAELS_FLESH",
             "RELIC.PAELS_LEGION",
             "RELIC.PAELS_TOOTH",
             "RELIC.PAELS_WING",
             "RELIC.PENDULUM",
             "RELIC.PEN_NIB",
-            "RELIC.POCKETWATCH",
             "RELIC.POLLINOUS_CORE",
             "RELIC.PUMPKIN_CANDLE",
-            "RELIC.RAINBOW_RING",
-            "RELIC.SHURIKEN",
             "RELIC.SILVER_CRUCIBLE",
             "RELIC.STONE_CALENDAR",
             "RELIC.SWORD_OF_STONE",
             "RELIC.TOY_BOX",
             "RELIC.TUNING_FORK",
-            "RELIC.VELVET_CHOKER",
             "RELIC.WINGED_BOOTS",
             "RELIC.WONGOS_MYSTERY_TICKET",
+        });
+
+    private static readonly RelicTaxonomyCategory ChargeResetsEachTurnCategory = new(
+        ChargeResetsEachTurnCategoryId,
+        "Charge: resets each turn",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "RELIC.BRILLIANT_SCARF",
+            "RELIC.DIAMOND_DIADEM",
+            "RELIC.KUNAI",
+            "RELIC.KUSARIGAMA",
+            "RELIC.LETTER_OPENER",
+            "RELIC.ORNAMENTAL_FAN",
+            "RELIC.POCKETWATCH",
+            "RELIC.RAINBOW_RING",
+            "RELIC.SHURIKEN",
+            "RELIC.VELVET_CHOKER",
         });
 
     public static IReadOnlyList<RelicTaxonomyCategory> Categories { get; } =
     [
         EnergyCategory,
-        ChargeCategory,
+        ChargeAcrossTurnsCategory,
+        ChargeResetsEachTurnCategory,
     ];
 
     public static bool IsRelicInAnySelectedCategory(

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -190,6 +190,12 @@ public class CardAggregate
     // listed damage says.
     public int TotalHpLost { get; set; }
 
+    // Maximum HP actually lost from playing this card. Kept separate from
+    // TotalHpLost because reducing max HP is a permanent run cost even when
+    // the player's current HP does not move. Brightest Flame is the first
+    // card using this field.
+    public int TotalMaxHpLost { get; set; }
+
     // M3i: Draw attribution. When THIS card's play causes OTHER cards to
     // be drawn. Signal for draw-enabler cards (Prepared, Coolheaded,
     // Acrobatics etc. depending on the character). Excludes turn-start

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -405,8 +405,8 @@ public class RelicAggregate
     // Total Plating this relic added. Used by Gorget.
     public decimal PlatingAdded { get; set; }
 
-    // Total cards this relic upgraded. Used by Stone Cracker, Sand Castle,
-    // Whetstone, War Paint, and other upgrade-granting relics.
+    // Total cards this relic upgraded. Used by Stone Cracker, Razor Tooth,
+    // Sand Castle, Whetstone, War Paint, and other upgrade-granting relics.
     public int CardsUpgraded { get; set; }
     public List<string> UpgradedCards { get; set; } = new();
 

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -410,6 +410,14 @@ public class RelicAggregate
     public int CardsUpgraded { get; set; }
     public List<string> UpgradedCards { get; set; } = new();
 
+    // Razor Tooth tracking. Combats/turns are held denominators for averages.
+    // Plays and draws count only events after the exact combat card was
+    // successfully upgraded by Razor Tooth; the triggering play is excluded.
+    public int RazorToothCombats { get; set; }
+    public int RazorToothTurns { get; set; }
+    public int RazorToothUpgradedCardPlays { get; set; }
+    public int RazorToothUpgradedCardDraws { get; set; }
+
     // Total times Bone Flute triggered from an owned Osty attack.
     public int BoneFluteTriggers { get; set; }
 

--- a/Core/RunHistoryStatsContext.cs
+++ b/Core/RunHistoryStatsContext.cs
@@ -17,6 +17,7 @@ internal static class RunHistoryStatsContext
 {
     private const string EnthralledDefinitionId = "CARD.ENTHRALLED";
     private const string CursedPearlCurseDefinitionId = "CARD.GREED";
+    private const string BrightestFlameDefinitionId = "CARD.BRIGHTEST_FLAME";
 
     private static readonly FieldInfo? DeckHistoryAmountField =
         AccessTools.Field(typeof(NDeckHistoryEntry), "_amount");
@@ -130,6 +131,9 @@ internal static class RunHistoryStatsContext
         var cursedPearlCurseAgg = relicModel is CursedPearl
             ? CardAggregatePooler.PoolByDefinition(run.Aggregates, CursedPearlCurseDefinitionId) ?? new CardAggregate()
             : null;
+        var storybookBrightestFlameAgg = relicModel is Storybook
+            ? CardAggregatePooler.PoolByDefinition(run.Aggregates, BrightestFlameDefinitionId) ?? new CardAggregate()
+            : null;
         IReadOnlyDictionary<string, CardAggregate>? neowsBonesCurseAggs = null;
         if (relicModel is NeowsBones)
         {
@@ -151,6 +155,7 @@ internal static class RunHistoryStatsContext
             bloodSoakedRoseCurseAgg,
             cursedPearlCurseAgg,
             neowsBonesCurseAggs,
+            storybookBrightestFlameAgg,
             out title,
             out body);
     }

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1520,6 +1520,7 @@ public static class RunTracker
         RecordLetterOpenerTurnForTrackedPlayerLocked();
         RecordTuningForkTurnForTrackedPlayerLocked();
         RecordPaperPhrogTurnForTrackedPlayerLocked();
+        RecordRazorToothTurnForTrackedPlayerLocked();
         RecordPaelsEyeCombatsWithoutActivationForTrackedPlayerLocked();
         RecordTurnEnergyRelicCombatsWithoutEnergyForTrackedPlayerLocked();
         RecordNunchakuCombatEndChargeForTrackedPlayerLocked();
@@ -1592,6 +1593,10 @@ public static class RunTracker
         target.PlatingAdded += source.PlatingAdded;
         target.CardsUpgraded += source.CardsUpgraded;
         MergeUpgradedCardsInto(target, source);
+        target.RazorToothCombats += source.RazorToothCombats;
+        target.RazorToothTurns += source.RazorToothTurns;
+        target.RazorToothUpgradedCardPlays += source.RazorToothUpgradedCardPlays;
+        target.RazorToothUpgradedCardDraws += source.RazorToothUpgradedCardDraws;
         target.BoneFluteTriggers += source.BoneFluteTriggers;
         target.TotalOstyHpSummoned += source.TotalOstyHpSummoned;
         target.CursesAcquired += source.CursesAcquired;
@@ -1873,6 +1878,7 @@ public static class RunTracker
             // Defensive: if CombatSetUp never fired (unusual), allocate lazily.
             _pendingCombat ??= new PendingCombat();
 
+            RecordRazorToothUpgradedCardPlayedLocked(cardPlay.Card);
             RecordStrikeDummyStrikePlayedIfOwnedLocked(cardPlay.Card);
             RecordNutritiousSoupEnchantedStrikePlayedIfOwnedLocked(cardPlay.Card);
             RecordMiniatureCannonUpgradedAttackPlayedIfOwnedLocked(cardPlay.Card);
@@ -2869,22 +2875,81 @@ public static class RunTracker
     /// level before and after that callback rather than inferring success from
     /// card type or upgrade eligibility.
     /// </summary>
-    public static void RecordRazorToothUpgrade(int previousUpgradeLevel, int currentUpgradeLevel)
+    public static void RecordRazorToothUpgrade(
+        RazorTooth relic,
+        CardModel card,
+        int previousUpgradeLevel,
+        int currentUpgradeLevel)
     {
+        if (relic?.Owner == null || card == null) return;
         if (currentUpgradeLevel <= previousUpgradeLevel) return;
 
         lock (_lock)
         {
             try
             {
+                if (!IsTrackedRelic(relic)) return;
+                if (!IsTrackedPlayer(relic.Owner)) return;
+                if (!ReferenceEquals(card.Owner, relic.Owner)) return;
+
+                _pendingCombat ??= new PendingCombat();
+                RecordRazorToothCombatForPlayerLocked(relic.Owner);
+                RecordRazorToothTurnForPlayerLocked(relic.Owner);
+
                 var agg = GetOrCreateRelicAggregateLocked(RazorToothRelicId);
                 RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel, currentUpgradeLevel);
+                _pendingCombat.RazorToothUpgradedCards.Add(card);
             }
             catch (Exception e)
             {
                 CoreMain.LogDebug($"RecordRazorToothUpgrade failed: {e.Message}");
             }
         }
+    }
+
+    public static void RecordRazorToothTurnStarted(Player player)
+    {
+        if (player == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedPlayer(player)) return;
+                _pendingCombat ??= new PendingCombat();
+                RecordRazorToothTurnForPlayerLocked(player);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordRazorToothTurnStarted failed: {e.Message}");
+            }
+        }
+    }
+
+    private static void RecordRazorToothUpgradedCardPlayedLocked(CardModel card)
+    {
+        if (_pendingCombat == null) return;
+        if (!_pendingCombat.RazorToothUpgradedCards.Contains(card)) return;
+        if (card.Owner is not Player player || !IsTrackedPlayer(player)) return;
+
+        RecordRazorToothCombatForPlayerLocked(player);
+        RecordRazorToothTurnForPlayerLocked(player);
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(RazorToothRelicId);
+        RecordRazorToothUpgradedCardPlayForTest(agg);
+    }
+
+    private static void RecordRazorToothUpgradedCardDrawnLocked(CardModel card)
+    {
+        if (_pendingCombat == null) return;
+        if (!_pendingCombat.RazorToothUpgradedCards.Contains(card)) return;
+        if (card.Owner is not Player player || !IsTrackedPlayer(player)) return;
+
+        RecordRazorToothCombatForPlayerLocked(player);
+        RecordRazorToothTurnForPlayerLocked(player);
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(RazorToothRelicId);
+        RecordRazorToothUpgradedCardDrawForTest(agg);
     }
 
     /// <summary>
@@ -5787,6 +5852,30 @@ public static class RunTracker
     {
         if (agg == null || currentUpgradeLevel <= previousUpgradeLevel) return;
         agg.CardsUpgraded += 1;
+    }
+
+    internal static void RecordRazorToothCombatForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RazorToothCombats += Math.Max(0, count);
+    }
+
+    internal static void RecordRazorToothTurnForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RazorToothTurns += Math.Max(0, count);
+    }
+
+    internal static void RecordRazorToothUpgradedCardPlayForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RazorToothUpgradedCardPlays += Math.Max(0, count);
+    }
+
+    internal static void RecordRazorToothUpgradedCardDrawForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.RazorToothUpgradedCardDraws += Math.Max(0, count);
     }
 
     internal static void RecordWhetstoneUpgradesForTest(
@@ -8738,6 +8827,18 @@ public static class RunTracker
         }
     }
 
+    private static bool PlayerHasRazorTooth(Player player)
+    {
+        try
+        {
+            return player.Relics.Any(r => r is RazorTooth);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static bool PlayerHasPaperPhrog(Player player)
     {
         try
@@ -8814,6 +8915,7 @@ public static class RunTracker
             RecordBookmarkCombatForPlayerLocked(player);
             RecordPaelsEyeCombatForPlayerLocked(player);
             RecordPaperPhrogCombatForPlayerLocked(player);
+            RecordRazorToothCombatForPlayerLocked(player);
             RecordRegaliteCombatForPlayerLocked(player);
         }
         catch (Exception e)
@@ -8987,6 +9089,50 @@ public static class RunTracker
 
         var agg = GetOrCreatePendingRelicAggregateLocked(PaperPhrogRelicId);
         RecordPaperPhrogTurnForTest(agg);
+    }
+
+    private static void RecordRazorToothCombatForPlayerLocked(Player player)
+    {
+        if (_pendingCombat == null) return;
+        if (!PlayerHasRazorTooth(player)) return;
+        if (!_pendingCombat.RazorToothCombatCountedPlayers.Add(player)) return;
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(RazorToothRelicId);
+        RecordRazorToothCombatForTest(agg);
+    }
+
+    private static void RecordRazorToothTurnForTrackedPlayerLocked()
+    {
+        try
+        {
+            var player = GetTrackedRunPlayerLocked();
+            if (player == null) return;
+            RecordRazorToothTurnForPlayerLocked(player);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"RecordRazorToothTurnForTrackedPlayerLocked failed: {e.Message}");
+        }
+    }
+
+    private static void RecordRazorToothTurnForPlayerLocked(Player player)
+    {
+        if (_pendingCombat == null) return;
+        if (!PlayerHasRazorTooth(player)) return;
+
+        var turnNumber = player.PlayerCombatState?.TurnNumber ?? 0;
+        if (turnNumber <= 0) return;
+        if (_pendingCombat.RazorToothTurnCountedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return;
+        }
+
+        _pendingCombat.RazorToothTurnCountedTurns[player] = turnNumber;
+        RecordRazorToothCombatForPlayerLocked(player);
+
+        var agg = GetOrCreatePendingRelicAggregateLocked(RazorToothRelicId);
+        RecordRazorToothTurnForTest(agg);
     }
 
     private static void RecordRegaliteCombatForPlayerLocked(Player player)
@@ -11366,6 +11512,7 @@ public static class RunTracker
     {
         lock (_lock)
         {
+            RecordRazorToothUpgradedCardDrawnLocked(card);
             if (!ShouldTrackCardStatsDuringCombatLocked()) return;
 
             _pendingCombat ??= new PendingCombat();
@@ -12903,6 +13050,12 @@ internal class PendingCombat
     public HashSet<Player> PaperPhrogCombatCountedPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Player, int> PaperPhrogTurnCountedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public HashSet<Player> RazorToothCombatCountedPlayers { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> RazorToothTurnCountedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public HashSet<CardModel> RazorToothUpgradedCards { get; }
         = new(ReferenceEqualityComparer.Instance);
     public HashSet<Player> RegaliteCombatCountedPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -4506,6 +4506,47 @@ public static class RunTracker
     }
 
     /// <summary>
+    /// Record the observed maximum-HP cost of Brightest Flame after its full
+    /// async OnPlay callback resolves. The game clamps LoseMaxHp at one max HP,
+    /// so the before/after delta is the truth rather than the card's requested
+    /// amount.
+    /// </summary>
+    public static void RecordBrightestFlameMaxHpLost(
+        BrightestFlame card,
+        int previousMaxHp,
+        int currentMaxHp)
+    {
+        if (card == null || currentMaxHp >= previousMaxHp) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedCard(card)) return;
+                if (!ShouldTrackCardStatsDuringCombatLocked()) return;
+
+                _pendingCombat ??= new PendingCombat();
+                var instanceId = GetOrAssignInstanceId(card);
+                var agg = GetOrCreateAggregate(_pendingCombat, instanceId);
+                RecordBrightestFlameMaxHpLostForTest(agg, previousMaxHp, currentMaxHp);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordBrightestFlameMaxHpLost failed: {e.Message}");
+            }
+        }
+    }
+
+    internal static void RecordBrightestFlameMaxHpLostForTest(
+        CardAggregate agg,
+        int previousMaxHp,
+        int currentMaxHp)
+    {
+        if (agg == null || currentMaxHp >= previousMaxHp) return;
+        agg.TotalMaxHpLost += Math.Max(0, previousMaxHp - currentMaxHp);
+    }
+
+    /// <summary>
     /// Record Unleash's Osty-current-HP contribution to its attack payload.
     /// This is card-specific intent metadata captured at the owner callback;
     /// observed damage still flows through DamageReceivedEntry.
@@ -12568,6 +12609,7 @@ public static class RunTracker
         target.TimesExhaustedOtherCards += source.TimesExhaustedOtherCards;
         target.TimesExhausted += source.TimesExhausted;
         target.TotalHpLost += source.TotalHpLost;
+        target.TotalMaxHpLost += source.TotalMaxHpLost;
         target.TimesCardsDrawn += source.TimesCardsDrawn;
         target.TimesCardsDrawAttempted += source.TimesCardsDrawAttempted;
         target.TimesCardsDrawBlocked += source.TimesCardsDrawBlocked;

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -2353,6 +2353,7 @@ public static class RunTracker
     private const string ReptileTrinketRelicId = "RELIC.REPTILE_TRINKET";
     private const string GorgetRelicId = "RELIC.GORGET";
     private const string StoneCrackerRelicId = "RELIC.STONE_CRACKER";
+    private const string RazorToothRelicId = "RELIC.RAZOR_TOOTH";
     private const string WhetstoneRelicId = "RELIC.WHETSTONE";
     private const string WarPaintRelicId = "RELIC.WAR_PAINT";
     private const string FragrantMushroomRelicId = "RELIC.FRAGRANT_MUSHROOM";
@@ -2857,6 +2858,31 @@ public static class RunTracker
             catch (Exception e)
             {
                 CoreMain.LogDebug($"RecordStoneCrackerActivation failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Record one card that Razor Tooth actually upgraded. The relic calls
+    /// <c>CardCmd.Upgrade</c> synchronously from its owner-specific
+    /// <c>AfterCardPlayed</c> callback, so callers pass the observed upgrade
+    /// level before and after that callback rather than inferring success from
+    /// card type or upgrade eligibility.
+    /// </summary>
+    public static void RecordRazorToothUpgrade(int previousUpgradeLevel, int currentUpgradeLevel)
+    {
+        if (currentUpgradeLevel <= previousUpgradeLevel) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateRelicAggregateLocked(RazorToothRelicId);
+                RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel, currentUpgradeLevel);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordRazorToothUpgrade failed: {e.Message}");
             }
         }
     }
@@ -5753,6 +5779,15 @@ public static class RunTracker
         RelicAggregate agg,
         IEnumerable<string>? upgradedCards)
         => RecordRelicUpgradedCards(agg, upgradedCards);
+
+    internal static void RecordRazorToothUpgradeForTest(
+        RelicAggregate agg,
+        int previousUpgradeLevel,
+        int currentUpgradeLevel)
+    {
+        if (agg == null || currentUpgradeLevel <= previousUpgradeLevel) return;
+        agg.CardsUpgraded += 1;
+    }
 
     internal static void RecordWhetstoneUpgradesForTest(
         RelicAggregate agg,

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -152,6 +152,9 @@ New fixtures added going forward do not need a `v*-` prefix.
   Adds Paper Phrog tracking for bonus damage added by its Vulnerable multiplier,
   vulnerable-enhanced attack counts, and held combat/turn denominators for
   average rows.
+- `razor-tooth-relic-run.json`
+  Adds Razor Tooth held combat/turn denominators plus later finished plays and
+  successful draws of the exact combat cards it was observed upgrading.
 - `brilliant-scarf-relic-run.json`
   Adds Brilliant Scarf discount tracking: energy-discount offers, taken
   discounts, energy saved by those taken discounts, held combats, and

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -155,6 +155,10 @@ New fixtures added going forward do not need a `v*-` prefix.
 - `razor-tooth-relic-run.json`
   Adds Razor Tooth held combat/turn denominators plus later finished plays and
   successful draws of the exact combat cards it was observed upgrading.
+- `storybook-relic-run.json`
+  Adds Brightest Flame's observed max-HP-loss card aggregate, which Storybook
+  surfaces through a definition-pooled view with play, draw, energy, and
+  card-draw stats.
 - `brilliant-scarf-relic-run.json`
   Adds Brilliant Scarf discount tracking: energy-discount offers, taken
   discounts, energy saved by those taken discounts, held combats, and

--- a/Fixtures/RunSchema/razor-tooth-relic-run.json
+++ b/Fixtures/RunSchema/razor-tooth-relic-run.json
@@ -1,0 +1,25 @@
+{
+  "run_id": "razor-tooth-relic-fixture",
+  "started_at": "2026-07-10T00:00:00Z",
+  "updated_at": "2026-07-10T00:05:00Z",
+  "character": "NECROBINDER",
+  "ascension": 10,
+  "floor_reached": 8,
+  "outcome": "in_progress",
+  "game_start_time": 1783641600,
+  "aggregates": {},
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.RAZOR_TOOTH": {
+      "cards_upgraded": 6,
+      "razor_tooth_combats": 2,
+      "razor_tooth_turns": 8,
+      "razor_tooth_upgraded_card_plays": 4,
+      "razor_tooth_upgraded_card_draws": 2
+    }
+  },
+  "enemy_aggregates": {},
+  "meta_stats": {},
+  "instance_numbers_by_def": {},
+  "def_counters": {}
+}

--- a/Fixtures/RunSchema/storybook-relic-run.json
+++ b/Fixtures/RunSchema/storybook-relic-run.json
@@ -1,0 +1,36 @@
+{
+  "run_id": "storybook-relic-fixture",
+  "started_at": "2026-07-11T00:00:00Z",
+  "updated_at": "2026-07-11T00:05:00Z",
+  "character": "IRONCLAD",
+  "ascension": 10,
+  "floor_reached": 9,
+  "outcome": "in_progress",
+  "game_start_time": 1783728000,
+  "aggregates": {
+    "CARD.BRIGHTEST_FLAME#1": {
+      "combats_in_deck": 3,
+      "plays": 4,
+      "total_energy_generated": 8,
+      "times_drawn": 6,
+      "total_max_hp_lost": 4,
+      "times_cards_drawn": 8,
+      "floor_added": 5,
+      "initial_upgrade_level": 0
+    }
+  },
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.STORYBOOK": {}
+  },
+  "enemy_aggregates": {},
+  "meta_stats": {},
+  "instance_numbers_by_def": {
+    "CARD.BRIGHTEST_FLAME": [
+      1
+    ]
+  },
+  "def_counters": {
+    "CARD.BRIGHTEST_FLAME": 1
+  }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Per-card attribution stats mod for [Slay the Spire 2](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/). For every card you play, it tracks what actually happened: effective damage vs. overkill, block that absorbed vs. wasted, drawn cards played vs. idle, energy generated vs. unused, and effect-oriented outcomes like poison damage.
 
-**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, Regent star-resource spend/gain tracking, forge granted from cards, blocked-draw attribution, recurring summon-to-hand tracking, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
+**Status:** Dev build - core per-instance card stats are live in-game, including damage/block attribution, observed draw and energy generation, card-caused current/max-HP loss, Regent star-resource spend/gain tracking, forge granted from cards, blocked-draw attribution, recurring summon-to-hand tracking, applied-effect summaries, Artifact-blocked debuffs, removed-card viewing, pooled combat-generated card summaries, and dedicated poison application/damage rows. Not yet published to Nexus (M6).
 
 For codebase orientation, start with [AGENTS.md](AGENTS.md), [docs/architecture.md](docs/architecture.md), and [docs/sts2-runtime-primer.md](docs/sts2-runtime-primer.md).
 
@@ -54,7 +54,7 @@ Available only on in-run deck-view surfaces for now (not Compendium - lifetime a
 | **M5b** | Run History integration - browse past-run stats | [#9](https://github.com/romaine-life/spirelens/issues/9) |
 | **M6** | Publish v0.1 to Nexus | - |
 
-Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, HP-lost from self-damage cards, cards-drawn attribution, blocked-draw attempt/reason tracking, Regent star-resource tracking, forge granted tracking, recurring summon-to-hand tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution including stacked Noxious Fumes contributor preservation.
+Additional shipped: discard count, pile-top placements (from hand / from discard), exhaust-others attribution, self-exhaust count, current/max-HP lost from card costs, cards-drawn attribution, blocked-draw attempt/reason tracking, Regent star-resource tracking, forge granted tracking, recurring summon-to-hand tracking, effect application summaries, Artifact-blocked debuff tracking, and downstream poison damage attribution including stacked Noxious Fumes contributor preservation.
 
 Run outcome detection (win/loss/abandoned) is implemented ([#10](https://github.com/romaine-life/spirelens/issues/10), closed) via the run-history entry hook.
 

--- a/Tests/SpireLens.Core.Tests/BrightestFlameStorybookStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/BrightestFlameStorybookStatsTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models.Cards;
+using MegaCrit.Sts2.Core.Models.Relics;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class BrightestFlameStorybookStatsTests
+{
+    private static readonly MethodInfo TargetMethod =
+        typeof(BrightestFlameOnPlayPatch).GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Brightest Flame TargetMethod not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void Patch_TargetsBrightestFlameOnPlayWithExpectedParameters()
+    {
+        var target = TargetMethod.Invoke(null, null) as MethodBase;
+
+        Assert.NotNull(target);
+        Assert.Equal(typeof(BrightestFlame), target!.DeclaringType);
+        Assert.Equal("OnPlay", target.Name);
+        Assert.Equal(
+            new[] { typeof(PlayerChoiceContext), typeof(CardPlay) },
+            target.GetParameters().Select(parameter => parameter.ParameterType));
+    }
+
+    [Fact]
+    public void CardAggregate_MaxHpLost_JsonRoundtripPreservesValue()
+    {
+        var run = new RunData();
+        run.Aggregates["CARD.BRIGHTEST_FLAME#1"] = new CardAggregate
+        {
+            TotalMaxHpLost = 4,
+        };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.Contains("total_max_hp_lost", json);
+        Assert.NotNull(restored);
+        Assert.Equal(4, restored!.Aggregates["CARD.BRIGHTEST_FLAME#1"].TotalMaxHpLost);
+    }
+
+    [Fact]
+    public void RunTracker_BrightestFlame_CountsOnlyPositiveObservedMaxHpLoss()
+    {
+        var agg = new CardAggregate();
+
+        RunTracker.RecordBrightestFlameMaxHpLostForTest(agg, previousMaxHp: 70, currentMaxHp: 69);
+        RunTracker.RecordBrightestFlameMaxHpLostForTest(agg, previousMaxHp: 69, currentMaxHp: 69);
+        RunTracker.RecordBrightestFlameMaxHpLostForTest(agg, previousMaxHp: 69, currentMaxHp: 70);
+        RunTracker.RecordBrightestFlameMaxHpLostForTest(agg, previousMaxHp: 3, currentMaxHp: 1);
+
+        Assert.Equal(3, agg.TotalMaxHpLost);
+    }
+
+    [Fact]
+    public void CardAggregate_MaxHpLost_MergesAndPools()
+    {
+        var merged = new CardAggregate { TotalMaxHpLost = 2 };
+        RunTracker.MergeAggregateInto(merged, new CardAggregate { TotalMaxHpLost = 3 });
+
+        var pooled = CardAggregatePooler.PoolByDefinition(
+            new[]
+            {
+                new KeyValuePair<string, CardAggregate>(
+                    "CARD.BRIGHTEST_FLAME#1",
+                    new CardAggregate { TotalMaxHpLost = 4 }),
+                new KeyValuePair<string, CardAggregate>(
+                    "CARD.BRIGHTEST_FLAME#2",
+                    new CardAggregate { TotalMaxHpLost = 1 }),
+            },
+            "CARD.BRIGHTEST_FLAME");
+
+        Assert.Equal(5, merged.TotalMaxHpLost);
+        Assert.NotNull(pooled);
+        Assert.Equal(5, pooled!.TotalMaxHpLost);
+    }
+
+    [Fact]
+    public void CardTooltip_BrightestFlame_ShowsMaxHpLostInFullAndCompactViews()
+    {
+        var card = new BrightestFlame();
+        var agg = new CardAggregate { TotalMaxHpLost = 4 };
+
+        var full = CardHoverShowPatch.BuildHistoricalBodyBBCode(card, agg, new RunMetaStats());
+        var compact = CardHoverShowPatch.BuildHistoricalBodyBBCode(
+            card,
+            agg,
+            new RunMetaStats(),
+            compact: true);
+
+        Assert.Contains("Max HP lost", full);
+        Assert.Contains("[b]4[/b]", full);
+        Assert.Contains("Max HP lost", compact);
+        Assert.Contains("[b]4[/b]", compact);
+    }
+
+    [Fact]
+    public void RelicTooltip_Storybook_ShowsPooledBrightestFlameStats()
+    {
+        var storybook = (Storybook)RuntimeHelpers.GetUninitializedObject(typeof(Storybook));
+        var brightestFlameAgg = new CardAggregate
+        {
+            Plays = 4,
+            TimesDrawn = 6,
+            TotalEnergyGenerated = 8,
+            TimesCardsDrawn = 8,
+            TotalMaxHpLost = 4,
+        };
+
+        var recognized = RelicHoverShowPatch.TryBuildBodyBBCode(
+            storybook,
+            new RelicAggregate(),
+            floorCount: null,
+            bloodSoakedRoseCurseAgg: null,
+            cursedPearlCurseAgg: null,
+            neowsBonesCurseAggs: null,
+            storybookBrightestFlameAgg: brightestFlameAgg,
+            out var title,
+            out var body);
+
+        Assert.True(recognized);
+        Assert.Equal("Storybook", title);
+        Assert.Contains("Brightest Flame played", body);
+        Assert.Contains("Brightest Flame drawn", body);
+        Assert.Contains("gained by Flame", body);
+        Assert.Contains("Cards drawn by Flame", body);
+        Assert.Contains("Max HP lost to Flame", body);
+        Assert.Contains("[b]4[/b]", body);
+        Assert.Contains("[b]6[/b]", body);
+        Assert.Contains("[b]8[/b]", body);
+    }
+}

--- a/Tests/SpireLens.Core.Tests/CompendiumRelicStatsContextTests.cs
+++ b/Tests/SpireLens.Core.Tests/CompendiumRelicStatsContextTests.cs
@@ -1,0 +1,48 @@
+using System.Runtime.CompilerServices;
+using MegaCrit.Sts2.Core.Entities.UI;
+using MegaCrit.Sts2.Core.Models.Relics;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class CompendiumRelicStatsContextTests
+{
+    [Fact]
+    public void ShouldShowStatsForVisibility_OnlyShowsVisibleRelics()
+    {
+        Assert.True(CompendiumRelicStatsContext.ShouldShowStatsForVisibility(ModelVisibility.Visible));
+        Assert.False(CompendiumRelicStatsContext.ShouldShowStatsForVisibility(ModelVisibility.None));
+        Assert.False(CompendiumRelicStatsContext.ShouldShowStatsForVisibility(ModelVisibility.NotSeen));
+        Assert.False(CompendiumRelicStatsContext.ShouldShowStatsForVisibility(ModelVisibility.Locked));
+    }
+
+    [Fact]
+    public void TryBuildRelicTooltipForRun_UsesSavedRunAggregate()
+    {
+        var run = new RunData { FloorReached = 5 };
+        run.RelicAggregates["RELIC.ANCHOR"] = new RelicAggregate
+        {
+            Activations = 1,
+            AdditionalBlockGained = 10,
+        };
+
+        var ok = CompendiumRelicStatsContext.TryBuildRelicTooltipForRun(
+            Uninitialized<FakeAnchor>(),
+            run,
+            out var title,
+            out var body);
+
+        Assert.True(ok);
+        Assert.Equal("???", title);
+        Assert.Contains("Activations", body);
+        Assert.Contains("[b]1[/b]", body);
+        Assert.Contains("block gained", body);
+        Assert.Contains("[b]10[/b]", body);
+    }
+
+    private static T Uninitialized<T>() where T : class
+    {
+        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+    }
+}

--- a/Tests/SpireLens.Core.Tests/CompendiumRelicStatsContextTests.cs
+++ b/Tests/SpireLens.Core.Tests/CompendiumRelicStatsContextTests.cs
@@ -41,6 +41,37 @@ public class CompendiumRelicStatsContextTests
         Assert.Contains("[b]10[/b]", body);
     }
 
+    [Fact]
+    public void TryBuildRelicTooltipForRun_StorybookUsesSavedBrightestFlameAggregate()
+    {
+        var run = new RunData { FloorReached = 9 };
+        run.Aggregates["CARD.BRIGHTEST_FLAME#1"] = new CardAggregate
+        {
+            Plays = 4,
+            TimesDrawn = 6,
+            TotalEnergyGenerated = 8,
+            TimesCardsDrawn = 8,
+            TotalMaxHpLost = 4,
+        };
+
+        var ok = CompendiumRelicStatsContext.TryBuildRelicTooltipForRun(
+            Uninitialized<Storybook>(),
+            run,
+            out var title,
+            out var body);
+
+        Assert.True(ok);
+        Assert.Equal("Storybook", title);
+        Assert.Contains("Brightest Flame played", body);
+        Assert.Contains("Brightest Flame drawn", body);
+        Assert.Contains("gained by Flame", body);
+        Assert.Contains("Cards drawn by Flame", body);
+        Assert.Contains("Max HP lost to Flame", body);
+        Assert.Contains("[b]4[/b]", body);
+        Assert.Contains("[b]6[/b]", body);
+        Assert.Contains("[b]8[/b]", body);
+    }
+
     private static T Uninitialized<T>() where T : class
     {
         return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));

--- a/Tests/SpireLens.Core.Tests/RazorToothStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/RazorToothStatsTests.cs
@@ -45,17 +45,33 @@ public class RazorToothStatsTests
     }
 
     [Fact]
-    public void RelicAggregate_RazorToothCardsUpgraded_JsonRoundtripPreservesCount()
+    public void RelicAggregate_RazorToothFields_JsonRoundtripPreservesValues()
     {
         var run = new RunData();
-        run.RelicAggregates[RazorToothRelicId] = new RelicAggregate { CardsUpgraded = 7 };
+        run.RelicAggregates[RazorToothRelicId] = new RelicAggregate
+        {
+            CardsUpgraded = 7,
+            RazorToothCombats = 3,
+            RazorToothTurns = 4,
+            RazorToothUpgradedCardPlays = 5,
+            RazorToothUpgradedCardDraws = 2,
+        };
 
         var json = JsonSerializer.Serialize(run, SerializerOptions);
         var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
 
         Assert.Contains("cards_upgraded", json);
+        Assert.Contains("razor_tooth_combats", json);
+        Assert.Contains("razor_tooth_turns", json);
+        Assert.Contains("razor_tooth_upgraded_card_plays", json);
+        Assert.Contains("razor_tooth_upgraded_card_draws", json);
         Assert.NotNull(restored);
-        Assert.Equal(7, restored!.RelicAggregates[RazorToothRelicId].CardsUpgraded);
+        var agg = restored!.RelicAggregates[RazorToothRelicId];
+        Assert.Equal(7, agg.CardsUpgraded);
+        Assert.Equal(3, agg.RazorToothCombats);
+        Assert.Equal(4, agg.RazorToothTurns);
+        Assert.Equal(5, agg.RazorToothUpgradedCardPlays);
+        Assert.Equal(2, agg.RazorToothUpgradedCardDraws);
     }
 
     [Fact]
@@ -73,12 +89,80 @@ public class RazorToothStatsTests
     }
 
     [Fact]
+    public void RunTracker_RazorToothTestHelpers_RecordDenominatorsAndFollowupEvents()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordRazorToothCombatForTest(agg, 3);
+        RunTracker.RecordRazorToothTurnForTest(agg, 8);
+        RunTracker.RecordRazorToothUpgradedCardPlayForTest(agg, 4);
+        RunTracker.RecordRazorToothUpgradedCardDrawForTest(agg, 2);
+
+        Assert.Equal(3, agg.RazorToothCombats);
+        Assert.Equal(8, agg.RazorToothTurns);
+        Assert.Equal(4, agg.RazorToothUpgradedCardPlays);
+        Assert.Equal(2, agg.RazorToothUpgradedCardDraws);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_RazorToothFields_Accumulates()
+    {
+        var target = new RelicAggregate
+        {
+            CardsUpgraded = 1,
+            RazorToothCombats = 1,
+            RazorToothTurns = 2,
+            RazorToothUpgradedCardPlays = 3,
+            RazorToothUpgradedCardDraws = 4,
+        };
+        var source = new RelicAggregate
+        {
+            CardsUpgraded = 5,
+            RazorToothCombats = 2,
+            RazorToothTurns = 6,
+            RazorToothUpgradedCardPlays = 1,
+            RazorToothUpgradedCardDraws = 2,
+        };
+
+        RunTracker.MergeRelicAggregateInto(target, source);
+
+        Assert.Equal(6, target.CardsUpgraded);
+        Assert.Equal(3, target.RazorToothCombats);
+        Assert.Equal(8, target.RazorToothTurns);
+        Assert.Equal(4, target.RazorToothUpgradedCardPlays);
+        Assert.Equal(6, target.RazorToothUpgradedCardDraws);
+    }
+
+    [Fact]
     public void RelicTooltip_RazorTooth_ShowsCardsUpgraded()
     {
-        var body = BuildBody(new RelicAggregate { CardsUpgraded = 4 });
+        var body = BuildBody(new RelicAggregate
+        {
+            CardsUpgraded = 7,
+            RazorToothCombats = 3,
+            RazorToothTurns = 4,
+            RazorToothUpgradedCardPlays = 5,
+            RazorToothUpgradedCardDraws = 2,
+        });
 
         Assert.Contains("Cards upgraded", body);
-        Assert.Contains("[b]4[/b]", body);
+        Assert.Contains("[b]7[/b]", body);
+        Assert.Contains("Avg cards upgraded/turn", body);
+        Assert.Contains("[b]1.75[/b]", body);
+        Assert.Contains("Avg cards upgraded/combat", body);
+        Assert.Contains("[b]2.33[/b]", body);
+        Assert.Contains("Upgraded-card plays", body);
+        Assert.Contains("[b]5[/b]", body);
+        Assert.Contains("Avg upgraded plays/turn", body);
+        Assert.Contains("[b]1.25[/b]", body);
+        Assert.Contains("Avg upgraded plays/combat", body);
+        Assert.Contains("[b]1.67[/b]", body);
+        Assert.Contains("Upgraded-card draws", body);
+        Assert.Contains("[b]2[/b]", body);
+        Assert.Contains("Avg upgraded draws/turn", body);
+        Assert.Contains("[b]0.5[/b]", body);
+        Assert.Contains("Avg upgraded draws/combat", body);
+        Assert.Contains("[b]0.67[/b]", body);
     }
 
     [Fact]
@@ -105,6 +189,14 @@ public class RazorToothStatsTests
         var body = BuildBody(new RelicAggregate());
 
         Assert.Contains("Cards upgraded", body);
+        Assert.Contains("Avg cards upgraded/turn", body);
+        Assert.Contains("Avg cards upgraded/combat", body);
+        Assert.Contains("Upgraded-card plays", body);
+        Assert.Contains("Avg upgraded plays/turn", body);
+        Assert.Contains("Avg upgraded plays/combat", body);
+        Assert.Contains("Upgraded-card draws", body);
+        Assert.Contains("Avg upgraded draws/turn", body);
+        Assert.Contains("Avg upgraded draws/combat", body);
         Assert.Contains("[b]0[/b]", body);
     }
 

--- a/Tests/SpireLens.Core.Tests/RazorToothStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/RazorToothStatsTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models.Relics;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class RazorToothStatsTests
+{
+    private const string RazorToothRelicId = "RELIC.RAZOR_TOOTH";
+
+    private static readonly MethodInfo BuildRazorToothBodyMethod =
+        typeof(RelicHoverShowPatch).GetMethod("BuildRazorToothBodyBBCode", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRazorToothBodyBBCode not found.");
+
+    private static readonly MethodInfo TargetMethod =
+        typeof(RazorToothAfterCardPlayedPatch).GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Razor Tooth TargetMethod not found.");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void Patch_TargetsRazorToothAfterCardPlayedWithExpectedParameters()
+    {
+        var target = TargetMethod.Invoke(null, null) as MethodBase;
+
+        Assert.NotNull(target);
+        Assert.Equal(typeof(RazorTooth), target!.DeclaringType);
+        Assert.Equal(nameof(RazorTooth.AfterCardPlayed), target.Name);
+        Assert.Equal(
+            new[] { typeof(PlayerChoiceContext), typeof(CardPlay) },
+            target.GetParameters().Select(parameter => parameter.ParameterType));
+    }
+
+    [Fact]
+    public void RelicAggregate_RazorToothCardsUpgraded_JsonRoundtripPreservesCount()
+    {
+        var run = new RunData();
+        run.RelicAggregates[RazorToothRelicId] = new RelicAggregate { CardsUpgraded = 7 };
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.Contains("cards_upgraded", json);
+        Assert.NotNull(restored);
+        Assert.Equal(7, restored!.RelicAggregates[RazorToothRelicId].CardsUpgraded);
+    }
+
+    [Fact]
+    public void RunTracker_RazorTooth_CountsOnlyPositiveObservedUpgradeDeltas()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel: 0, currentUpgradeLevel: 1);
+        RunTracker.RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel: 1, currentUpgradeLevel: 1);
+        RunTracker.RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel: 2, currentUpgradeLevel: 1);
+        RunTracker.RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel: 1, currentUpgradeLevel: 2);
+        RunTracker.RecordRazorToothUpgradeForTest(agg, previousUpgradeLevel: 0, currentUpgradeLevel: 2);
+
+        Assert.Equal(3, agg.CardsUpgraded);
+    }
+
+    [Fact]
+    public void RelicTooltip_RazorTooth_ShowsCardsUpgraded()
+    {
+        var body = BuildBody(new RelicAggregate { CardsUpgraded = 4 });
+
+        Assert.Contains("Cards upgraded", body);
+        Assert.Contains("[b]4[/b]", body);
+    }
+
+    [Fact]
+    public void RelicTooltip_RazorTooth_DispatchesForRazorToothModel()
+    {
+        var relic = (RazorTooth)RuntimeHelpers.GetUninitializedObject(typeof(RazorTooth));
+
+        var recognized = RelicHoverShowPatch.TryBuildBodyBBCode(
+            relic,
+            new RelicAggregate { CardsUpgraded = 4 },
+            floorCount: null,
+            out var title,
+            out var body);
+
+        Assert.True(recognized);
+        Assert.Equal("Razor Tooth", title);
+        Assert.Contains("Cards upgraded", body);
+        Assert.Contains("[b]4[/b]", body);
+    }
+
+    [Fact]
+    public void RelicTooltip_RazorTooth_ShowsZeroBeforeAnyUpgrade()
+    {
+        var body = BuildBody(new RelicAggregate());
+
+        Assert.Contains("Cards upgraded", body);
+        Assert.Contains("[b]0[/b]", body);
+    }
+
+    private static string BuildBody(RelicAggregate agg)
+        => (string)(BuildRazorToothBodyMethod.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException("BuildRazorToothBodyBBCode returned null."));
+}

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class RelicCompendiumFilterTests
+{
+    [Fact]
+    public void EnergyTaxonomy_IncludesTrackedEnergyRelics()
+    {
+        var energy = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.EnergyCategoryId);
+
+        Assert.Contains("RELIC.HAPPY_FLOWER", energy.RelicIds);
+        Assert.Contains("RELIC.NUNCHAKU", energy.RelicIds);
+        Assert.Contains("RELIC.BOOMING_CONCH", energy.RelicIds);
+        Assert.Contains("RELIC.PRISMATIC_GEM", energy.RelicIds);
+        Assert.Contains("RELIC.BRILLIANT_SCARF", energy.RelicIds);
+    }
+
+    [Fact]
+    public void IsRelicInAnySelectedCategory_UsesSelectedCategories()
+    {
+        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.LANTERN",
+            new[] { RelicTaxonomy.EnergyCategoryId }));
+
+        Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.ANCHOR",
+            new[] { RelicTaxonomy.EnergyCategoryId }));
+
+        Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.LANTERN",
+            Enumerable.Empty<string>()));
+    }
+
+    [Fact]
+    public void GetVisualAction_MapsModeAndMatchToVisualAction()
+    {
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Normal,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Off, true, false));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Normal,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, true, true));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Dim,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, true, false));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Normal,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, true, true));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Hidden,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, true, false));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Normal,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, false, false));
+    }
+}

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -79,21 +79,33 @@ public class RelicCompendiumFilterTests
     {
         Assert.Equal(
             CompendiumRelicEntryVisualAction.Normal,
-            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Off, true, false));
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Off, true, true, false));
         Assert.Equal(
             CompendiumRelicEntryVisualAction.Normal,
-            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, true, true));
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Off, false, false, false));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Normal,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, true, true, true));
         Assert.Equal(
             CompendiumRelicEntryVisualAction.Dim,
-            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, true, false));
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, true, true, false));
         Assert.Equal(
             CompendiumRelicEntryVisualAction.Normal,
-            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, true, true));
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, false, true, false));
         Assert.Equal(
             CompendiumRelicEntryVisualAction.Hidden,
-            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, true, false));
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Compare, false, false, false));
         Assert.Equal(
             CompendiumRelicEntryVisualAction.Normal,
-            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, false, false));
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, true, true, true));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Hidden,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, true, true, false));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Normal,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, false, true, false));
+        Assert.Equal(
+            CompendiumRelicEntryVisualAction.Hidden,
+            RelicCompendiumFilterContext.GetVisualAction(CompendiumRelicFilterMode.Filter, false, false, false));
     }
 }

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -19,6 +19,19 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
+    public void ChargeTaxonomy_IncludesIncrementingRelics()
+    {
+        var charge = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.ChargeCategoryId);
+
+        Assert.Contains("RELIC.PEN_NIB", charge.RelicIds);
+        Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
+        Assert.Contains("RELIC.NUNCHAKU", charge.RelicIds);
+        Assert.Contains("RELIC.IRON_CLUB", charge.RelicIds);
+        Assert.Contains("RELIC.HAPPY_FLOWER", charge.RelicIds);
+        Assert.Contains("RELIC.WINGED_BOOTS", charge.RelicIds);
+    }
+
+    [Fact]
     public void IsRelicInAnySelectedCategory_UsesSelectedCategories()
     {
         Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
@@ -32,6 +45,14 @@ public class RelicCompendiumFilterTests
         Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.LANTERN",
             Enumerable.Empty<string>()));
+
+        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.PEN_NIB",
+            new[] { RelicTaxonomy.ChargeCategoryId }));
+
+        Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.PEN_NIB",
+            new[] { RelicTaxonomy.EnergyCategoryId }));
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -19,16 +19,31 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
-    public void ChargeTaxonomy_IncludesIncrementingRelics()
+    public void ChargeAcrossTurnsTaxonomy_IncludesPersistentIncrementingRelics()
     {
-        var charge = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.ChargeCategoryId);
+        var charge = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.ChargeAcrossTurnsCategoryId);
 
         Assert.Contains("RELIC.PEN_NIB", charge.RelicIds);
-        Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
         Assert.Contains("RELIC.NUNCHAKU", charge.RelicIds);
         Assert.Contains("RELIC.IRON_CLUB", charge.RelicIds);
         Assert.Contains("RELIC.HAPPY_FLOWER", charge.RelicIds);
         Assert.Contains("RELIC.WINGED_BOOTS", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.LETTER_OPENER", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.VELVET_CHOKER", charge.RelicIds);
+    }
+
+    [Fact]
+    public void ChargeResetsEachTurnTaxonomy_IncludesTurnLocalIncrementingRelics()
+    {
+        var charge = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.ChargeResetsEachTurnCategoryId);
+
+        Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
+        Assert.Contains("RELIC.KUNAI", charge.RelicIds);
+        Assert.Contains("RELIC.SHURIKEN", charge.RelicIds);
+        Assert.Contains("RELIC.BRILLIANT_SCARF", charge.RelicIds);
+        Assert.Contains("RELIC.VELVET_CHOKER", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.PEN_NIB", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.NUNCHAKU", charge.RelicIds);
     }
 
     [Fact]
@@ -48,11 +63,15 @@ public class RelicCompendiumFilterTests
 
         Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.PEN_NIB",
-            new[] { RelicTaxonomy.ChargeCategoryId }));
+            new[] { RelicTaxonomy.ChargeAcrossTurnsCategoryId }));
+
+        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.LETTER_OPENER",
+            new[] { RelicTaxonomy.ChargeResetsEachTurnCategoryId }));
 
         Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.PEN_NIB",
-            new[] { RelicTaxonomy.EnergyCategoryId }));
+            new[] { RelicTaxonomy.ChargeResetsEachTurnCategoryId }));
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2370,6 +2370,39 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsStorybookRelicFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("storybook-relic-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        Assert.True(loaded.Data.RelicAggregates.ContainsKey("RELIC.STORYBOOK"));
+        var cardAgg = loaded.Data.Aggregates["CARD.BRIGHTEST_FLAME#1"];
+        Assert.Equal(4, cardAgg.Plays);
+        Assert.Equal(6, cardAgg.TimesDrawn);
+        Assert.Equal(8, cardAgg.TotalEnergyGenerated);
+        Assert.Equal(8, cardAgg.TimesCardsDrawn);
+        Assert.Equal(4, cardAgg.TotalMaxHpLost);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsStorybookRelicFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("storybook-relic-run.json"));
+
+        Assert.NotNull(resumed);
+        Assert.True(resumed!.RelicAggregates.ContainsKey("RELIC.STORYBOOK"));
+        var cardAgg = resumed.Aggregates["CARD.BRIGHTEST_FLAME#1"];
+        Assert.Equal(4, cardAgg.Plays);
+        Assert.Equal(6, cardAgg.TimesDrawn);
+        Assert.Equal(8, cardAgg.TotalEnergyGenerated);
+        Assert.Equal(8, cardAgg.TimesCardsDrawn);
+        Assert.Equal(4, cardAgg.TotalMaxHpLost);
+        Assert.Equal(new[] { 1 }, resumed.InstanceNumbersByDef["CARD.BRIGHTEST_FLAME"]);
+        Assert.Equal(1, resumed.DefCounters["CARD.BRIGHTEST_FLAME"]);
+    }
+
+    [Fact]
     public void HistoricalLoad_AcceptsBookmarkRelicFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("bookmark-relic-run.json"));

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2341,6 +2341,35 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsRazorToothRelicFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("razor-tooth-relic-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+        var relicAgg = loaded.Data.RelicAggregates["RELIC.RAZOR_TOOTH"];
+        Assert.Equal(6, relicAgg.CardsUpgraded);
+        Assert.Equal(2, relicAgg.RazorToothCombats);
+        Assert.Equal(8, relicAgg.RazorToothTurns);
+        Assert.Equal(4, relicAgg.RazorToothUpgradedCardPlays);
+        Assert.Equal(2, relicAgg.RazorToothUpgradedCardDraws);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsRazorToothRelicFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("razor-tooth-relic-run.json"));
+
+        Assert.NotNull(resumed);
+        var relicAgg = resumed!.RelicAggregates["RELIC.RAZOR_TOOTH"];
+        Assert.Equal(6, relicAgg.CardsUpgraded);
+        Assert.Equal(2, relicAgg.RazorToothCombats);
+        Assert.Equal(8, relicAgg.RazorToothTurns);
+        Assert.Equal(4, relicAgg.RazorToothUpgradedCardPlays);
+        Assert.Equal(2, relicAgg.RazorToothUpgradedCardDraws);
+    }
+
+    [Fact]
     public void HistoricalLoad_AcceptsBookmarkRelicFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("bookmark-relic-run.json"));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,7 @@ Examples already implemented:
 - direct attack damage, blocked damage, overkill, kills
 - block gained / effective / wasted
 - actual energy generated
+- actual maximum HP lost to card costs
 - Regent stars spent / generated
 - forge granted from cards
 - observed cards drawn from draw effects

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,8 @@ This combat-boundary rule is important:
 
 - [Core/RunData.cs](../Core/RunData.cs) defines the serialized run shape.
 - [Core/RunStorage.cs](../Core/RunStorage.cs) handles load/save and resumability rules.
-- Schema changes are additive when possible. The current schema fixture is `v23`.
+- Schema changes are additive when possible. The fixture catalog retains
+  historical numbered shapes and adds unversioned per-feature shapes.
 
 Historical compatibility is pinned by:
 

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -410,7 +410,13 @@ effect, and `CardCmd.Upgrade` only adds the game's run-history upgrade record fo
 cards in the permanent Deck pile. Snapshot the played card's
 `CurrentUpgradeLevel` before and after Razor Tooth's callback and count only a
 positive observed delta; `CardCmd.Upgrade` can still no-op while combat is
-ending.
+ending. Keep successfully upgraded cards in a combat-local, raw-reference set:
+the same combat `CardModel` survives pile moves and later replay/draw events,
+while canonicalizing would risk giving a distinct generated or copied card the
+same credit. `CardPlayFinished` occurs before Razor Tooth's callback, so the
+triggering play is not an upgraded-card play; later finished replay iterations
+are. Count later successful draws only from `Hook.AfterCardDrawn`, and use held
+player turns/combats (including zero-result ones) as rate denominators.
 
 Brilliant Scarf increments its per-turn card counter from `AfterCardPlayed`,
 after `CardPlayFinished` has already entered combat history. Its actual cost

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -211,6 +211,24 @@ Known trap — combat-ending killing blows: `DamageReceivedEntry` is NOT complet
 
 Player self-damage is tracked as HP lost from playing a card and uses observed unblocked damage after reductions. That is the real cost, not the text value.
 
+Maximum-HP costs are a separate signal from current-HP damage. Brightest
+Flame's owner-specific `OnPlay` gains energy, draws, and then awaits
+`CreatureCmd.LoseMaxHp`. That command records the requested amount in the
+game's map history but clamps the resulting max HP to at least one; it can also
+deal current-HP damage with no card source when current HP is above the new
+maximum. Wrap Brightest Flame's returned `OnPlay` task and compare the owner's
+max HP before and after the callback so SpireLens records only the actual max
+HP removed, including a zero delta at the one-max-HP floor. Keep this in the
+card aggregate, separate from `TotalHpLost`.
+
+Storybook grants a permanent-deck Brightest Flame but does not retain a
+reference to that exact granted card. Its tooltip therefore uses the explicit
+pooled-by-definition model: combine every `CARD.BRIGHTEST_FLAME` aggregate,
+including pending combat data in live views, and show the card's play, draw,
+energy, card-draw, and max-HP-loss stats. Brightest Flame can also come from
+the event card pool, so this is deliberately a family-wide projection rather
+than exact Storybook-grant lineage.
+
 ## Osty Body Attribution
 
 Necrobinder has both investment cards that create or maintain Osty and payoff

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -403,6 +403,15 @@ to confirm the eligibility rule. Base Strikes are `IsBasicStrikeOrDefend` cards
 that also carry the Strike tag, while non-base Strike cards are every other
 permanent deck card with that tag.
 
+Razor Tooth upgrades eligible Attack and Skill cards synchronously inside its
+owner-specific `AfterCardPlayed` callback, after the finished card-play history
+entry has already been emitted. Combat history has no upgrade entry for this
+effect, and `CardCmd.Upgrade` only adds the game's run-history upgrade record for
+cards in the permanent Deck pile. Snapshot the played card's
+`CurrentUpgradeLevel` before and after Razor Tooth's callback and count only a
+positive observed delta; `CardCmd.Upgrade` can still no-op while combat is
+ending.
+
 Brilliant Scarf increments its per-turn card counter from `AfterCardPlayed`,
 after `CardPlayFinished` has already entered combat history. Its actual cost
 discounts happen through `TryModifyEnergyCostInCombatLate` and `TryModifyStarCost`


### PR DESCRIPTION
## Summary
- restore and consolidate the complete relic Compendium stats/filtering work
- include Razor Tooth upgrade usage stats and Brightest Flame/Storybook stats
- bridge saved-run Storybook stats into Compendium tooltips
- retain the repository's user-owned testing policy

## Build
- `dotnet build Core/SpireLens.Core.csproj -c Debug -p:SkipModsDeploy=true` (0 errors; 10 existing nullable warnings)

Tests and gameplay verification were not run per the repository's user-owned verification policy.