### PR TITLE
Refine relic charge categories and complete missing stats

### DIFF
--- a/Core/Patches/CanonicalPowerHoverTipsPatch.cs
+++ b/Core/Patches/CanonicalPowerHoverTipsPatch.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.HoverTips;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Exceptions;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Preserves the game's power hover tips when a later mod postfix tries to
+/// read mutable-only state from a canonical power model. BaseLib 3.3.3 does
+/// this while expanding dynamic-var tips, which breaks callers such as
+/// Gorget's Plating hover tip after the game has already built a valid result.
+/// </summary>
+[HarmonyPatch(typeof(PowerModel), nameof(PowerModel.HoverTips), MethodType.Getter)]
+public static class CanonicalPowerHoverTipsPatch
+{
+    [HarmonyFinalizer]
+    public static Exception? Finalizer(
+        PowerModel __instance,
+        IEnumerable<IHoverTip>? __result,
+        Exception? __exception)
+    {
+        if (__exception is CanonicalModelException
+            && !__instance.IsMutable
+            && __result != null)
+        {
+            CoreMain.LogDebug(
+                $"CanonicalPowerHoverTipsPatch preserved {__instance.GetType().Name} hover tips");
+            return null;
+        }
+
+        return __exception;
+    }
+}

--- a/Core/Patches/PaelsWingSacrificeStatsPatch.cs
+++ b/Core/Patches/PaelsWingSacrificeStatsPatch.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.CardRewardAlternatives;
 using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Relics;
 using MegaCrit.Sts2.Core.Rewards;
 
@@ -45,8 +46,24 @@ public static class PaelsWingTryModifyCardRewardAlternativesPatch
 
             async Task WrappedOnSelect()
             {
+                var owner = __instance.Owner;
+
+                void OnRelicObtained(RelicModel relic)
+                {
+                    owner.RelicObtained -= OnRelicObtained;
+                    RunTracker.RecordPaelsWingArtifactGained(relic);
+                }
+
                 RunTracker.RecordPaelSacrificeMade(cardReward);
-                await original();
+                owner.RelicObtained += OnRelicObtained;
+                try
+                {
+                    await original();
+                }
+                finally
+                {
+                    owner.RelicObtained -= OnRelicObtained;
+                }
             }
 
             OnSelectBackingField.SetValue(sacrifice, (Func<Task>)WrappedOnSelect);

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -109,7 +109,7 @@ internal static class RelicCompendiumFilterUi
     private const string PanelName = "SpireLensRelicFilterPanel";
     private const string FlatGridName = "SpireLensFlatRelicGrid";
     private const int CategoryTreeColumn = 0;
-    private const int MaxVisibleCategoryTreeRows = 6;
+    private const int MaxVisibleCategoryTreeRows = 8;
     private const float CategoryTreeRowHeight = 24f;
     private const float CategoryTreeVerticalPadding = 8f;
     private const float DimmedAlpha = 0.5f;

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -109,6 +109,9 @@ internal static class RelicCompendiumFilterUi
     private const string PanelName = "SpireLensRelicFilterPanel";
     private const string FlatGridName = "SpireLensFlatRelicGrid";
     private const int CategoryTreeColumn = 0;
+    private const int MaxVisibleCategoryTreeRows = 6;
+    private const float CategoryTreeRowHeight = 24f;
+    private const float CategoryTreeVerticalPadding = 8f;
     private const float DimmedAlpha = 0.5f;
     private const int FallbackFlatGridColumns = 8;
     private static readonly string[] CategoryFieldNames =
@@ -347,7 +350,11 @@ internal static class RelicCompendiumFilterUi
             ScrollVerticalEnabled = true,
             MouseFilter = Control.MouseFilterEnum.Stop,
             SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
-            CustomMinimumSize = new Vector2(0f, 92f),
+            CustomMinimumSize = new Vector2(
+                0f,
+                Math.Min(RelicTaxonomy.Categories.Count, MaxVisibleCategoryTreeRows)
+                * CategoryTreeRowHeight
+                + CategoryTreeVerticalPadding),
         };
         categoryTree.AddThemeFontSizeOverride("font_size", 14);
 

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -143,9 +143,13 @@ internal static class RelicCompendiumFilterUi
     private static readonly HashSet<string> SelectedCategoryIds =
         new(RelicTaxonomy.LeafCategories.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
 
-    private static CompendiumRelicFilterMode _mode = CompendiumRelicFilterMode.Off;
-    private static bool _showUndiscoveredRelics = true;
-    private static bool _useSingleRelicGrid;
+    private const CompendiumRelicFilterMode DefaultMode = CompendiumRelicFilterMode.Filter;
+    private const bool DefaultShowUndiscoveredRelics = false;
+    private const bool DefaultUseSingleRelicGrid = true;
+
+    private static CompendiumRelicFilterMode _mode = DefaultMode;
+    private static bool _showUndiscoveredRelics = DefaultShowUndiscoveredRelics;
+    private static bool _useSingleRelicGrid = DefaultUseSingleRelicGrid;
     private static bool _syncingControls;
 
     public static void Inject(NRelicCollection? collection)
@@ -246,9 +250,9 @@ internal static class RelicCompendiumFilterUi
 
     internal static void ResetForTests()
     {
-        _mode = CompendiumRelicFilterMode.Off;
-        _showUndiscoveredRelics = true;
-        _useSingleRelicGrid = false;
+        _mode = DefaultMode;
+        _showUndiscoveredRelics = DefaultShowUndiscoveredRelics;
+        _useSingleRelicGrid = DefaultUseSingleRelicGrid;
         SelectedCategoryIds.Clear();
         foreach (var category in RelicTaxonomy.LeafCategories)
             SelectedCategoryIds.Add(category.Id);

--- a/Core/Patches/RelicCompendiumFilterPatch.cs
+++ b/Core/Patches/RelicCompendiumFilterPatch.cs
@@ -108,6 +108,7 @@ internal static class RelicCompendiumFilterUi
 {
     private const string PanelName = "SpireLensRelicFilterPanel";
     private const string FlatGridName = "SpireLensFlatRelicGrid";
+    private const int CategoryTreeColumn = 0;
     private const float DimmedAlpha = 0.5f;
     private const int FallbackFlatGridColumns = 8;
     private static readonly string[] CategoryFieldNames =
@@ -137,7 +138,7 @@ internal static class RelicCompendiumFilterUi
     private static readonly List<EntryOriginalVisual> EntryOriginals = new();
     private static readonly List<FlatCollectionLayout> FlatLayouts = new();
     private static readonly HashSet<string> SelectedCategoryIds =
-        new(RelicTaxonomy.Categories.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
+        new(RelicTaxonomy.LeafCategories.Select(c => c.Id), StringComparer.OrdinalIgnoreCase);
 
     private static CompendiumRelicFilterMode _mode = CompendiumRelicFilterMode.Off;
     private static bool _showUndiscoveredRelics = true;
@@ -246,7 +247,7 @@ internal static class RelicCompendiumFilterUi
         _showUndiscoveredRelics = true;
         _useSingleRelicGrid = false;
         SelectedCategoryIds.Clear();
-        foreach (var category in RelicTaxonomy.Categories)
+        foreach (var category in RelicTaxonomy.LeafCategories)
             SelectedCategoryIds.Add(category.Id);
     }
 
@@ -336,23 +337,29 @@ internal static class RelicCompendiumFilterUi
         var categoriesLabel = NewLabel("SpireLens categories", 13, new Color(0.78f, 0.73f, 0.64f, 1f));
         vbox.AddChild(categoriesLabel);
 
-        var checkboxByCategory = new Dictionary<string, CheckBox>(StringComparer.OrdinalIgnoreCase);
-        foreach (var category in RelicTaxonomy.Categories)
+        var categoryTree = new Tree
         {
-            var checkbox = new CheckBox
-            {
-                Name = $"Category_{category.Id}",
-                Text = category.DisplayName,
-                MouseFilter = Control.MouseFilterEnum.Stop,
-                SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
-            };
-            checkbox.AddThemeFontSizeOverride("font_size", 14);
-            checkbox.Connect(
-                BaseButton.SignalName.Toggled,
-                Callable.From<bool>(pressed => OnCategoryToggled(category.Id, pressed)));
-            checkboxByCategory[category.Id] = checkbox;
-            vbox.AddChild(checkbox);
-        }
+            Name = "CategoryTree",
+            Columns = 1,
+            HideRoot = true,
+            HideFolding = false,
+            ScrollHorizontalEnabled = false,
+            ScrollVerticalEnabled = true,
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            SizeFlagsHorizontal = Control.SizeFlags.Fill | Control.SizeFlags.Expand,
+            CustomMinimumSize = new Vector2(0f, 92f),
+        };
+        categoryTree.AddThemeFontSizeOverride("font_size", 14);
+
+        var categoryItems = new Dictionary<string, TreeItem>(StringComparer.OrdinalIgnoreCase);
+        var hiddenRoot = categoryTree.CreateItem();
+        foreach (var category in RelicTaxonomy.RootCategories)
+            AddCategoryTreeItem(categoryTree, hiddenRoot, category, categoryItems);
+
+        categoryTree.Connect(
+            Tree.SignalName.ItemEdited,
+            Callable.From(() => OnCategoryTreeItemEdited(categoryTree, categoryItems)));
+        vbox.AddChild(categoryTree);
 
         var buttons = new HBoxContainer
         {
@@ -377,7 +384,27 @@ internal static class RelicCompendiumFilterUi
             modeDropdown,
             showUndiscovered,
             singleRelicGrid,
-            checkboxByCategory);
+            categoryItems);
+    }
+
+    private static void AddCategoryTreeItem(
+        Tree categoryTree,
+        TreeItem parentItem,
+        RelicTaxonomyCategory category,
+        IDictionary<string, TreeItem> categoryItems)
+    {
+        var item = categoryTree.CreateItem(parentItem);
+        item.SetCellMode(CategoryTreeColumn, TreeItem.TreeCellMode.Check);
+        item.SetText(CategoryTreeColumn, category.DisplayName);
+        item.SetEditable(CategoryTreeColumn, true);
+        item.SetSelectable(CategoryTreeColumn, false);
+        categoryItems[category.Id] = item;
+
+        foreach (var child in category.Children)
+            AddCategoryTreeItem(categoryTree, item, child, categoryItems);
+
+        if (category.Children.Count > 0)
+            item.Collapsed = false;
     }
 
     private static Label NewLabel(string text, int fontSize, Color color)
@@ -419,15 +446,28 @@ internal static class RelicCompendiumFilterUi
         ApplyToActiveEntries();
     }
 
-    private static void OnCategoryToggled(string categoryId, bool selected)
+    private static void OnCategoryTreeItemEdited(
+        Tree categoryTree,
+        IReadOnlyDictionary<string, TreeItem> categoryItems)
     {
-        if (_syncingControls) return;
+        if (_syncingControls || categoryTree.GetEditedColumn() != CategoryTreeColumn) return;
 
-        if (selected)
-            SelectedCategoryIds.Add(categoryId);
-        else
-            SelectedCategoryIds.Remove(categoryId);
+        var editedItem = categoryTree.GetEdited();
+        if (editedItem == null) return;
 
+        var editedItemId = editedItem.GetInstanceId();
+        var categoryId = categoryItems
+            .FirstOrDefault(pair => pair.Value.GetInstanceId() == editedItemId)
+            .Key;
+        if (string.IsNullOrWhiteSpace(categoryId)) return;
+
+        var currentState = RelicTaxonomy.GetSelectionState(categoryId, SelectedCategoryIds);
+        RelicTaxonomy.SetCategorySelection(
+            SelectedCategoryIds,
+            categoryId,
+            selected: currentState != RelicTaxonomyCategorySelectionState.Selected);
+
+        SyncAllControls();
         ApplyToActiveEntries();
     }
 
@@ -450,7 +490,7 @@ internal static class RelicCompendiumFilterUi
 
     private static void SelectAllCategories()
     {
-        foreach (var category in RelicTaxonomy.Categories)
+        foreach (var category in RelicTaxonomy.LeafCategories)
             SelectedCategoryIds.Add(category.Id);
         SyncAllControls();
         ApplyToActiveEntries();
@@ -835,7 +875,7 @@ internal static class RelicCompendiumFilterUi
         OptionButton ModeDropdown,
         CheckBox ShowUndiscoveredCheckbox,
         CheckBox SingleRelicGridCheckbox,
-        IReadOnlyDictionary<string, CheckBox> Checkboxes)
+        IReadOnlyDictionary<string, TreeItem> CategoryItems)
     {
         public bool IsValid =>
             Root != null
@@ -869,10 +909,21 @@ internal static class RelicCompendiumFilterUi
             if (SingleRelicGridCheckbox != null && GodotObject.IsInstanceValid(SingleRelicGridCheckbox))
                 SingleRelicGridCheckbox.SetPressedNoSignal(_useSingleRelicGrid);
 
-            foreach (var (categoryId, checkbox) in Checkboxes)
+            foreach (var (categoryId, item) in CategoryItems)
             {
-                if (checkbox == null || !GodotObject.IsInstanceValid(checkbox)) continue;
-                checkbox.SetPressedNoSignal(SelectedCategoryIds.Contains(categoryId));
+                if (item == null || !GodotObject.IsInstanceValid(item)) continue;
+
+                var state = RelicTaxonomy.GetSelectionState(categoryId, SelectedCategoryIds);
+
+                // Godot can retain a stale mixed state when SetChecked(false)
+                // is a no-op, so always clear it before setting the final state.
+                item.SetIndeterminate(CategoryTreeColumn, false);
+                item.SetChecked(
+                    CategoryTreeColumn,
+                    state == RelicTaxonomyCategorySelectionState.Selected);
+                item.SetIndeterminate(
+                    CategoryTreeColumn,
+                    state == RelicTaxonomyCategorySelectionState.Partial);
             }
         }
     }

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -1129,6 +1129,27 @@ public static class RelicHoverShowPatch
             return true;
         }
 
+        if (relicModel is Kusarigama)
+        {
+            title = "Kusarigama";
+            body = BuildKusarigamaBodyBBCode(agg);
+            return true;
+        }
+
+        if (relicModel is OrnamentalFan)
+        {
+            title = "Ornamental Fan";
+            body = BuildOrnamentalFanBodyBBCode(agg);
+            return true;
+        }
+
+        if (relicModel is Shuriken)
+        {
+            title = "Shuriken";
+            body = BuildShurikenBodyBBCode(agg);
+            return true;
+        }
+
         if (relicModel is PaperPhrog)
         {
             title = "Paper Phrog";
@@ -2607,6 +2628,81 @@ public static class RelicHoverShowPatch
         Row3(sb, "Turns ended at 2 charges", agg.KunaiTurnsEndedAt2Charges.ToString(), "");
         Row3(sb, "Avg charge at turn end", FormatDecimal(averageEndCharge), "");
         return sb.ToString();
+    }
+
+    private static string BuildKusarigamaBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        Row3(sb, "Attacks played", agg.KusarigamaAttacksPlayed.ToString(), "");
+        AppendRelicDamageStats(
+            sb,
+            agg,
+            triggerLabel: "Activations",
+            averageLabel: "Damage per activation",
+            averageDenominator: agg.Activations);
+        AppendTurnResetChargeRows(
+            sb,
+            agg.KusarigamaTurnsEndedAt1Charge,
+            agg.KusarigamaTurnsEndedAt2Charges,
+            agg.KusarigamaTurnEndChargeTotal,
+            agg.KusarigamaTurnEndChargeCount);
+        return sb.ToString();
+    }
+
+    private static string BuildOrnamentalFanBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        var blockPerActivation = agg.Activations <= 0
+            ? 0m
+            : (decimal)agg.AdditionalBlockGained / agg.Activations;
+
+        Row3(sb, "Attacks played", agg.OrnamentalFanAttacksPlayed.ToString(), "");
+        Row3(sb, "Activations", agg.Activations.ToString(), "");
+        Row3(sb, BlockLabel("block gained"), agg.AdditionalBlockGained.ToString(), "");
+        Row3(sb, BlockLabel("block gained per activation"), FormatDecimal(blockPerActivation), "");
+        AppendTurnResetChargeRows(
+            sb,
+            agg.OrnamentalFanTurnsEndedAt1Charge,
+            agg.OrnamentalFanTurnsEndedAt2Charges,
+            agg.OrnamentalFanTurnEndChargeTotal,
+            agg.OrnamentalFanTurnEndChargeCount);
+        return sb.ToString();
+    }
+
+    private static string BuildShurikenBodyBBCode(RelicAggregate agg)
+    {
+        var sb = new StringBuilder();
+        var strengthPerActivation = agg.Activations <= 0
+            ? 0m
+            : agg.StrengthAdded / agg.Activations;
+
+        Row3(sb, "Attacks played", agg.ShurikenAttacksPlayed.ToString(), "");
+        Row3(sb, "Activations", agg.Activations.ToString(), "");
+        Row3(sb, "Strength gained", FormatDecimal(agg.StrengthAdded), "");
+        Row3(sb, "Strength gained per activation", FormatDecimal(strengthPerActivation), "");
+        AppendTurnResetChargeRows(
+            sb,
+            agg.ShurikenTurnsEndedAt1Charge,
+            agg.ShurikenTurnsEndedAt2Charges,
+            agg.ShurikenTurnEndChargeTotal,
+            agg.ShurikenTurnEndChargeCount);
+        return sb.ToString();
+    }
+
+    private static void AppendTurnResetChargeRows(
+        StringBuilder sb,
+        int turnsEndedAt1Charge,
+        int turnsEndedAt2Charges,
+        int turnEndChargeTotal,
+        int turnEndChargeCount)
+    {
+        var averageEndCharge = turnEndChargeCount <= 0
+            ? 0m
+            : (decimal)turnEndChargeTotal / turnEndChargeCount;
+
+        Row3(sb, "Turns ended at 1 charge", turnsEndedAt1Charge.ToString(), "");
+        Row3(sb, "Turns ended at 2 charges", turnsEndedAt2Charges.ToString(), "");
+        Row3(sb, "Avg charge at turn end", FormatDecimal(averageEndCharge), "");
     }
 
     private static string BuildPaperPhrogBodyBBCode(RelicAggregate agg)

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -2492,6 +2492,23 @@ public static class RelicHoverShowPatch
         Row3(sb, "common cards consumed", agg.CommonCardsConsumed.ToString(), "");
         Row3(sb, "uncommon cards consumed", agg.UncommonCardsConsumed.ToString(), "");
         Row3(sb, "rare cards consumed", agg.RareCardsConsumed.ToString(), "");
+        var artifacts = agg.RelicsGranted.Values
+            .Where(artifact => artifact.Count > 0)
+            .OrderByDescending(artifact => artifact.Count)
+            .ThenBy(artifact => artifact.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var artifactsGained = artifacts.Sum(artifact => Math.Max(0, artifact.Count));
+        Row3(sb, "Artifacts gained", artifactsGained.ToString(), "");
+
+        foreach (var artifact in artifacts)
+        {
+            var displayName = StatsTooltip.EscapeBbcode(string.IsNullOrWhiteSpace(artifact.DisplayName)
+                ? RunTracker.FormatRelicIdForDisplay(artifact.RelicId)
+                : artifact.DisplayName);
+            var value = artifact.Count == 1 ? displayName : $"{displayName} x{artifact.Count}";
+            Row3(sb, "Artifact gained", value, "");
+        }
+
         Row3(sb, "Sacrifices made", agg.SacrificesMade.ToString(), "");
         Row3(sb, "Sacrifices skipped", agg.SacrificesSkipped.ToString(), "");
         if (TryFloorCountSinceRelicObtained(floorReached, floorAdded, out var floorCount))

--- a/Core/Patches/RelicHoverTooltipPatch.cs
+++ b/Core/Patches/RelicHoverTooltipPatch.cs
@@ -904,6 +904,9 @@ public static class RelicHoverShowPatch
         if (IsMrStrugglesStatsRelicModel(relicModel))
             return "RELIC.MR_STRUGGLES";
 
+        if (relicModel is Storybook)
+            return "RELIC.STORYBOOK";
+
         return relicModel.Id.ToString();
     }
 

--- a/Core/Patches/UnlimitedAttackChargeRelicsStatsPatch.cs
+++ b/Core/Patches/UnlimitedAttackChargeRelicsStatsPatch.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Localization.DynamicVars;
+using MegaCrit.Sts2.Core.Models.Powers;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace SpireLens.Core.Patches;
+
+/// <summary>
+/// Kusarigama counts owner Attacks and can fire on every third one in a turn.
+/// The owner callback arms only the exact single-target damage command it emits.
+/// </summary>
+[HarmonyPatch(typeof(Kusarigama), nameof(Kusarigama.AfterCardPlayed))]
+public static class KusarigamaAfterCardPlayedStatsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Kusarigama __instance, CardPlay cardPlay, out Creature? __state)
+    {
+        __state = null;
+
+        try
+        {
+            RunTracker.RecordKusarigamaAttackPlayedAndShouldArmDamageAttribution(
+                __instance,
+                cardPlay,
+                out __state);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KusarigamaAfterCardPlayedStatsPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(Creature? __state, Task __result)
+    {
+        if (__state == null) return;
+
+        try
+        {
+            if (__result == null)
+            {
+                RunTracker.DisarmKusarigamaDamageAttribution(__state);
+                return;
+            }
+
+            __result.ContinueWith(
+                _ => RunTracker.DisarmKusarigamaDamageAttribution(__state),
+                TaskScheduler.Default);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KusarigamaAfterCardPlayedStatsPatch.Postfix failed: {e.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// Captures Kusarigama's actual damage result, including block, overkill, and
+/// a combat-ending kill that the game's normal history may omit.
+/// </summary>
+[HarmonyPatch(
+    typeof(CreatureCmd),
+    nameof(CreatureCmd.Damage),
+    new[] { typeof(PlayerChoiceContext), typeof(Creature), typeof(DamageVar), typeof(Creature) })]
+public static class KusarigamaCreatureDamageStatsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Creature dealer, out bool __state)
+    {
+        __state = false;
+
+        try
+        {
+            __state = RunTracker.TryConsumeKusarigamaDamageAttribution(dealer);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KusarigamaCreatureDamageStatsPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(bool __state, Task<IEnumerable<DamageResult>> __result)
+    {
+        if (!__state || __result == null) return;
+        ObserveDamageResultAsync(__result);
+    }
+
+    private static async void ObserveDamageResultAsync(Task<IEnumerable<DamageResult>> damageTask)
+    {
+        try
+        {
+            var results = await damageTask.ConfigureAwait(false);
+            RunTracker.RecordKusarigamaDamage(results);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"KusarigamaCreatureDamageStatsPatch damage observation failed: {e.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// Ornamental Fan counts owner Attacks and arms its block command on every
+/// third play. The command result is the block amount after modifiers.
+/// </summary>
+[HarmonyPatch(typeof(OrnamentalFan), nameof(OrnamentalFan.AfterCardPlayed))]
+public static class OrnamentalFanAfterCardPlayedStatsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(OrnamentalFan __instance, CardPlay cardPlay, out Creature? __state)
+    {
+        __state = null;
+
+        try
+        {
+            RunTracker.RecordOrnamentalFanAttackPlayedAndShouldArmBlockAttribution(
+                __instance,
+                cardPlay,
+                out __state);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"OrnamentalFanAfterCardPlayedStatsPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(Creature? __state, Task __result)
+    {
+        if (__state == null) return;
+
+        try
+        {
+            if (__result == null)
+            {
+                RunTracker.DisarmOrnamentalFanBlockAttribution(__state);
+                return;
+            }
+
+            __result.ContinueWith(
+                _ => RunTracker.DisarmOrnamentalFanBlockAttribution(__state),
+                TaskScheduler.Default);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"OrnamentalFanAfterCardPlayedStatsPatch.Postfix failed: {e.Message}");
+        }
+    }
+}
+
+[HarmonyPatch(
+    typeof(CreatureCmd),
+    nameof(CreatureCmd.GainBlock),
+    new[] { typeof(Creature), typeof(BlockVar), typeof(CardPlay), typeof(bool) })]
+public static class OrnamentalFanCreatureGainBlockStatsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Creature creature, out bool __state)
+    {
+        __state = false;
+
+        try
+        {
+            __state = RunTracker.TryConsumeOrnamentalFanBlockAttribution(creature);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"OrnamentalFanCreatureGainBlockStatsPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(bool __state, Task<decimal> __result)
+    {
+        if (!__state || __result == null) return;
+        ObserveBlockResultAsync(__result);
+    }
+
+    private static async void ObserveBlockResultAsync(Task<decimal> blockTask)
+    {
+        try
+        {
+            var gained = await blockTask.ConfigureAwait(false);
+            RunTracker.RecordOrnamentalFanBlockGained(gained);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"OrnamentalFanCreatureGainBlockStatsPatch block observation failed: {e.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// Shuriken mirrors Kunai: snapshot Strength at the third-Attack threshold and
+/// record the positive observed delta after its async callback succeeds.
+/// </summary>
+[HarmonyPatch(typeof(Shuriken), nameof(Shuriken.AfterCardPlayed))]
+public static class ShurikenAfterCardPlayedStatsPatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(Shuriken __instance, CardPlay cardPlay, out ShurikenActivationState? __state)
+    {
+        __state = null;
+
+        try
+        {
+            if (!RunTracker.RecordShurikenAttackPlayedAndShouldObserveActivation(
+                    __instance,
+                    cardPlay,
+                    out var ownerCreature,
+                    out var strengthBefore))
+            {
+                return;
+            }
+
+            if (ownerCreature == null) return;
+            __state = new ShurikenActivationState(ownerCreature, strengthBefore);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"ShurikenAfterCardPlayedStatsPatch.Prefix failed: {e.Message}");
+        }
+    }
+
+    [HarmonyPostfix]
+    public static void Postfix(Task __result, ShurikenActivationState? __state)
+    {
+        if (__state == null) return;
+
+        try
+        {
+            if (__result == null)
+            {
+                FinalizeActivation(__state);
+                return;
+            }
+
+            if (__result.IsCompleted)
+            {
+                if (__result.IsCompletedSuccessfully)
+                    FinalizeActivation(__state);
+                return;
+            }
+
+            __result.ContinueWith(
+                task =>
+                {
+                    if (task.IsCompletedSuccessfully)
+                        FinalizeActivation(__state);
+                },
+                TaskScheduler.Default);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"ShurikenAfterCardPlayedStatsPatch.Postfix failed: {e.Message}");
+        }
+    }
+
+    private static void FinalizeActivation(ShurikenActivationState state)
+    {
+        try
+        {
+            var strengthAfter = state.OwnerCreature.GetPower<StrengthPower>()?.Amount ?? 0;
+            RunTracker.RecordShurikenActivation(Math.Max(0m, strengthAfter - state.StrengthBefore));
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"ShurikenAfterCardPlayedStatsPatch finalize failed: {e.Message}");
+        }
+    }
+}
+
+public sealed class ShurikenActivationState
+{
+    public ShurikenActivationState(Creature ownerCreature, decimal strengthBefore)
+    {
+        OwnerCreature = ownerCreature;
+        StrengthBefore = strengthBefore;
+    }
+
+    public Creature OwnerCreature { get; }
+    public decimal StrengthBefore { get; }
+}
+
+/// <summary>
+/// Snapshots the three repeatable Attack-counter relics before their per-turn
+/// counters reset. Bound by runtime lookup for the same compatibility reason
+/// as the existing Kunai and Letter Opener snapshots.
+/// </summary>
+[HarmonyPatch]
+public static class HookBeforeSideTurnEndUnlimitedAttackChargeRelicsPatch
+{
+    private static MethodBase? TargetMethod()
+    {
+        var hookType = Sts2CoreAssembly()?.GetType("MegaCrit.Sts2.Core.Hooks.Hook", throwOnError: false);
+        if (hookType == null) return null;
+
+        return AccessTools.Method(hookType, "BeforeSideTurnEnd")
+            ?? AccessTools.Method(hookType, "BeforeTurnEnd");
+    }
+
+    private static Assembly? Sts2CoreAssembly()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.GetName().Name == "sts2") return assembly;
+        }
+
+        return null;
+    }
+
+    private static bool Prepare() => TargetMethod() != null;
+
+    [HarmonyPrefix]
+    public static void Prefix(CombatSide side, IEnumerable<Creature> participants)
+    {
+        try
+        {
+            if (side != CombatSide.Player) return;
+            RunTracker.RecordUnlimitedAttackChargeRelicsTurnEnded(participants);
+        }
+        catch (Exception e)
+        {
+            CoreMain.LogDebug($"HookBeforeSideTurnEndUnlimitedAttackChargeRelicsPatch failed: {e.Message}");
+        }
+    }
+}

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -11,38 +11,8 @@ internal sealed record RelicTaxonomyCategory(
 
 internal static class RelicTaxonomy
 {
-    public const string EnergyCategoryId = "energy";
     public const string ChargeAcrossTurnsCategoryId = "charge_across_turns";
     public const string ChargeResetsEachTurnCategoryId = "charge_resets_each_turn";
-
-    private static readonly RelicTaxonomyCategory EnergyCategory = new(
-        EnergyCategoryId,
-        "Energy relics",
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "RELIC.ART_OF_WAR",
-            "RELIC.BLOOD_SOAKED_ROSE",
-            "RELIC.BOOMING_CONCH",
-            "RELIC.BOOKMARK",
-            "RELIC.BRILLIANT_SCARF",
-            "RELIC.CANDELABRA",
-            "RELIC.CHANDELIER",
-            "RELIC.ECTOPLASM",
-            "RELIC.FAKE_HAPPY_FLOWER",
-            "RELIC.FAKE_VENERABLE_TEA_SET",
-            "RELIC.GREMLIN_HORN",
-            "RELIC.HAPPY_FLOWER",
-            "RELIC.ICE_CREAM",
-            "RELIC.LANTERN",
-            "RELIC.MUMMIFIED_HAND",
-            "RELIC.NUNCHAKU",
-            "RELIC.PHILOSOPHERS_STONE",
-            "RELIC.PRISMATIC_GEM",
-            "RELIC.SOZU",
-            "RELIC.VELVET_CHOKER",
-            "RELIC.VENERABLE_TEA_SET",
-            "RELIC.VERY_HOT_COCOA",
-        });
 
     private static readonly RelicTaxonomyCategory ChargeAcrossTurnsCategory = new(
         ChargeAcrossTurnsCategoryId,
@@ -96,7 +66,6 @@ internal static class RelicTaxonomy
 
     public static IReadOnlyList<RelicTaxonomyCategory> Categories { get; } =
     [
-        EnergyCategory,
         ChargeAcrossTurnsCategory,
         ChargeResetsEachTurnCategory,
     ];

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -7,16 +7,25 @@ namespace SpireLens.Core;
 internal sealed record RelicTaxonomyCategory(
     string Id,
     string DisplayName,
-    IReadOnlySet<string> RelicIds);
+    IReadOnlySet<string> RelicIds,
+    IReadOnlyList<RelicTaxonomyCategory> Children);
+
+internal enum RelicTaxonomyCategorySelectionState
+{
+    Unselected,
+    Partial,
+    Selected,
+}
 
 internal static class RelicTaxonomy
 {
+    public const string ChargeCategoryId = "charge";
     public const string ChargeAcrossTurnsCategoryId = "charge_across_turns";
     public const string ChargeResetsEachTurnCategoryId = "charge_resets_each_turn";
 
     private static readonly RelicTaxonomyCategory ChargeAcrossTurnsCategory = new(
         ChargeAcrossTurnsCategoryId,
-        "Charge: across turns",
+        "Across turns",
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "RELIC.BOOK_OF_FIVE_RINGS",
@@ -45,11 +54,12 @@ internal static class RelicTaxonomy
             "RELIC.TUNING_FORK",
             "RELIC.WINGED_BOOTS",
             "RELIC.WONGOS_MYSTERY_TICKET",
-        });
+        },
+        []);
 
     private static readonly RelicTaxonomyCategory ChargeResetsEachTurnCategory = new(
         ChargeResetsEachTurnCategoryId,
-        "Charge: resets each turn",
+        "Resets each turn",
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "RELIC.BRILLIANT_SCARF",
@@ -62,27 +72,150 @@ internal static class RelicTaxonomy
             "RELIC.RAINBOW_RING",
             "RELIC.SHURIKEN",
             "RELIC.VELVET_CHOKER",
-        });
+        },
+        []);
 
-    public static IReadOnlyList<RelicTaxonomyCategory> Categories { get; } =
+    private static readonly RelicTaxonomyCategory ChargeCategory = new(
+        ChargeCategoryId,
+        "Charge",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+        [
+            ChargeAcrossTurnsCategory,
+            ChargeResetsEachTurnCategory,
+        ]);
+
+    public static IReadOnlyList<RelicTaxonomyCategory> RootCategories { get; } =
     [
-        ChargeAcrossTurnsCategory,
-        ChargeResetsEachTurnCategory,
+        ChargeCategory,
     ];
 
-    public static bool IsRelicInAnySelectedCategory(
-        string? relicId,
+    public static IReadOnlyList<RelicTaxonomyCategory> Categories { get; } =
+        Flatten(RootCategories);
+
+    public static IReadOnlyList<RelicTaxonomyCategory> LeafCategories { get; } =
+        Categories.Where(category => category.Children.Count == 0).ToArray();
+
+    static RelicTaxonomy()
+    {
+        foreach (var category in Categories)
+        {
+            if (category.Children.Count > 0 && category.RelicIds.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Relic taxonomy group '{category.Id}' cannot own relics directly.");
+            }
+        }
+    }
+
+    public static IReadOnlyList<string> GetSelectableCategoryIds(string? categoryId)
+    {
+        if (string.IsNullOrWhiteSpace(categoryId)) return Array.Empty<string>();
+
+        var category = Categories.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, categoryId, StringComparison.OrdinalIgnoreCase));
+        if (category == null) return Array.Empty<string>();
+
+        return EnumerateLeafCategories(category)
+            .Select(leaf => leaf.Id)
+            .ToArray();
+    }
+
+    public static RelicTaxonomyCategorySelectionState GetSelectionState(
+        string categoryId,
         IEnumerable<string> selectedCategoryIds)
     {
-        if (string.IsNullOrWhiteSpace(relicId)) return false;
+        var selectableIds = GetSelectableCategoryIds(categoryId);
+        if (selectableIds.Count == 0)
+            return RelicTaxonomyCategorySelectionState.Unselected;
 
         var selected = new HashSet<string>(
             selectedCategoryIds ?? Array.Empty<string>(),
             StringComparer.OrdinalIgnoreCase);
+        var selectedCount = selectableIds.Count(selected.Contains);
+
+        if (selectedCount == 0)
+            return RelicTaxonomyCategorySelectionState.Unselected;
+        if (selectedCount == selectableIds.Count)
+            return RelicTaxonomyCategorySelectionState.Selected;
+        return RelicTaxonomyCategorySelectionState.Partial;
+    }
+
+    public static void SetCategorySelection(
+        ISet<string> selectedCategoryIds,
+        string categoryId,
+        bool selected)
+    {
+        ArgumentNullException.ThrowIfNull(selectedCategoryIds);
+
+        foreach (var group in Categories.Where(candidate => candidate.Children.Count > 0))
+            selectedCategoryIds.Remove(group.Id);
+
+        foreach (var selectableId in GetSelectableCategoryIds(categoryId))
+        {
+            if (selected)
+                selectedCategoryIds.Add(selectableId);
+            else
+                selectedCategoryIds.Remove(selectableId);
+        }
+    }
+
+    public static bool IsRelicInAnySelectedCategory(
+        string? relicId,
+        IEnumerable<string> selectedLeafCategoryIds)
+    {
+        if (string.IsNullOrWhiteSpace(relicId)) return false;
+
+        var selected = new HashSet<string>(
+            selectedLeafCategoryIds ?? Array.Empty<string>(),
+            StringComparer.OrdinalIgnoreCase);
         if (selected.Count == 0) return false;
 
-        return Categories.Any(category =>
+        return LeafCategories.Any(category =>
             selected.Contains(category.Id)
             && category.RelicIds.Contains(relicId));
+    }
+
+    private static IReadOnlyList<RelicTaxonomyCategory> Flatten(
+        IEnumerable<RelicTaxonomyCategory> roots)
+    {
+        var flattened = new List<RelicTaxonomyCategory>();
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var root in roots)
+            AddCategoryAndDescendants(root, flattened, seenIds);
+
+        return flattened;
+    }
+
+    private static void AddCategoryAndDescendants(
+        RelicTaxonomyCategory category,
+        ICollection<RelicTaxonomyCategory> flattened,
+        ISet<string> seenIds)
+    {
+        if (!seenIds.Add(category.Id))
+        {
+            throw new InvalidOperationException(
+                $"Relic taxonomy category ID '{category.Id}' is duplicated or cyclic.");
+        }
+
+        flattened.Add(category);
+        foreach (var child in category.Children)
+            AddCategoryAndDescendants(child, flattened, seenIds);
+    }
+
+    private static IEnumerable<RelicTaxonomyCategory> EnumerateLeafCategories(
+        RelicTaxonomyCategory category)
+    {
+        if (category.Children.Count == 0)
+        {
+            yield return category;
+            yield break;
+        }
+
+        foreach (var child in category.Children)
+        {
+            foreach (var leaf in EnumerateLeafCategories(child))
+                yield return leaf;
+        }
     }
 }

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -22,6 +22,10 @@ internal static class RelicTaxonomy
     public const string ChargeCategoryId = "charge";
     public const string ChargeAcrossTurnsCategoryId = "charge_across_turns";
     public const string ChargeResetsEachTurnCategoryId = "charge_resets_each_turn";
+    public const string ChargeResetsEachTurnLimitedActivationsCategoryId =
+        "charge_resets_each_turn_limited_activations";
+    public const string ChargeResetsEachTurnUnlimitedActivationsCategoryId =
+        "charge_resets_each_turn_unlimited_activations";
 
     private static readonly RelicTaxonomyCategory ChargeAcrossTurnsCategory = new(
         ChargeAcrossTurnsCategoryId,
@@ -57,23 +61,40 @@ internal static class RelicTaxonomy
         },
         []);
 
-    private static readonly RelicTaxonomyCategory ChargeResetsEachTurnCategory = new(
-        ChargeResetsEachTurnCategoryId,
-        "Resets each turn",
+    private static readonly RelicTaxonomyCategory ChargeResetsEachTurnLimitedActivationsCategory = new(
+        ChargeResetsEachTurnLimitedActivationsCategoryId,
+        "Limited activations",
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "RELIC.BRILLIANT_SCARF",
             "RELIC.DIAMOND_DIADEM",
+            "RELIC.POCKETWATCH",
+            "RELIC.RAINBOW_RING",
+            "RELIC.VELVET_CHOKER",
+        },
+        []);
+
+    private static readonly RelicTaxonomyCategory ChargeResetsEachTurnUnlimitedActivationsCategory = new(
+        ChargeResetsEachTurnUnlimitedActivationsCategoryId,
+        "Unlimited activations",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
             "RELIC.KUNAI",
             "RELIC.KUSARIGAMA",
             "RELIC.LETTER_OPENER",
             "RELIC.ORNAMENTAL_FAN",
-            "RELIC.POCKETWATCH",
-            "RELIC.RAINBOW_RING",
             "RELIC.SHURIKEN",
-            "RELIC.VELVET_CHOKER",
         },
         []);
+
+    private static readonly RelicTaxonomyCategory ChargeResetsEachTurnCategory = new(
+        ChargeResetsEachTurnCategoryId,
+        "Resets each turn",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+        [
+            ChargeResetsEachTurnLimitedActivationsCategory,
+            ChargeResetsEachTurnUnlimitedActivationsCategory,
+        ]);
 
     private static readonly RelicTaxonomyCategory ChargeCategory = new(
         ChargeCategoryId,

--- a/Core/RelicTaxonomy.cs
+++ b/Core/RelicTaxonomy.cs
@@ -20,6 +20,9 @@ internal enum RelicTaxonomyCategorySelectionState
 internal static class RelicTaxonomy
 {
     public const string ChargeCategoryId = "charge";
+    public const string ChargeAcrossCombatsCategoryId = "charge_across_combats";
+    public const string ChargeAcrossCombatsCyclingCategoryId = "charge_across_combats_cycling";
+    public const string ChargeAcrossCombatsNonCyclingCategoryId = "charge_across_combats_non_cycling";
     public const string ChargeAcrossTurnsCategoryId = "charge_across_turns";
     public const string ChargeResetsEachTurnCategoryId = "charge_resets_each_turn";
     public const string ChargeResetsEachTurnLimitedActivationsCategoryId =
@@ -32,34 +35,59 @@ internal static class RelicTaxonomy
         "Across turns",
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            "RELIC.METRONOME",
+            "RELIC.PAELS_FLESH",
+            "RELIC.PAELS_LEGION",
+            "RELIC.STONE_CALENDAR",
+        },
+        []);
+
+    private static readonly RelicTaxonomyCategory ChargeAcrossCombatsCyclingCategory = new(
+        ChargeAcrossCombatsCyclingCategoryId,
+        "Cycling",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
             "RELIC.BOOK_OF_FIVE_RINGS",
             "RELIC.FAKE_HAPPY_FLOWER",
             "RELIC.FISHING_ROD",
             "RELIC.GALACTIC_DUST",
-            "RELIC.GIRYA",
             "RELIC.HAPPY_FLOWER",
             "RELIC.IRON_CLUB",
             "RELIC.JOSS_PAPER",
             "RELIC.LASTING_CANDY",
-            "RELIC.METRONOME",
             "RELIC.NUNCHAKU",
-            "RELIC.PAELS_FLESH",
-            "RELIC.PAELS_LEGION",
-            "RELIC.PAELS_TOOTH",
             "RELIC.PAELS_WING",
             "RELIC.PENDULUM",
             "RELIC.PEN_NIB",
             "RELIC.POLLINOUS_CORE",
-            "RELIC.PUMPKIN_CANDLE",
-            "RELIC.SILVER_CRUCIBLE",
-            "RELIC.STONE_CALENDAR",
-            "RELIC.SWORD_OF_STONE",
             "RELIC.TOY_BOX",
             "RELIC.TUNING_FORK",
+        },
+        []);
+
+    private static readonly RelicTaxonomyCategory ChargeAcrossCombatsNonCyclingCategory = new(
+        ChargeAcrossCombatsNonCyclingCategoryId,
+        "Non-cycling",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "RELIC.GIRYA",
+            "RELIC.PAELS_TOOTH",
+            "RELIC.PUMPKIN_CANDLE",
+            "RELIC.SILVER_CRUCIBLE",
+            "RELIC.SWORD_OF_STONE",
             "RELIC.WINGED_BOOTS",
             "RELIC.WONGOS_MYSTERY_TICKET",
         },
         []);
+
+    private static readonly RelicTaxonomyCategory ChargeAcrossCombatsCategory = new(
+        ChargeAcrossCombatsCategoryId,
+        "Across combats",
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+        [
+            ChargeAcrossCombatsCyclingCategory,
+            ChargeAcrossCombatsNonCyclingCategory,
+        ]);
 
     private static readonly RelicTaxonomyCategory ChargeResetsEachTurnLimitedActivationsCategory = new(
         ChargeResetsEachTurnLimitedActivationsCategoryId,
@@ -101,6 +129,7 @@ internal static class RelicTaxonomy
         "Charge",
         new HashSet<string>(StringComparer.OrdinalIgnoreCase),
         [
+            ChargeAcrossCombatsCategory,
             ChargeAcrossTurnsCategory,
             ChargeResetsEachTurnCategory,
         ]);

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -558,8 +558,8 @@ public class RelicAggregate
     public int RareRelicsAcquired { get; set; }
     public int CampfiresNotDug { get; set; }
 
-    // Specific relics granted by relic-owned effects. Used by Large Capsule
-    // and Neow's Bones to show which relics were obtained.
+    // Specific relics granted by relic-owned effects. Used by Large Capsule,
+    // Neow's Bones, and Pael's Wing to show which relics/artifacts were obtained.
     public Dictionary<string, RelicGrantedAggregate> RelicsGranted { get; set; } = new();
 
     // Total offered cards by rarity for relics that generate card-choice

--- a/Core/RunData.cs
+++ b/Core/RunData.cs
@@ -396,8 +396,8 @@ public class RelicAggregate
 
     // Total block gained from this relic across all combats.
     // Used by Orichalcum, Permafrost, The Abacus, Bone Flute, Cloak Clasp,
-    // Anchor, Horn Cleat, Tuning Fork, Regalite, and Vambrace's extra block
-    // from its multiplier.
+    // Anchor, Horn Cleat, Tuning Fork, Ornamental Fan, Regalite, and Vambrace's
+    // extra block from its multiplier.
     public int AdditionalBlockGained { get; set; }
 
     // Total times this relic got its own trigger check but was blocked by
@@ -405,7 +405,7 @@ public class RelicAggregate
     // has block at end of turn.
     public int BlockedTriggers { get; set; }
 
-    // Total Strength this relic added. Used by Reptile Trinket.
+    // Total Strength this relic added. Used by Reptile Trinket and Shuriken.
     public decimal StrengthAdded { get; set; }
 
     // Total Plating this relic added. Used by Gorget.
@@ -613,6 +613,26 @@ public class RelicAggregate
     public int KunaiTurnsEndedAt2Charges { get; set; }
     public int KunaiTurnEndChargeTotal { get; set; }
     public int KunaiTurnEndChargeCount { get; set; }
+
+    // Kusarigama, Ornamental Fan, and Shuriken share Kunai's repeatable
+    // three-Attack, turn-reset counter. Their payoff uses the shared relic
+    // damage, block, and Strength fields above; these fields preserve each
+    // relic's input count and player-turn-end unused charge.
+    public int KusarigamaAttacksPlayed { get; set; }
+    public int KusarigamaTurnsEndedAt1Charge { get; set; }
+    public int KusarigamaTurnsEndedAt2Charges { get; set; }
+    public int KusarigamaTurnEndChargeTotal { get; set; }
+    public int KusarigamaTurnEndChargeCount { get; set; }
+    public int OrnamentalFanAttacksPlayed { get; set; }
+    public int OrnamentalFanTurnsEndedAt1Charge { get; set; }
+    public int OrnamentalFanTurnsEndedAt2Charges { get; set; }
+    public int OrnamentalFanTurnEndChargeTotal { get; set; }
+    public int OrnamentalFanTurnEndChargeCount { get; set; }
+    public int ShurikenAttacksPlayed { get; set; }
+    public int ShurikenTurnsEndedAt1Charge { get; set; }
+    public int ShurikenTurnsEndedAt2Charges { get; set; }
+    public int ShurikenTurnEndChargeTotal { get; set; }
+    public int ShurikenTurnEndChargeCount { get; set; }
 
     // Paper Phrog tracking. Damage added is the actual current damage amount
     // multiplied by Paper Phrog's extra Vulnerable multiplier. Enhanced attacks

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using MegaCrit.Sts2.Core.Combat;
@@ -830,6 +831,7 @@ public static class RunTracker
     /// this record instead of stranding it — the previous inline mints omitted
     /// it, re-seeding the stranding bug. Single home for the lazy mint.
     /// </summary>
+    [MemberNotNull(nameof(_currentRun))]
     private static void EnsureLazyCurrentRunLocked()
     {
         if (_currentRun != null) return;

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -4481,6 +4481,33 @@ public static class RunTracker
     }
 
     /// <summary>
+    /// Record the direct artifact Pael's Wing adds to its owner's inventory
+    /// after a completed pair of sacrifices.
+    /// </summary>
+    public static void RecordPaelsWingArtifactGained(RelicModel artifactGained)
+    {
+        if (artifactGained == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateCurrentRunRelicAggregateLocked(PaelsWingRelicId);
+                RecordPaelsWingArtifactGainedForTest(
+                    agg,
+                    artifactGained.Id.ToString(),
+                    GetRelicDisplayName(artifactGained));
+                RefreshCurrentRunMetadataLocked();
+                SaveCurrentRun();
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordPaelsWingArtifactGained failed: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
     /// Record a Pael's Wing sacrifice opportunity that resolved without
     /// selecting Sacrifice, either by taking a card or by using another
     /// alternative such as Skip.
@@ -6421,6 +6448,15 @@ public static class RunTracker
     }
 
     internal static void RecordLargeCapsuleRelicObtainedForTest(
+        RelicAggregate agg,
+        string? relicId,
+        string? displayName)
+    {
+        if (agg == null || string.IsNullOrWhiteSpace(relicId)) return;
+        AddRelicGranted(agg.RelicsGranted, relicId, displayName ?? "", 1);
+    }
+
+    internal static void RecordPaelsWingArtifactGainedForTest(
         RelicAggregate agg,
         string? relicId,
         string? displayName)

--- a/Core/RunTracker.cs
+++ b/Core/RunTracker.cs
@@ -79,7 +79,9 @@ public static class RunTracker
     private static readonly List<PendingRelicHealing> _pendingRelicHeals = new();
     private static readonly List<Player> _pendingPendulumDrawAttributions = new();
     private static readonly List<Creature> _pendingParryingShieldDamageAttributions = new();
+    private static readonly List<Creature> _pendingKusarigamaDamageAttributions = new();
     private static readonly List<Creature> _pendingFestivePopperDamageAttributions = new();
+    private static readonly List<Creature> _pendingOrnamentalFanBlockAttributions = new();
     private static readonly List<Creature> _pendingMercuryHourglassDamageAttributions = new();
     private static readonly List<Creature> _pendingMrStrugglesDamageAttributions = new();
     private static readonly Dictionary<PowerModel, int> _bronzeScalesThornsContributions = new(ReferenceEqualityComparer.Instance);
@@ -929,7 +931,9 @@ public static class RunTracker
         _pendingAkabekoVigorAttribution = false;
         _pendingPendulumDrawAttributions.Clear();
         _pendingParryingShieldDamageAttributions.Clear();
+        _pendingKusarigamaDamageAttributions.Clear();
         _pendingFestivePopperDamageAttributions.Clear();
+        _pendingOrnamentalFanBlockAttributions.Clear();
         _pendingMercuryHourglassDamageAttributions.Clear();
         _pendingMrStrugglesDamageAttributions.Clear();
         _bronzeScalesThornsContributions.Clear();
@@ -1691,6 +1695,21 @@ public static class RunTracker
         target.KunaiTurnsEndedAt2Charges += source.KunaiTurnsEndedAt2Charges;
         target.KunaiTurnEndChargeTotal += source.KunaiTurnEndChargeTotal;
         target.KunaiTurnEndChargeCount += source.KunaiTurnEndChargeCount;
+        target.KusarigamaAttacksPlayed += source.KusarigamaAttacksPlayed;
+        target.KusarigamaTurnsEndedAt1Charge += source.KusarigamaTurnsEndedAt1Charge;
+        target.KusarigamaTurnsEndedAt2Charges += source.KusarigamaTurnsEndedAt2Charges;
+        target.KusarigamaTurnEndChargeTotal += source.KusarigamaTurnEndChargeTotal;
+        target.KusarigamaTurnEndChargeCount += source.KusarigamaTurnEndChargeCount;
+        target.OrnamentalFanAttacksPlayed += source.OrnamentalFanAttacksPlayed;
+        target.OrnamentalFanTurnsEndedAt1Charge += source.OrnamentalFanTurnsEndedAt1Charge;
+        target.OrnamentalFanTurnsEndedAt2Charges += source.OrnamentalFanTurnsEndedAt2Charges;
+        target.OrnamentalFanTurnEndChargeTotal += source.OrnamentalFanTurnEndChargeTotal;
+        target.OrnamentalFanTurnEndChargeCount += source.OrnamentalFanTurnEndChargeCount;
+        target.ShurikenAttacksPlayed += source.ShurikenAttacksPlayed;
+        target.ShurikenTurnsEndedAt1Charge += source.ShurikenTurnsEndedAt1Charge;
+        target.ShurikenTurnsEndedAt2Charges += source.ShurikenTurnsEndedAt2Charges;
+        target.ShurikenTurnEndChargeTotal += source.ShurikenTurnEndChargeTotal;
+        target.ShurikenTurnEndChargeCount += source.ShurikenTurnEndChargeCount;
         target.PaperPhrogDamageAdded += source.PaperPhrogDamageAdded;
         target.PaperPhrogEnhancedAttacks += source.PaperPhrogEnhancedAttacks;
         target.PaperPhrogCombats += source.PaperPhrogCombats;
@@ -2392,6 +2411,9 @@ public static class RunTracker
     private const string MiniatureCannonRelicId = "RELIC.MINIATURE_CANNON";
     private const string VajraRelicId = "RELIC.VAJRA";
     private const string KunaiRelicId = "RELIC.KUNAI";
+    private const string KusarigamaRelicId = "RELIC.KUSARIGAMA";
+    private const string OrnamentalFanRelicId = "RELIC.ORNAMENTAL_FAN";
+    private const string ShurikenRelicId = "RELIC.SHURIKEN";
     private const string PaperPhrogRelicId = "RELIC.PAPER_PHROG";
     private const string RegaliteRelicId = "RELIC.REGALITE";
     private const string BookmarkRelicId = "RELIC.BOOKMARK";
@@ -6276,6 +6298,417 @@ public static class RunTracker
             agg.KunaiTurnsEndedAt2Charges += 1;
     }
 
+    /// <summary>
+    /// Record a Kusarigama-owned Attack and arm the exact damage command when
+    /// this play reaches the repeatable three-Attack threshold.
+    /// </summary>
+    public static bool RecordKusarigamaAttackPlayedAndShouldArmDamageAttribution(
+        Kusarigama relic,
+        CardPlay cardPlay,
+        out Creature? dealer)
+    {
+        dealer = null;
+        if (relic?.Owner == null || cardPlay?.Card == null) return false;
+        if (cardPlay.Card.Type != CardType.Attack) return false;
+        if (cardPlay.Card.Owner != null && !ReferenceEquals(cardPlay.Card.Owner, relic.Owner)) return false;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedRelic(relic) || !IsTrackedPlayer(relic.Owner)) return false;
+                if (CombatManager.Instance?.IsInProgress != true) return false;
+
+                _pendingCombat ??= new PendingCombat();
+                var agg = GetOrCreatePendingRelicAggregateLocked(KusarigamaRelicId);
+                RecordKusarigamaAttackPlayedForTest(agg);
+
+                var threshold = KusarigamaCardsPerActivation(relic);
+                if (threshold <= 0 || KusarigamaCharge(relic) + 1 < threshold) return false;
+
+                dealer = relic.Owner.Creature;
+                if (dealer?.CombatState?.HittableEnemies?.Any() != true)
+                {
+                    dealer = null;
+                    return false;
+                }
+
+                RecordKusarigamaActivationForTest(agg);
+                _pendingKusarigamaDamageAttributions.Add(dealer);
+                return true;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordKusarigamaAttackPlayedAndShouldArmDamageAttribution failed: {e.Message}");
+                dealer = null;
+                return false;
+            }
+        }
+    }
+
+    public static bool TryConsumeKusarigamaDamageAttribution(Creature dealer)
+    {
+        if (dealer == null) return false;
+
+        lock (_lock)
+        {
+            try
+            {
+                return ConsumePendingCreatureAttribution(_pendingKusarigamaDamageAttributions, dealer);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"TryConsumeKusarigamaDamageAttribution failed: {e.Message}");
+                return false;
+            }
+        }
+    }
+
+    public static void DisarmKusarigamaDamageAttribution(Creature? dealer)
+    {
+        if (dealer == null) return;
+        lock (_lock)
+            ConsumePendingCreatureAttribution(_pendingKusarigamaDamageAttributions, dealer);
+    }
+
+    public static void RecordKusarigamaDamage(IEnumerable<DamageResult>? results)
+    {
+        if (results == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateRelicAggregateForCurrentContextLocked(KusarigamaRelicId);
+                AddRelicDamageResultsLocked(agg, results);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordKusarigamaDamage failed: {e.Message}");
+            }
+        }
+    }
+
+    internal static void RecordKusarigamaAttackPlayedForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.KusarigamaAttacksPlayed += Math.Max(0, count);
+    }
+
+    internal static void RecordKusarigamaActivationForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.Activations += Math.Max(0, count);
+    }
+
+    internal static void RecordKusarigamaDamageForTest(
+        RelicAggregate agg,
+        IEnumerable<(int BlockedDamage, int UnblockedDamage, int OverkillDamage, bool WasTargetKilled)> results)
+    {
+        if (agg == null || results == null) return;
+        foreach (var result in results)
+        {
+            AddRelicDamageResultPartsLocked(
+                agg,
+                result.BlockedDamage,
+                result.UnblockedDamage,
+                result.OverkillDamage,
+                result.WasTargetKilled);
+        }
+    }
+
+    internal static void RecordKusarigamaTurnEndChargeForTest(RelicAggregate agg, int charge)
+    {
+        if (agg == null || charge < 0) return;
+
+        charge %= 3;
+        agg.KusarigamaTurnEndChargeTotal += charge;
+        agg.KusarigamaTurnEndChargeCount += 1;
+        if (charge == 1)
+            agg.KusarigamaTurnsEndedAt1Charge += 1;
+        else if (charge == 2)
+            agg.KusarigamaTurnsEndedAt2Charges += 1;
+    }
+
+    /// <summary>
+    /// Record an Ornamental Fan-owned Attack and arm its exact block command
+    /// when this play reaches the repeatable three-Attack threshold.
+    /// </summary>
+    public static bool RecordOrnamentalFanAttackPlayedAndShouldArmBlockAttribution(
+        OrnamentalFan relic,
+        CardPlay cardPlay,
+        out Creature? ownerCreature)
+    {
+        ownerCreature = null;
+        if (relic?.Owner == null || cardPlay?.Card == null) return false;
+        if (cardPlay.Card.Type != CardType.Attack) return false;
+        if (cardPlay.Card.Owner != null && !ReferenceEquals(cardPlay.Card.Owner, relic.Owner)) return false;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedRelic(relic) || !IsTrackedPlayer(relic.Owner)) return false;
+                if (CombatManager.Instance?.IsInProgress != true) return false;
+
+                _pendingCombat ??= new PendingCombat();
+                var agg = GetOrCreatePendingRelicAggregateLocked(OrnamentalFanRelicId);
+                RecordOrnamentalFanAttackPlayedForTest(agg);
+
+                var threshold = OrnamentalFanCardsPerActivation(relic);
+                if (threshold <= 0 || OrnamentalFanCharge(relic) + 1 < threshold) return false;
+
+                ownerCreature = relic.Owner.Creature;
+                if (ownerCreature == null) return false;
+
+                RecordOrnamentalFanActivationForTest(agg);
+                _pendingOrnamentalFanBlockAttributions.Add(ownerCreature);
+                return true;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordOrnamentalFanAttackPlayedAndShouldArmBlockAttribution failed: {e.Message}");
+                ownerCreature = null;
+                return false;
+            }
+        }
+    }
+
+    public static bool TryConsumeOrnamentalFanBlockAttribution(Creature creature)
+    {
+        if (creature == null) return false;
+
+        lock (_lock)
+        {
+            try
+            {
+                return ConsumePendingCreatureAttribution(_pendingOrnamentalFanBlockAttributions, creature);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"TryConsumeOrnamentalFanBlockAttribution failed: {e.Message}");
+                return false;
+            }
+        }
+    }
+
+    public static void DisarmOrnamentalFanBlockAttribution(Creature? creature)
+    {
+        if (creature == null) return;
+        lock (_lock)
+            ConsumePendingCreatureAttribution(_pendingOrnamentalFanBlockAttributions, creature);
+    }
+
+    public static void RecordOrnamentalFanBlockGained(decimal amount)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateRelicAggregateForCurrentContextLocked(OrnamentalFanRelicId);
+                RecordOrnamentalFanBlockGainedForTest(agg, amount);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordOrnamentalFanBlockGained failed: {e.Message}");
+            }
+        }
+    }
+
+    internal static void RecordOrnamentalFanAttackPlayedForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.OrnamentalFanAttacksPlayed += Math.Max(0, count);
+    }
+
+    internal static void RecordOrnamentalFanActivationForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.Activations += Math.Max(0, count);
+    }
+
+    internal static void RecordOrnamentalFanBlockGainedForTest(RelicAggregate agg, decimal amount)
+    {
+        if (agg == null || amount <= 0m) return;
+        agg.AdditionalBlockGained += (int)amount;
+    }
+
+    internal static void RecordOrnamentalFanTurnEndChargeForTest(RelicAggregate agg, int charge)
+    {
+        if (agg == null || charge < 0) return;
+
+        charge %= 3;
+        agg.OrnamentalFanTurnEndChargeTotal += charge;
+        agg.OrnamentalFanTurnEndChargeCount += 1;
+        if (charge == 1)
+            agg.OrnamentalFanTurnsEndedAt1Charge += 1;
+        else if (charge == 2)
+            agg.OrnamentalFanTurnsEndedAt2Charges += 1;
+    }
+
+    /// <summary>
+    /// Record a Shuriken-owned Attack and snapshot Strength when this play
+    /// reaches the repeatable three-Attack threshold.
+    /// </summary>
+    public static bool RecordShurikenAttackPlayedAndShouldObserveActivation(
+        Shuriken relic,
+        CardPlay cardPlay,
+        out Creature? ownerCreature,
+        out decimal strengthBefore)
+    {
+        ownerCreature = null;
+        strengthBefore = 0m;
+        if (relic?.Owner == null || cardPlay?.Card == null) return false;
+        if (cardPlay.Card.Type != CardType.Attack) return false;
+        if (cardPlay.Card.Owner != null && !ReferenceEquals(cardPlay.Card.Owner, relic.Owner)) return false;
+
+        lock (_lock)
+        {
+            try
+            {
+                if (!IsTrackedRelic(relic) || !IsTrackedPlayer(relic.Owner)) return false;
+                if (CombatManager.Instance?.IsInProgress != true) return false;
+
+                _pendingCombat ??= new PendingCombat();
+                var agg = GetOrCreatePendingRelicAggregateLocked(ShurikenRelicId);
+                RecordShurikenAttackPlayedForTest(agg);
+
+                var threshold = ShurikenCardsPerActivation(relic);
+                if (threshold <= 0 || ShurikenCharge(relic) + 1 < threshold) return false;
+
+                ownerCreature = relic.Owner.Creature;
+                if (ownerCreature == null) return false;
+                strengthBefore = CurrentStrength(ownerCreature);
+                return true;
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordShurikenAttackPlayedAndShouldObserveActivation failed: {e.Message}");
+                ownerCreature = null;
+                strengthBefore = 0m;
+                return false;
+            }
+        }
+    }
+
+    public static void RecordShurikenActivation(decimal strengthGained)
+    {
+        lock (_lock)
+        {
+            try
+            {
+                var agg = GetOrCreateRelicAggregateForCurrentContextLocked(ShurikenRelicId);
+                RecordShurikenActivationForTest(agg, strengthGained);
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordShurikenActivation failed: {e.Message}");
+            }
+        }
+    }
+
+    internal static void RecordShurikenAttackPlayedForTest(RelicAggregate agg, int count = 1)
+    {
+        if (agg == null) return;
+        agg.ShurikenAttacksPlayed += Math.Max(0, count);
+    }
+
+    internal static void RecordShurikenActivationForTest(RelicAggregate agg, decimal strengthGained)
+    {
+        if (agg == null) return;
+        agg.Activations += 1;
+        agg.StrengthAdded += Math.Max(0m, strengthGained);
+    }
+
+    internal static void RecordShurikenTurnEndChargeForTest(RelicAggregate agg, int charge)
+    {
+        if (agg == null || charge < 0) return;
+
+        charge %= 3;
+        agg.ShurikenTurnEndChargeTotal += charge;
+        agg.ShurikenTurnEndChargeCount += 1;
+        if (charge == 1)
+            agg.ShurikenTurnsEndedAt1Charge += 1;
+        else if (charge == 2)
+            agg.ShurikenTurnsEndedAt2Charges += 1;
+    }
+
+    /// <summary>
+    /// Snapshot the three missing Kunai-style Attack counters at player turn
+    /// end before their game models reset them.
+    /// </summary>
+    public static void RecordUnlimitedAttackChargeRelicsTurnEnded(IEnumerable<Creature>? participants)
+    {
+        if (participants == null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                _pendingCombat ??= new PendingCombat();
+
+                foreach (var creature in participants)
+                {
+                    var player = creature?.Player;
+                    if (player == null || !IsTrackedPlayer(player)) continue;
+
+                    var turnNumber = player.PlayerCombatState?.TurnNumber ?? 0;
+                    if (turnNumber <= 0) continue;
+
+                    RecordKusarigamaTurnEndChargeForPlayerLocked(player, turnNumber);
+                    RecordOrnamentalFanTurnEndChargeForPlayerLocked(player, turnNumber);
+                    RecordShurikenTurnEndChargeForPlayerLocked(player, turnNumber);
+                }
+            }
+            catch (Exception e)
+            {
+                CoreMain.LogDebug($"RecordUnlimitedAttackChargeRelicsTurnEnded failed: {e.Message}");
+            }
+        }
+    }
+
+    private static void RecordKusarigamaTurnEndChargeForPlayerLocked(Player player, int turnNumber)
+    {
+        if (_pendingCombat == null || !TryGetKusarigama(player, out var relic) || relic == null) return;
+        if (_pendingCombat.KusarigamaTurnEndChargeRecordedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return;
+        }
+
+        _pendingCombat.KusarigamaTurnEndChargeRecordedTurns[player] = turnNumber;
+        var agg = GetOrCreatePendingRelicAggregateLocked(KusarigamaRelicId);
+        RecordKusarigamaTurnEndChargeForTest(agg, KusarigamaCharge(relic));
+    }
+
+    private static void RecordOrnamentalFanTurnEndChargeForPlayerLocked(Player player, int turnNumber)
+    {
+        if (_pendingCombat == null || !TryGetOrnamentalFan(player, out var relic) || relic == null) return;
+        if (_pendingCombat.OrnamentalFanTurnEndChargeRecordedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return;
+        }
+
+        _pendingCombat.OrnamentalFanTurnEndChargeRecordedTurns[player] = turnNumber;
+        var agg = GetOrCreatePendingRelicAggregateLocked(OrnamentalFanRelicId);
+        RecordOrnamentalFanTurnEndChargeForTest(agg, OrnamentalFanCharge(relic));
+    }
+
+    private static void RecordShurikenTurnEndChargeForPlayerLocked(Player player, int turnNumber)
+    {
+        if (_pendingCombat == null || !TryGetShuriken(player, out var relic) || relic == null) return;
+        if (_pendingCombat.ShurikenTurnEndChargeRecordedTurns.TryGetValue(player, out var recordedTurn)
+            && recordedTurn == turnNumber)
+        {
+            return;
+        }
+
+        _pendingCombat.ShurikenTurnEndChargeRecordedTurns[player] = turnNumber;
+        var agg = GetOrCreatePendingRelicAggregateLocked(ShurikenRelicId);
+        RecordShurikenTurnEndChargeForTest(agg, ShurikenCharge(relic));
+    }
+
     public static void RecordPaperPhrogVulnerableBonus(
         PaperPhrog relic,
         decimal damageAdded,
@@ -9599,6 +10032,123 @@ public static class RunTracker
         catch
         {
             return 0;
+        }
+    }
+
+    private static bool TryGetKusarigama(Player player, out Kusarigama? kusarigama)
+    {
+        kusarigama = null;
+
+        try
+        {
+            kusarigama = player?.Relics?.OfType<Kusarigama>().FirstOrDefault();
+            return kusarigama != null;
+        }
+        catch
+        {
+            kusarigama = null;
+            return false;
+        }
+    }
+
+    private static int KusarigamaCharge(Kusarigama relic)
+    {
+        var threshold = KusarigamaCardsPerActivation(relic);
+        if (threshold <= 0) return 0;
+        return Math.Max(0, relic.AttacksPlayedThisTurn) % threshold;
+    }
+
+    private static int KusarigamaCardsPerActivation(Kusarigama relic)
+    {
+        try
+        {
+            return Math.Max(1, relic.DynamicVars.Cards.IntValue);
+        }
+        catch
+        {
+            return 3;
+        }
+    }
+
+    private static bool TryGetOrnamentalFan(Player player, out OrnamentalFan? ornamentalFan)
+    {
+        ornamentalFan = null;
+
+        try
+        {
+            ornamentalFan = player?.Relics?.OfType<OrnamentalFan>().FirstOrDefault();
+            return ornamentalFan != null;
+        }
+        catch
+        {
+            ornamentalFan = null;
+            return false;
+        }
+    }
+
+    private static int OrnamentalFanCharge(OrnamentalFan relic)
+    {
+        var threshold = OrnamentalFanCardsPerActivation(relic);
+        if (threshold <= 0) return 0;
+        return Math.Max(0, relic.AttacksPlayedThisTurn) % threshold;
+    }
+
+    private static int OrnamentalFanCardsPerActivation(OrnamentalFan relic)
+    {
+        try
+        {
+            return Math.Max(1, relic.DynamicVars.Cards.IntValue);
+        }
+        catch
+        {
+            return 3;
+        }
+    }
+
+    private static bool TryGetShuriken(Player player, out Shuriken? shuriken)
+    {
+        shuriken = null;
+
+        try
+        {
+            shuriken = player?.Relics?.OfType<Shuriken>().FirstOrDefault();
+            return shuriken != null;
+        }
+        catch
+        {
+            shuriken = null;
+            return false;
+        }
+    }
+
+    private static int ShurikenCharge(Shuriken relic)
+    {
+        var threshold = ShurikenCardsPerActivation(relic);
+        if (threshold <= 0) return 0;
+        return Math.Max(0, relic.AttacksPlayedThisTurn) % threshold;
+    }
+
+    private static int ShurikenCardsPerActivation(Shuriken relic)
+    {
+        try
+        {
+            return Math.Max(1, relic.DynamicVars.Cards.IntValue);
+        }
+        catch
+        {
+            return 3;
+        }
+    }
+
+    private static decimal CurrentStrength(Creature creature)
+    {
+        try
+        {
+            return creature.GetPower<StrengthPower>()?.Amount ?? 0m;
+        }
+        catch
+        {
+            return 0m;
         }
     }
 
@@ -13156,6 +13706,12 @@ internal class PendingCombat
     public Dictionary<Player, int> PenNibTurnEndChargeRecordedTurns { get; }
         = new(ReferenceEqualityComparer.Instance);
     public Dictionary<Player, int> KunaiTurnEndChargeRecordedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> KusarigamaTurnEndChargeRecordedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> OrnamentalFanTurnEndChargeRecordedTurns { get; }
+        = new(ReferenceEqualityComparer.Instance);
+    public Dictionary<Player, int> ShurikenTurnEndChargeRecordedTurns { get; }
         = new(ReferenceEqualityComparer.Instance);
     public HashSet<Player> GamblingChipDiscardAttributionPlayers { get; }
         = new(ReferenceEqualityComparer.Instance);

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -230,6 +230,10 @@ New fixtures added going forward do not need a `v*-` prefix.
 - `kunai-relic-run.json`
   Adds Kunai attack-counter tracking: owner attack plays, activations, observed
   Dexterity gained, and 1/2 charge turn-end buckets with average charge samples.
+- `unlimited-attack-charge-relics-run.json`
+  Adds the remaining unlimited three-Attack turn counters: Kusarigama,
+  Ornamental Fan, and Shuriken, including observed damage/block/Strength
+  outcomes and 1/2 charge turn-end buckets with average charge samples.
 - `tuning-fork-relic-run.json`
   Adds Tuning Fork owner Skill-play count, trigger count, observed block
   gained, held combat/turn denominators, and turn-end charge buckets.

--- a/Fixtures/RunSchema/README.md
+++ b/Fixtures/RunSchema/README.md
@@ -130,7 +130,8 @@ New fixtures added going forward do not need a `v*-` prefix.
   combat-end charge samples for average charge.
 - `paels-wing-sacrifice-relic-run.json`
   Adds Pael's Wing sacrifice tracking: consumed card reward options split by
-  common, uncommon, and rare, plus sacrifices made and skipped.
+  common, uncommon, and rare, sacrifices made and skipped, and the total and
+  specific artifacts gained from its completed sacrifice pairs.
 - `paels-eye-relic-run.json`
   Adds Pael's Eye activation tracking plus counts of status and curse cards
   actually exhausted by its extra-turn callback, and combats where it was held

--- a/Fixtures/RunSchema/paels-wing-sacrifice-relic-run.json
+++ b/Fixtures/RunSchema/paels-wing-sacrifice-relic-run.json
@@ -18,7 +18,14 @@
       "uncommon_cards_consumed": 3,
       "rare_cards_consumed": 1,
       "sacrifices_made": 3,
-      "sacrifices_skipped": 2
+      "sacrifices_skipped": 2,
+      "relics_granted": {
+        "RELIC.KUNAI": {
+          "relic_id": "RELIC.KUNAI",
+          "display_name": "Kunai",
+          "count": 1
+        }
+      }
     }
   },
   "meta_stats": {},

--- a/Fixtures/RunSchema/unlimited-attack-charge-relics-run.json
+++ b/Fixtures/RunSchema/unlimited-attack-charge-relics-run.json
@@ -1,0 +1,45 @@
+{
+  "run_id": "unlimited-attack-charge-relics-fixture",
+  "started_at": "2026-07-13T17:00:00Z",
+  "updated_at": "2026-07-13T17:12:00Z",
+  "outcome": "in_progress",
+  "aggregates": {},
+  "events": [],
+  "relic_aggregates": {
+    "RELIC.KUSARIGAMA": {
+      "kusarigama_attacks_played": 14,
+      "activations": 4,
+      "total_damage_attempted": 24,
+      "total_damage_dealt": 17,
+      "total_damage_blocked": 3,
+      "total_damage_overkill": 4,
+      "kills": 2,
+      "total_targets": 4,
+      "kusarigama_turns_ended_at1_charge": 2,
+      "kusarigama_turns_ended_at2_charges": 3,
+      "kusarigama_turn_end_charge_total": 8,
+      "kusarigama_turn_end_charge_count": 7
+    },
+    "RELIC.ORNAMENTAL_FAN": {
+      "ornamental_fan_attacks_played": 11,
+      "activations": 3,
+      "additional_block_gained": 13,
+      "ornamental_fan_turns_ended_at1_charge": 1,
+      "ornamental_fan_turns_ended_at2_charges": 3,
+      "ornamental_fan_turn_end_charge_total": 7,
+      "ornamental_fan_turn_end_charge_count": 5
+    },
+    "RELIC.SHURIKEN": {
+      "shuriken_attacks_played": 17,
+      "activations": 5,
+      "strength_added": 5,
+      "shuriken_turns_ended_at1_charge": 2,
+      "shuriken_turns_ended_at2_charges": 2,
+      "shuriken_turn_end_charge_total": 6,
+      "shuriken_turn_end_charge_count": 6
+    }
+  },
+  "meta_stats": {},
+  "instance_numbers_by_def": {},
+  "def_counters": {}
+}

--- a/Tests/SpireLens.Core.Tests/BrightestFlameStorybookStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/BrightestFlameStorybookStatsTests.cs
@@ -28,6 +28,7 @@ public class BrightestFlameStorybookStatsTests
     };
 
     [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void Patch_TargetsBrightestFlameOnPlayWithExpectedParameters()
     {
         var target = TargetMethod.Invoke(null, null) as MethodBase;
@@ -96,7 +97,7 @@ public class BrightestFlameStorybookStatsTests
     [Fact]
     public void CardTooltip_BrightestFlame_ShowsMaxHpLostInFullAndCompactViews()
     {
-        var card = new BrightestFlame();
+        var card = (BrightestFlame)RuntimeHelpers.GetUninitializedObject(typeof(BrightestFlame));
         var agg = new CardAggregate { TotalMaxHpLost = 4 };
 
         var full = CardHoverShowPatch.BuildHistoricalBodyBBCode(card, agg, new RunMetaStats());

--- a/Tests/SpireLens.Core.Tests/BrightestFlameStorybookStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/BrightestFlameStorybookStatsTests.cs
@@ -95,6 +95,7 @@ public class BrightestFlameStorybookStatsTests
     }
 
     [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void CardTooltip_BrightestFlame_ShowsMaxHpLostInFullAndCompactViews()
     {
         var card = (BrightestFlame)RuntimeHelpers.GetUninitializedObject(typeof(BrightestFlame));

--- a/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
+++ b/Tests/SpireLens.Core.Tests/HookPatchTargetTests.cs
@@ -131,6 +131,28 @@ public class HookPatchTargetTests
 
     [Fact]
     [Trait("Category", "RequiresLiveGame")]
+    public void UnlimitedAttackChargeRelicsTurnEndPatch_ResolvesBeforeSideTurnEnd()
+    {
+        var target = InvokeTargetMethod(typeof(HookBeforeSideTurnEndUnlimitedAttackChargeRelicsPatch));
+
+        Assert.NotNull(target);
+        Assert.Equal("MegaCrit.Sts2.Core.Hooks.Hook", target!.DeclaringType?.FullName);
+        Assert.Contains(target.Name, new[] { "BeforeSideTurnEnd", "BeforeTurnEnd" });
+        Assert.Equal(
+            new[]
+            {
+                "side",
+                "participants",
+            },
+            target.GetParameters().Select(parameter => parameter.Name).ToArray());
+
+        var sideParameter = target.GetParameters().SingleOrDefault(parameter => parameter.Name == "side");
+        Assert.NotNull(sideParameter);
+        Assert.Equal("MegaCrit.Sts2.Core.Combat.CombatSide", sideParameter!.ParameterType.FullName);
+    }
+
+    [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void TuningForkTurnEndPatch_ResolvesBeforeSideTurnEnd()
     {
         var target = InvokeTargetMethod(typeof(HookBeforeSideTurnEndTuningForkPatch));

--- a/Tests/SpireLens.Core.Tests/PaelsWingStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/PaelsWingStatsTests.cs
@@ -36,6 +36,7 @@ public class PaelsWingStatsTests
         Assert.Equal(0, agg.RareCardsConsumed);
         Assert.Equal(0, agg.SacrificesMade);
         Assert.Equal(0, agg.SacrificesSkipped);
+        Assert.Empty(agg.RelicsGranted);
     }
 
     [Fact]
@@ -48,6 +49,15 @@ public class PaelsWingStatsTests
             RareCardsConsumed = 1,
             SacrificesMade = 3,
             SacrificesSkipped = 2,
+            RelicsGranted =
+            {
+                ["RELIC.KUNAI"] = new RelicGrantedAggregate
+                {
+                    RelicId = "RELIC.KUNAI",
+                    DisplayName = "Kunai",
+                    Count = 1,
+                },
+            },
         };
         var run = new RunData();
         run.RelicAggregates[PaelsWingRelicId] = agg;
@@ -59,6 +69,7 @@ public class PaelsWingStatsTests
         Assert.Contains("rare_cards_consumed", json);
         Assert.Contains("sacrifices_made", json);
         Assert.Contains("sacrifices_skipped", json);
+        Assert.Contains("relics_granted", json);
 
         var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
 
@@ -70,6 +81,8 @@ public class PaelsWingStatsTests
         Assert.Equal(1, restoredAgg.RareCardsConsumed);
         Assert.Equal(3, restoredAgg.SacrificesMade);
         Assert.Equal(2, restoredAgg.SacrificesSkipped);
+        Assert.Equal(1, restoredAgg.RelicsGranted["RELIC.KUNAI"].Count);
+        Assert.Equal("Kunai", restoredAgg.RelicsGranted["RELIC.KUNAI"].DisplayName);
     }
 
     [Fact]
@@ -82,6 +95,21 @@ public class PaelsWingStatsTests
             RareCardsConsumed = 1,
             SacrificesMade = 3,
             SacrificesSkipped = 2,
+            RelicsGranted =
+            {
+                ["RELIC.KUNAI"] = new RelicGrantedAggregate
+                {
+                    RelicId = "RELIC.KUNAI",
+                    DisplayName = "Kunai",
+                    Count = 2,
+                },
+                ["RELIC.BAG_OF_PREPARATION"] = new RelicGrantedAggregate
+                {
+                    RelicId = "RELIC.BAG_OF_PREPARATION",
+                    DisplayName = "Bag of Preparation",
+                    Count = 1,
+                },
+            },
         };
 
         var body = (string)(BuildPaelsWingBodyMethod.Invoke(null, new object?[] { agg })
@@ -92,12 +120,36 @@ public class PaelsWingStatsTests
         Assert.Contains("rare cards consumed", body);
         Assert.Contains("Sacrifices made", body);
         Assert.Contains("Sacrifices skipped", body);
+        Assert.Contains("Artifacts gained", body);
+        Assert.Contains("Artifact gained", body);
+        Assert.Contains("Kunai x2", body);
+        Assert.Contains("Bag of Preparation", body);
         Assert.DoesNotContain("Sacrifice rate", body);
         Assert.DoesNotContain("/floor", body);
         Assert.Contains("[b]5[/b]", body);
         Assert.Contains("[b]3[/b]", body);
         Assert.Contains("[b]2[/b]", body);
         Assert.Contains("[b]1[/b]", body);
+    }
+
+    [Fact]
+    public void RunTracker_PaelsWingHelper_RecordsEachArtifactGained()
+    {
+        var agg = new RelicAggregate();
+
+        RunTracker.RecordPaelsWingArtifactGainedForTest(agg, "RELIC.KUNAI", "Kunai");
+        RunTracker.RecordPaelsWingArtifactGainedForTest(agg, "RELIC.KUNAI", "Kunai");
+        RunTracker.RecordPaelsWingArtifactGainedForTest(
+            agg,
+            "RELIC.BAG_OF_PREPARATION",
+            "Bag of Preparation");
+        RunTracker.RecordPaelsWingArtifactGainedForTest(agg, null, null);
+
+        Assert.Equal(2, agg.RelicsGranted.Count);
+        Assert.Equal(2, agg.RelicsGranted["RELIC.KUNAI"].Count);
+        Assert.Equal("Kunai", agg.RelicsGranted["RELIC.KUNAI"].DisplayName);
+        Assert.Equal(1, agg.RelicsGranted["RELIC.BAG_OF_PREPARATION"].Count);
+        Assert.Equal("Bag of Preparation", agg.RelicsGranted["RELIC.BAG_OF_PREPARATION"].DisplayName);
     }
 
     [Fact]
@@ -164,5 +216,6 @@ public class PaelsWingStatsTests
         Assert.Equal(0, agg.RareCardsConsumed);
         Assert.Equal(0, agg.SacrificesMade);
         Assert.Equal(0, agg.SacrificesSkipped);
+        Assert.Empty(agg.RelicsGranted);
     }
 }

--- a/Tests/SpireLens.Core.Tests/RazorToothStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/RazorToothStatsTests.cs
@@ -32,6 +32,7 @@ public class RazorToothStatsTests
     };
 
     [Fact]
+    [Trait("Category", "RequiresLiveGame")]
     public void Patch_TargetsRazorToothAfterCardPlayedWithExpectedParameters()
     {
         var target = TargetMethod.Invoke(null, null) as MethodBase;

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -7,15 +7,10 @@ namespace SpireLens.Core.Tests;
 public class RelicCompendiumFilterTests
 {
     [Fact]
-    public void EnergyTaxonomy_IncludesTrackedEnergyRelics()
+    public void Taxonomy_OmitsRemovedEnergyCategory()
     {
-        var energy = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.EnergyCategoryId);
-
-        Assert.Contains("RELIC.HAPPY_FLOWER", energy.RelicIds);
-        Assert.Contains("RELIC.NUNCHAKU", energy.RelicIds);
-        Assert.Contains("RELIC.BOOMING_CONCH", energy.RelicIds);
-        Assert.Contains("RELIC.PRISMATIC_GEM", energy.RelicIds);
-        Assert.Contains("RELIC.BRILLIANT_SCARF", energy.RelicIds);
+        Assert.DoesNotContain(RelicTaxonomy.Categories, category => category.Id == "energy");
+        Assert.DoesNotContain(RelicTaxonomy.Categories, category => category.DisplayName == "Energy relics");
     }
 
     [Fact]
@@ -49,16 +44,8 @@ public class RelicCompendiumFilterTests
     [Fact]
     public void IsRelicInAnySelectedCategory_UsesSelectedCategories()
     {
-        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
-            "RELIC.LANTERN",
-            new[] { RelicTaxonomy.EnergyCategoryId }));
-
         Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
-            "RELIC.ANCHOR",
-            new[] { RelicTaxonomy.EnergyCategoryId }));
-
-        Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
-            "RELIC.LANTERN",
+            "RELIC.PEN_NIB",
             Enumerable.Empty<string>()));
 
         Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -79,13 +79,16 @@ public class RelicCompendiumFilterTests
         var charge = RelicTaxonomy.LeafCategories.Single(
             c => c.Id == RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId);
 
-        Assert.Contains("RELIC.BRILLIANT_SCARF", charge.RelicIds);
-        Assert.Contains("RELIC.DIAMOND_DIADEM", charge.RelicIds);
-        Assert.Contains("RELIC.POCKETWATCH", charge.RelicIds);
-        Assert.Contains("RELIC.RAINBOW_RING", charge.RelicIds);
-        Assert.Contains("RELIC.VELVET_CHOKER", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.KUNAI", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.SHURIKEN", charge.RelicIds);
+        Assert.Equal(
+            new[]
+            {
+                "RELIC.BRILLIANT_SCARF",
+                "RELIC.DIAMOND_DIADEM",
+                "RELIC.POCKETWATCH",
+                "RELIC.RAINBOW_RING",
+                "RELIC.VELVET_CHOKER",
+            },
+            charge.RelicIds.OrderBy(id => id, StringComparer.Ordinal).ToArray());
     }
 
     [Fact]
@@ -94,13 +97,16 @@ public class RelicCompendiumFilterTests
         var charge = RelicTaxonomy.LeafCategories.Single(
             c => c.Id == RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId);
 
-        Assert.Contains("RELIC.KUNAI", charge.RelicIds);
-        Assert.Contains("RELIC.KUSARIGAMA", charge.RelicIds);
-        Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
-        Assert.Contains("RELIC.ORNAMENTAL_FAN", charge.RelicIds);
-        Assert.Contains("RELIC.SHURIKEN", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.BRILLIANT_SCARF", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.VELVET_CHOKER", charge.RelicIds);
+        Assert.Equal(
+            new[]
+            {
+                "RELIC.KUNAI",
+                "RELIC.KUSARIGAMA",
+                "RELIC.LETTER_OPENER",
+                "RELIC.ORNAMENTAL_FAN",
+                "RELIC.SHURIKEN",
+            },
+            charge.RelicIds.OrderBy(id => id, StringComparer.Ordinal).ToArray());
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -16,7 +16,7 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
-    public void ChargeTaxonomy_NestsChargeLeavesUnderChargeGroup()
+    public void ChargeTaxonomy_NestsActivationLeavesUnderResetsEachTurn()
     {
         var charge = RelicTaxonomy.RootCategories.Single();
 
@@ -33,9 +33,29 @@ public class RelicCompendiumFilterTests
         Assert.Equal(
             new[] { "Across turns", "Resets each turn" },
             charge.Children.Select(category => category.DisplayName).ToArray());
+
+        var resetsEachTurn = charge.Children.Single(
+            category => category.Id == RelicTaxonomy.ChargeResetsEachTurnCategoryId);
+
+        Assert.Empty(resetsEachTurn.RelicIds);
         Assert.Equal(
-            charge.Children.ToArray(),
-            RelicTaxonomy.LeafCategories.ToArray());
+            new[]
+            {
+                RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId,
+            },
+            resetsEachTurn.Children.Select(category => category.Id).ToArray());
+        Assert.Equal(
+            new[] { "Limited activations", "Unlimited activations" },
+            resetsEachTurn.Children.Select(category => category.DisplayName).ToArray());
+        Assert.Equal(
+            new[]
+            {
+                RelicTaxonomy.ChargeAcrossTurnsCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId,
+            },
+            RelicTaxonomy.LeafCategories.Select(category => category.Id).ToArray());
     }
 
     [Fact]
@@ -54,18 +74,33 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
-    public void ChargeResetsEachTurnTaxonomy_IncludesTurnLocalIncrementingRelics()
+    public void ChargeResetsEachTurnLimitedActivationsTaxonomy_IncludesCappedRelics()
     {
         var charge = RelicTaxonomy.LeafCategories.Single(
-            c => c.Id == RelicTaxonomy.ChargeResetsEachTurnCategoryId);
+            c => c.Id == RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId);
 
-        Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
-        Assert.Contains("RELIC.KUNAI", charge.RelicIds);
-        Assert.Contains("RELIC.SHURIKEN", charge.RelicIds);
         Assert.Contains("RELIC.BRILLIANT_SCARF", charge.RelicIds);
+        Assert.Contains("RELIC.DIAMOND_DIADEM", charge.RelicIds);
+        Assert.Contains("RELIC.POCKETWATCH", charge.RelicIds);
+        Assert.Contains("RELIC.RAINBOW_RING", charge.RelicIds);
         Assert.Contains("RELIC.VELVET_CHOKER", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.PEN_NIB", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.NUNCHAKU", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.KUNAI", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.SHURIKEN", charge.RelicIds);
+    }
+
+    [Fact]
+    public void ChargeResetsEachTurnUnlimitedActivationsTaxonomy_IncludesRepeatableRelics()
+    {
+        var charge = RelicTaxonomy.LeafCategories.Single(
+            c => c.Id == RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId);
+
+        Assert.Contains("RELIC.KUNAI", charge.RelicIds);
+        Assert.Contains("RELIC.KUSARIGAMA", charge.RelicIds);
+        Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
+        Assert.Contains("RELIC.ORNAMENTAL_FAN", charge.RelicIds);
+        Assert.Contains("RELIC.SHURIKEN", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.BRILLIANT_SCARF", charge.RelicIds);
+        Assert.DoesNotContain("RELIC.VELVET_CHOKER", charge.RelicIds);
     }
 
     [Fact]
@@ -81,11 +116,15 @@ public class RelicCompendiumFilterTests
 
         Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.LETTER_OPENER",
-            new[] { RelicTaxonomy.ChargeResetsEachTurnCategoryId }));
+            new[] { RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId }));
+
+        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.BRILLIANT_SCARF",
+            new[] { RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId }));
 
         Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.PEN_NIB",
-            new[] { RelicTaxonomy.ChargeResetsEachTurnCategoryId }));
+            new[] { RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId }));
     }
 
     [Fact]
@@ -106,7 +145,8 @@ public class RelicCompendiumFilterTests
             new[]
             {
                 RelicTaxonomy.ChargeAcrossTurnsCategoryId,
-                RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId,
             },
             selected.OrderBy(id => id, StringComparer.Ordinal).ToArray());
         Assert.Equal(
@@ -127,7 +167,7 @@ public class RelicCompendiumFilterTests
             RelicTaxonomy.ChargeCategoryId,
             selected: true);
 
-        Assert.Equal(2, selected.Count);
+        Assert.Equal(3, selected.Count);
         Assert.Equal(
             RelicTaxonomyCategorySelectionState.Selected,
             RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
@@ -141,6 +181,33 @@ public class RelicCompendiumFilterTests
         Assert.Equal(
             RelicTaxonomyCategorySelectionState.Unselected,
             RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
+    }
+
+    [Fact]
+    public void ResetsEachTurnSelection_ReflectsMixedActivationChildren()
+    {
+        var selected = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId,
+        };
+
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Partial,
+            RelicTaxonomy.GetSelectionState(
+                RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+                selected));
+
+        RelicTaxonomy.SetCategorySelection(
+            selected,
+            RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+            selected: true);
+
+        Assert.Equal(2, selected.Count);
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Selected,
+            RelicTaxonomy.GetSelectionState(
+                RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+                selected));
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -16,7 +16,7 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
-    public void ChargeTaxonomy_NestsActivationLeavesUnderResetsEachTurn()
+    public void ChargeTaxonomy_NestsCombatAndTurnResetGroups()
     {
         var charge = RelicTaxonomy.RootCategories.Single();
 
@@ -26,13 +26,29 @@ public class RelicCompendiumFilterTests
         Assert.Equal(
             new[]
             {
+                RelicTaxonomy.ChargeAcrossCombatsCategoryId,
                 RelicTaxonomy.ChargeAcrossTurnsCategoryId,
                 RelicTaxonomy.ChargeResetsEachTurnCategoryId,
             },
             charge.Children.Select(category => category.Id).ToArray());
         Assert.Equal(
-            new[] { "Across turns", "Resets each turn" },
+            new[] { "Across combats", "Across turns", "Resets each turn" },
             charge.Children.Select(category => category.DisplayName).ToArray());
+
+        var acrossCombats = charge.Children.Single(
+            category => category.Id == RelicTaxonomy.ChargeAcrossCombatsCategoryId);
+
+        Assert.Empty(acrossCombats.RelicIds);
+        Assert.Equal(
+            new[]
+            {
+                RelicTaxonomy.ChargeAcrossCombatsCyclingCategoryId,
+                RelicTaxonomy.ChargeAcrossCombatsNonCyclingCategoryId,
+            },
+            acrossCombats.Children.Select(category => category.Id).ToArray());
+        Assert.Equal(
+            new[] { "Cycling", "Non-cycling" },
+            acrossCombats.Children.Select(category => category.DisplayName).ToArray());
 
         var resetsEachTurn = charge.Children.Single(
             category => category.Id == RelicTaxonomy.ChargeResetsEachTurnCategoryId);
@@ -51,6 +67,8 @@ public class RelicCompendiumFilterTests
         Assert.Equal(
             new[]
             {
+                RelicTaxonomy.ChargeAcrossCombatsCyclingCategoryId,
+                RelicTaxonomy.ChargeAcrossCombatsNonCyclingCategoryId,
                 RelicTaxonomy.ChargeAcrossTurnsCategoryId,
                 RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId,
                 RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId,
@@ -59,18 +77,68 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
-    public void ChargeAcrossTurnsTaxonomy_IncludesPersistentIncrementingRelics()
+    public void ChargeAcrossTurnsTaxonomy_IncludesOnlyCombatLocalCounters()
     {
         var charge = RelicTaxonomy.LeafCategories.Single(
             c => c.Id == RelicTaxonomy.ChargeAcrossTurnsCategoryId);
 
-        Assert.Contains("RELIC.PEN_NIB", charge.RelicIds);
-        Assert.Contains("RELIC.NUNCHAKU", charge.RelicIds);
-        Assert.Contains("RELIC.IRON_CLUB", charge.RelicIds);
-        Assert.Contains("RELIC.HAPPY_FLOWER", charge.RelicIds);
-        Assert.Contains("RELIC.WINGED_BOOTS", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.LETTER_OPENER", charge.RelicIds);
-        Assert.DoesNotContain("RELIC.VELVET_CHOKER", charge.RelicIds);
+        Assert.Equal(
+            new[]
+            {
+                "RELIC.METRONOME",
+                "RELIC.PAELS_FLESH",
+                "RELIC.PAELS_LEGION",
+                "RELIC.STONE_CALENDAR",
+            },
+            charge.RelicIds.OrderBy(id => id, StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public void ChargeAcrossCombatsCyclingTaxonomy_IncludesRestartingCounters()
+    {
+        var charge = RelicTaxonomy.LeafCategories.Single(
+            c => c.Id == RelicTaxonomy.ChargeAcrossCombatsCyclingCategoryId);
+
+        Assert.Equal(
+            new[]
+            {
+                "RELIC.BOOK_OF_FIVE_RINGS",
+                "RELIC.FAKE_HAPPY_FLOWER",
+                "RELIC.FISHING_ROD",
+                "RELIC.GALACTIC_DUST",
+                "RELIC.HAPPY_FLOWER",
+                "RELIC.IRON_CLUB",
+                "RELIC.JOSS_PAPER",
+                "RELIC.LASTING_CANDY",
+                "RELIC.NUNCHAKU",
+                "RELIC.PAELS_WING",
+                "RELIC.PENDULUM",
+                "RELIC.PEN_NIB",
+                "RELIC.POLLINOUS_CORE",
+                "RELIC.TOY_BOX",
+                "RELIC.TUNING_FORK",
+            },
+            charge.RelicIds.OrderBy(id => id, StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public void ChargeAcrossCombatsNonCyclingTaxonomy_IncludesNonWrappingCounters()
+    {
+        var charge = RelicTaxonomy.LeafCategories.Single(
+            c => c.Id == RelicTaxonomy.ChargeAcrossCombatsNonCyclingCategoryId);
+
+        Assert.Equal(
+            new[]
+            {
+                "RELIC.GIRYA",
+                "RELIC.PAELS_TOOTH",
+                "RELIC.PUMPKIN_CANDLE",
+                "RELIC.SILVER_CRUCIBLE",
+                "RELIC.SWORD_OF_STONE",
+                "RELIC.WINGED_BOOTS",
+                "RELIC.WONGOS_MYSTERY_TICKET",
+            },
+            charge.RelicIds.OrderBy(id => id, StringComparer.Ordinal).ToArray());
     }
 
     [Fact]
@@ -118,6 +186,14 @@ public class RelicCompendiumFilterTests
 
         Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.PEN_NIB",
+            new[] { RelicTaxonomy.ChargeAcrossCombatsCyclingCategoryId }));
+
+        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.GIRYA",
+            new[] { RelicTaxonomy.ChargeAcrossCombatsNonCyclingCategoryId }));
+
+        Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
+            "RELIC.METRONOME",
             new[] { RelicTaxonomy.ChargeAcrossTurnsCategoryId }));
 
         Assert.True(RelicTaxonomy.IsRelicInAnySelectedCategory(
@@ -150,6 +226,8 @@ public class RelicCompendiumFilterTests
         Assert.Equal(
             new[]
             {
+                RelicTaxonomy.ChargeAcrossCombatsCyclingCategoryId,
+                RelicTaxonomy.ChargeAcrossCombatsNonCyclingCategoryId,
                 RelicTaxonomy.ChargeAcrossTurnsCategoryId,
                 RelicTaxonomy.ChargeResetsEachTurnLimitedActivationsCategoryId,
                 RelicTaxonomy.ChargeResetsEachTurnUnlimitedActivationsCategoryId,
@@ -173,7 +251,7 @@ public class RelicCompendiumFilterTests
             RelicTaxonomy.ChargeCategoryId,
             selected: true);
 
-        Assert.Equal(3, selected.Count);
+        Assert.Equal(5, selected.Count);
         Assert.Equal(
             RelicTaxonomyCategorySelectionState.Selected,
             RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
@@ -187,6 +265,33 @@ public class RelicCompendiumFilterTests
         Assert.Equal(
             RelicTaxonomyCategorySelectionState.Unselected,
             RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
+    }
+
+    [Fact]
+    public void AcrossCombatsSelection_ReflectsMixedCyclingChildren()
+    {
+        var selected = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            RelicTaxonomy.ChargeAcrossCombatsCyclingCategoryId,
+        };
+
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Partial,
+            RelicTaxonomy.GetSelectionState(
+                RelicTaxonomy.ChargeAcrossCombatsCategoryId,
+                selected));
+
+        RelicTaxonomy.SetCategorySelection(
+            selected,
+            RelicTaxonomy.ChargeAcrossCombatsCategoryId,
+            selected: true);
+
+        Assert.Equal(2, selected.Count);
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Selected,
+            RelicTaxonomy.GetSelectionState(
+                RelicTaxonomy.ChargeAcrossCombatsCategoryId,
+                selected));
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
+++ b/Tests/SpireLens.Core.Tests/RelicCompendiumFilterTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using SpireLens.Core.Patches;
 using Xunit;
@@ -14,9 +16,33 @@ public class RelicCompendiumFilterTests
     }
 
     [Fact]
+    public void ChargeTaxonomy_NestsChargeLeavesUnderChargeGroup()
+    {
+        var charge = RelicTaxonomy.RootCategories.Single();
+
+        Assert.Equal(RelicTaxonomy.ChargeCategoryId, charge.Id);
+        Assert.Equal("Charge", charge.DisplayName);
+        Assert.Empty(charge.RelicIds);
+        Assert.Equal(
+            new[]
+            {
+                RelicTaxonomy.ChargeAcrossTurnsCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+            },
+            charge.Children.Select(category => category.Id).ToArray());
+        Assert.Equal(
+            new[] { "Across turns", "Resets each turn" },
+            charge.Children.Select(category => category.DisplayName).ToArray());
+        Assert.Equal(
+            charge.Children.ToArray(),
+            RelicTaxonomy.LeafCategories.ToArray());
+    }
+
+    [Fact]
     public void ChargeAcrossTurnsTaxonomy_IncludesPersistentIncrementingRelics()
     {
-        var charge = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.ChargeAcrossTurnsCategoryId);
+        var charge = RelicTaxonomy.LeafCategories.Single(
+            c => c.Id == RelicTaxonomy.ChargeAcrossTurnsCategoryId);
 
         Assert.Contains("RELIC.PEN_NIB", charge.RelicIds);
         Assert.Contains("RELIC.NUNCHAKU", charge.RelicIds);
@@ -30,7 +56,8 @@ public class RelicCompendiumFilterTests
     [Fact]
     public void ChargeResetsEachTurnTaxonomy_IncludesTurnLocalIncrementingRelics()
     {
-        var charge = RelicTaxonomy.Categories.Single(c => c.Id == RelicTaxonomy.ChargeResetsEachTurnCategoryId);
+        var charge = RelicTaxonomy.LeafCategories.Single(
+            c => c.Id == RelicTaxonomy.ChargeResetsEachTurnCategoryId);
 
         Assert.Contains("RELIC.LETTER_OPENER", charge.RelicIds);
         Assert.Contains("RELIC.KUNAI", charge.RelicIds);
@@ -59,6 +86,61 @@ public class RelicCompendiumFilterTests
         Assert.False(RelicTaxonomy.IsRelicInAnySelectedCategory(
             "RELIC.PEN_NIB",
             new[] { RelicTaxonomy.ChargeResetsEachTurnCategoryId }));
+    }
+
+    [Fact]
+    public void ChargeSelection_ParentControlsLeavesAndReflectsPartialState()
+    {
+        var selected = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Unselected,
+            RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
+
+        RelicTaxonomy.SetCategorySelection(
+            selected,
+            RelicTaxonomy.ChargeCategoryId,
+            selected: true);
+
+        Assert.Equal(
+            new[]
+            {
+                RelicTaxonomy.ChargeAcrossTurnsCategoryId,
+                RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+            },
+            selected.OrderBy(id => id, StringComparer.Ordinal).ToArray());
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Selected,
+            RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
+
+        RelicTaxonomy.SetCategorySelection(
+            selected,
+            RelicTaxonomy.ChargeResetsEachTurnCategoryId,
+            selected: false);
+
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Partial,
+            RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
+
+        RelicTaxonomy.SetCategorySelection(
+            selected,
+            RelicTaxonomy.ChargeCategoryId,
+            selected: true);
+
+        Assert.Equal(2, selected.Count);
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Selected,
+            RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
+
+        RelicTaxonomy.SetCategorySelection(
+            selected,
+            RelicTaxonomy.ChargeCategoryId,
+            selected: false);
+
+        Assert.Empty(selected);
+        Assert.Equal(
+            RelicTaxonomyCategorySelectionState.Unselected,
+            RelicTaxonomy.GetSelectionState(RelicTaxonomy.ChargeCategoryId, selected));
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -1388,6 +1388,8 @@ public class SchemaLoadingTests
         Assert.Equal(1, relicAgg.RareCardsConsumed);
         Assert.Equal(3, relicAgg.SacrificesMade);
         Assert.Equal(2, relicAgg.SacrificesSkipped);
+        Assert.Equal(1, relicAgg.RelicsGranted["RELIC.KUNAI"].Count);
+        Assert.Equal("Kunai", relicAgg.RelicsGranted["RELIC.KUNAI"].DisplayName);
     }
 
     [Fact]
@@ -1402,6 +1404,8 @@ public class SchemaLoadingTests
         Assert.Equal(1, relicAgg.RareCardsConsumed);
         Assert.Equal(3, relicAgg.SacrificesMade);
         Assert.Equal(2, relicAgg.SacrificesSkipped);
+        Assert.Equal(1, relicAgg.RelicsGranted["RELIC.KUNAI"].Count);
+        Assert.Equal("Kunai", relicAgg.RelicsGranted["RELIC.KUNAI"].DisplayName);
     }
 
     [Fact]

--- a/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
+++ b/Tests/SpireLens.Core.Tests/SchemaLoadingTests.cs
@@ -2318,6 +2318,87 @@ public class SchemaLoadingTests
     }
 
     [Fact]
+    public void HistoricalLoad_AcceptsUnlimitedAttackChargeRelicsFixture()
+    {
+        var loaded = RunStorage.LoadHistorical(FixturePath("unlimited-attack-charge-relics-run.json"));
+
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.SupportsResume);
+
+        var kusarigama = loaded.Data.RelicAggregates["RELIC.KUSARIGAMA"];
+        Assert.Equal(14, kusarigama.KusarigamaAttacksPlayed);
+        Assert.Equal(4, kusarigama.Activations);
+        Assert.Equal(24, kusarigama.TotalDamageAttempted);
+        Assert.Equal(17, kusarigama.TotalDamageDealt);
+        Assert.Equal(3, kusarigama.TotalDamageBlocked);
+        Assert.Equal(4, kusarigama.TotalDamageOverkill);
+        Assert.Equal(2, kusarigama.Kills);
+        Assert.Equal(4, kusarigama.TotalTargets);
+        Assert.Equal(2, kusarigama.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(3, kusarigama.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(8, kusarigama.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(7, kusarigama.KusarigamaTurnEndChargeCount);
+
+        var ornamentalFan = loaded.Data.RelicAggregates["RELIC.ORNAMENTAL_FAN"];
+        Assert.Equal(11, ornamentalFan.OrnamentalFanAttacksPlayed);
+        Assert.Equal(3, ornamentalFan.Activations);
+        Assert.Equal(13, ornamentalFan.AdditionalBlockGained);
+        Assert.Equal(1, ornamentalFan.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(3, ornamentalFan.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(7, ornamentalFan.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(5, ornamentalFan.OrnamentalFanTurnEndChargeCount);
+
+        var shuriken = loaded.Data.RelicAggregates["RELIC.SHURIKEN"];
+        Assert.Equal(17, shuriken.ShurikenAttacksPlayed);
+        Assert.Equal(5, shuriken.Activations);
+        Assert.Equal(5m, shuriken.StrengthAdded);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeTotal);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void ResumableLoad_AcceptsUnlimitedAttackChargeRelicsFixture()
+    {
+        var resumed = RunStorage.LoadResumable(FixturePath("unlimited-attack-charge-relics-run.json"));
+
+        Assert.NotNull(resumed);
+
+        var kusarigama = resumed!.RelicAggregates["RELIC.KUSARIGAMA"];
+        Assert.Equal(14, kusarigama.KusarigamaAttacksPlayed);
+        Assert.Equal(4, kusarigama.Activations);
+        Assert.Equal(24, kusarigama.TotalDamageAttempted);
+        Assert.Equal(17, kusarigama.TotalDamageDealt);
+        Assert.Equal(3, kusarigama.TotalDamageBlocked);
+        Assert.Equal(4, kusarigama.TotalDamageOverkill);
+        Assert.Equal(2, kusarigama.Kills);
+        Assert.Equal(4, kusarigama.TotalTargets);
+        Assert.Equal(2, kusarigama.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(3, kusarigama.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(8, kusarigama.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(7, kusarigama.KusarigamaTurnEndChargeCount);
+
+        var ornamentalFan = resumed.RelicAggregates["RELIC.ORNAMENTAL_FAN"];
+        Assert.Equal(11, ornamentalFan.OrnamentalFanAttacksPlayed);
+        Assert.Equal(3, ornamentalFan.Activations);
+        Assert.Equal(13, ornamentalFan.AdditionalBlockGained);
+        Assert.Equal(1, ornamentalFan.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(3, ornamentalFan.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(7, ornamentalFan.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(5, ornamentalFan.OrnamentalFanTurnEndChargeCount);
+
+        var shuriken = resumed.RelicAggregates["RELIC.SHURIKEN"];
+        Assert.Equal(17, shuriken.ShurikenAttacksPlayed);
+        Assert.Equal(5, shuriken.Activations);
+        Assert.Equal(5m, shuriken.StrengthAdded);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeTotal);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeCount);
+    }
+
+    [Fact]
     public void HistoricalLoad_AcceptsPaperPhrogRelicFixture()
     {
         var loaded = RunStorage.LoadHistorical(FixturePath("paper-phrog-relic-run.json"));

--- a/Tests/SpireLens.Core.Tests/UnlimitedAttackChargeRelicStatsTests.cs
+++ b/Tests/SpireLens.Core.Tests/UnlimitedAttackChargeRelicStatsTests.cs
@@ -1,0 +1,527 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MegaCrit.Sts2.Core.Models.Relics;
+using SpireLens.Core;
+using SpireLens.Core.Patches;
+using Xunit;
+
+namespace SpireLens.Core.Tests;
+
+public class UnlimitedAttackChargeRelicStatsTests
+{
+    private const string KusarigamaRelicId = "RELIC.KUSARIGAMA";
+    private const string OrnamentalFanRelicId = "RELIC.ORNAMENTAL_FAN";
+    private const string ShurikenRelicId = "RELIC.SHURIKEN";
+
+    private static readonly MethodInfo BuildKusarigamaBodyMethod = GetBuilder("BuildKusarigamaBodyBBCode");
+    private static readonly MethodInfo BuildOrnamentalFanBodyMethod = GetBuilder("BuildOrnamentalFanBodyBBCode");
+    private static readonly MethodInfo BuildShurikenBodyMethod = GetBuilder("BuildShurikenBodyBBCode");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void RelicAggregate_UnlimitedAttackChargeFields_DefaultToZero()
+    {
+        var agg = new RelicAggregate();
+
+        Assert.Equal(0, agg.KusarigamaAttacksPlayed);
+        Assert.Equal(0, agg.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(0, agg.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(0, agg.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(0, agg.KusarigamaTurnEndChargeCount);
+
+        Assert.Equal(0, agg.OrnamentalFanAttacksPlayed);
+        Assert.Equal(0, agg.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(0, agg.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(0, agg.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(0, agg.OrnamentalFanTurnEndChargeCount);
+
+        Assert.Equal(0, agg.ShurikenAttacksPlayed);
+        Assert.Equal(0, agg.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(0, agg.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(0, agg.ShurikenTurnEndChargeTotal);
+        Assert.Equal(0, agg.ShurikenTurnEndChargeCount);
+
+        Assert.Equal(0, agg.Activations);
+        Assert.Equal(0, agg.TotalDamageAttempted);
+        Assert.Equal(0, agg.TotalDamageDealt);
+        Assert.Equal(0, agg.TotalDamageBlocked);
+        Assert.Equal(0, agg.TotalDamageOverkill);
+        Assert.Equal(0, agg.Kills);
+        Assert.Equal(0, agg.TotalTargets);
+        Assert.Equal(0, agg.AdditionalBlockGained);
+        Assert.Equal(0m, agg.StrengthAdded);
+    }
+
+    [Fact]
+    public void RelicAggregate_UnlimitedAttackChargeFields_JsonRoundtrip_PreservesFields()
+    {
+        var run = BuildRepresentativeRun();
+
+        var json = JsonSerializer.Serialize(run, SerializerOptions);
+
+        Assert.Contains("kusarigama_attacks_played", json);
+        Assert.Contains("kusarigama_turns_ended_at1_charge", json);
+        Assert.Contains("kusarigama_turns_ended_at2_charges", json);
+        Assert.Contains("kusarigama_turn_end_charge_total", json);
+        Assert.Contains("kusarigama_turn_end_charge_count", json);
+        Assert.Contains("ornamental_fan_attacks_played", json);
+        Assert.Contains("ornamental_fan_turns_ended_at1_charge", json);
+        Assert.Contains("ornamental_fan_turns_ended_at2_charges", json);
+        Assert.Contains("ornamental_fan_turn_end_charge_total", json);
+        Assert.Contains("ornamental_fan_turn_end_charge_count", json);
+        Assert.Contains("shuriken_attacks_played", json);
+        Assert.Contains("shuriken_turns_ended_at1_charge", json);
+        Assert.Contains("shuriken_turns_ended_at2_charges", json);
+        Assert.Contains("shuriken_turn_end_charge_total", json);
+        Assert.Contains("shuriken_turn_end_charge_count", json);
+
+        var restored = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(restored);
+        AssertRepresentativeAggregates(restored!);
+    }
+
+    [Fact]
+    public void RunTracker_UnlimitedAttackChargeHelpers_AccumulateAndClamp()
+    {
+        var kusarigama = new RelicAggregate();
+        RunTracker.RecordKusarigamaAttackPlayedForTest(kusarigama, 14);
+        RunTracker.RecordKusarigamaAttackPlayedForTest(kusarigama, -2);
+        RunTracker.RecordKusarigamaActivationForTest(kusarigama);
+        RunTracker.RecordKusarigamaActivationForTest(kusarigama);
+        RunTracker.RecordKusarigamaDamageForTest(
+            kusarigama,
+            new[]
+            {
+                (BlockedDamage: 2, UnblockedDamage: 3, OverkillDamage: 1, WasTargetKilled: true),
+                (BlockedDamage: 0, UnblockedDamage: 6, OverkillDamage: 0, WasTargetKilled: false),
+            });
+        RunTracker.RecordKusarigamaTurnEndChargeForTest(kusarigama, 1);
+        RunTracker.RecordKusarigamaTurnEndChargeForTest(kusarigama, 2);
+        RunTracker.RecordKusarigamaTurnEndChargeForTest(kusarigama, 5);
+        RunTracker.RecordKusarigamaTurnEndChargeForTest(kusarigama, -1);
+
+        Assert.Equal(14, kusarigama.KusarigamaAttacksPlayed);
+        Assert.Equal(2, kusarigama.Activations);
+        Assert.Equal(12, kusarigama.TotalDamageAttempted);
+        Assert.Equal(9, kusarigama.TotalDamageDealt);
+        Assert.Equal(2, kusarigama.TotalDamageBlocked);
+        Assert.Equal(1, kusarigama.TotalDamageOverkill);
+        Assert.Equal(1, kusarigama.Kills);
+        Assert.Equal(2, kusarigama.TotalTargets);
+        Assert.Equal(1, kusarigama.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(2, kusarigama.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(5, kusarigama.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(3, kusarigama.KusarigamaTurnEndChargeCount);
+
+        var ornamentalFan = new RelicAggregate();
+        RunTracker.RecordOrnamentalFanAttackPlayedForTest(ornamentalFan, 8);
+        RunTracker.RecordOrnamentalFanAttackPlayedForTest(ornamentalFan, -2);
+        RunTracker.RecordOrnamentalFanActivationForTest(ornamentalFan);
+        RunTracker.RecordOrnamentalFanActivationForTest(ornamentalFan);
+        RunTracker.RecordOrnamentalFanBlockGainedForTest(ornamentalFan, 4);
+        RunTracker.RecordOrnamentalFanBlockGainedForTest(ornamentalFan, 5);
+        RunTracker.RecordOrnamentalFanBlockGainedForTest(ornamentalFan, -2);
+        RunTracker.RecordOrnamentalFanTurnEndChargeForTest(ornamentalFan, 1);
+        RunTracker.RecordOrnamentalFanTurnEndChargeForTest(ornamentalFan, 2);
+        RunTracker.RecordOrnamentalFanTurnEndChargeForTest(ornamentalFan, 4);
+        RunTracker.RecordOrnamentalFanTurnEndChargeForTest(ornamentalFan, -1);
+
+        Assert.Equal(8, ornamentalFan.OrnamentalFanAttacksPlayed);
+        Assert.Equal(2, ornamentalFan.Activations);
+        Assert.Equal(9, ornamentalFan.AdditionalBlockGained);
+        Assert.Equal(2, ornamentalFan.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(1, ornamentalFan.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(4, ornamentalFan.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(3, ornamentalFan.OrnamentalFanTurnEndChargeCount);
+
+        var shuriken = new RelicAggregate();
+        RunTracker.RecordShurikenAttackPlayedForTest(shuriken, 11);
+        RunTracker.RecordShurikenAttackPlayedForTest(shuriken, -2);
+        RunTracker.RecordShurikenActivationForTest(shuriken, 1m);
+        RunTracker.RecordShurikenActivationForTest(shuriken, 2m);
+        RunTracker.RecordShurikenActivationForTest(shuriken, -1m);
+        RunTracker.RecordShurikenTurnEndChargeForTest(shuriken, 0);
+        RunTracker.RecordShurikenTurnEndChargeForTest(shuriken, 1);
+        RunTracker.RecordShurikenTurnEndChargeForTest(shuriken, 2);
+        RunTracker.RecordShurikenTurnEndChargeForTest(shuriken, 8);
+        RunTracker.RecordShurikenTurnEndChargeForTest(shuriken, -1);
+
+        Assert.Equal(11, shuriken.ShurikenAttacksPlayed);
+        Assert.Equal(3, shuriken.Activations);
+        Assert.Equal(3m, shuriken.StrengthAdded);
+        Assert.Equal(1, shuriken.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(5, shuriken.ShurikenTurnEndChargeTotal);
+        Assert.Equal(4, shuriken.ShurikenTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void MergeRelicAggregateInto_UnlimitedAttackChargeFields_Accumulates()
+    {
+        var kusarigama = new RelicAggregate
+        {
+            KusarigamaAttacksPlayed = 5,
+            Activations = 1,
+            TotalDamageAttempted = 6,
+            TotalDamageDealt = 4,
+            TotalDamageBlocked = 1,
+            TotalDamageOverkill = 1,
+            TotalTargets = 1,
+            KusarigamaTurnsEndedAt1Charge = 1,
+            KusarigamaTurnEndChargeTotal = 1,
+            KusarigamaTurnEndChargeCount = 1,
+        };
+        RunTracker.MergeRelicAggregateInto(kusarigama, new RelicAggregate
+        {
+            KusarigamaAttacksPlayed = 9,
+            Activations = 3,
+            TotalDamageAttempted = 18,
+            TotalDamageDealt = 13,
+            TotalDamageBlocked = 2,
+            TotalDamageOverkill = 3,
+            Kills = 2,
+            TotalTargets = 3,
+            KusarigamaTurnsEndedAt1Charge = 1,
+            KusarigamaTurnsEndedAt2Charges = 3,
+            KusarigamaTurnEndChargeTotal = 7,
+            KusarigamaTurnEndChargeCount = 6,
+        });
+
+        Assert.Equal(14, kusarigama.KusarigamaAttacksPlayed);
+        Assert.Equal(4, kusarigama.Activations);
+        Assert.Equal(24, kusarigama.TotalDamageAttempted);
+        Assert.Equal(17, kusarigama.TotalDamageDealt);
+        Assert.Equal(3, kusarigama.TotalDamageBlocked);
+        Assert.Equal(4, kusarigama.TotalDamageOverkill);
+        Assert.Equal(2, kusarigama.Kills);
+        Assert.Equal(4, kusarigama.TotalTargets);
+        Assert.Equal(2, kusarigama.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(3, kusarigama.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(8, kusarigama.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(7, kusarigama.KusarigamaTurnEndChargeCount);
+
+        var ornamentalFan = new RelicAggregate
+        {
+            OrnamentalFanAttacksPlayed = 5,
+            Activations = 1,
+            AdditionalBlockGained = 4,
+            OrnamentalFanTurnsEndedAt1Charge = 1,
+            OrnamentalFanTurnEndChargeTotal = 1,
+            OrnamentalFanTurnEndChargeCount = 1,
+        };
+        RunTracker.MergeRelicAggregateInto(ornamentalFan, new RelicAggregate
+        {
+            OrnamentalFanAttacksPlayed = 6,
+            Activations = 2,
+            AdditionalBlockGained = 9,
+            OrnamentalFanTurnsEndedAt2Charges = 3,
+            OrnamentalFanTurnEndChargeTotal = 6,
+            OrnamentalFanTurnEndChargeCount = 4,
+        });
+
+        Assert.Equal(11, ornamentalFan.OrnamentalFanAttacksPlayed);
+        Assert.Equal(3, ornamentalFan.Activations);
+        Assert.Equal(13, ornamentalFan.AdditionalBlockGained);
+        Assert.Equal(1, ornamentalFan.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(3, ornamentalFan.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(7, ornamentalFan.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(5, ornamentalFan.OrnamentalFanTurnEndChargeCount);
+
+        var shuriken = new RelicAggregate
+        {
+            ShurikenAttacksPlayed = 8,
+            Activations = 2,
+            StrengthAdded = 2m,
+            ShurikenTurnsEndedAt1Charge = 1,
+            ShurikenTurnEndChargeTotal = 1,
+            ShurikenTurnEndChargeCount = 2,
+        };
+        RunTracker.MergeRelicAggregateInto(shuriken, new RelicAggregate
+        {
+            ShurikenAttacksPlayed = 9,
+            Activations = 3,
+            StrengthAdded = 3m,
+            ShurikenTurnsEndedAt1Charge = 1,
+            ShurikenTurnsEndedAt2Charges = 2,
+            ShurikenTurnEndChargeTotal = 5,
+            ShurikenTurnEndChargeCount = 4,
+        });
+
+        Assert.Equal(17, shuriken.ShurikenAttacksPlayed);
+        Assert.Equal(5, shuriken.Activations);
+        Assert.Equal(5m, shuriken.StrengthAdded);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeTotal);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeCount);
+    }
+
+    [Fact]
+    public void RelicTooltips_UnlimitedAttackChargeRelics_ShowEffectAndChargeRows()
+    {
+        var kusarigamaBody = BuildBody(BuildKusarigamaBodyMethod, new RelicAggregate
+        {
+            KusarigamaAttacksPlayed = 14,
+            Activations = 4,
+            TotalDamageAttempted = 24,
+            TotalDamageDealt = 17,
+            TotalDamageBlocked = 3,
+            TotalDamageOverkill = 4,
+            Kills = 2,
+            TotalTargets = 4,
+            KusarigamaTurnsEndedAt1Charge = 2,
+            KusarigamaTurnsEndedAt2Charges = 3,
+            KusarigamaTurnEndChargeTotal = 8,
+            KusarigamaTurnEndChargeCount = 7,
+        });
+        Assert.Contains("Attacks played", kusarigamaBody);
+        Assert.Contains("Activations", kusarigamaBody);
+        Assert.Contains("Damage attempted", kusarigamaBody);
+        Assert.Contains("Damage dealt", kusarigamaBody);
+        Assert.Contains("Damage blocked", kusarigamaBody);
+        Assert.Contains("Overkill", kusarigamaBody);
+        Assert.Contains("Kills", kusarigamaBody);
+        Assert.Contains("Targets hit", kusarigamaBody);
+        Assert.Contains("Damage per activation", kusarigamaBody);
+        Assert.Contains("Turns ended at 1 charge", kusarigamaBody);
+        Assert.Contains("Turns ended at 2 charges", kusarigamaBody);
+        Assert.Contains("Avg charge at turn end", kusarigamaBody);
+        Assert.Contains("[b]4.25[/b]", kusarigamaBody);
+        Assert.Contains("[b]1.14[/b]", kusarigamaBody);
+
+        var ornamentalFanBody = BuildBody(BuildOrnamentalFanBodyMethod, new RelicAggregate
+        {
+            OrnamentalFanAttacksPlayed = 11,
+            Activations = 3,
+            AdditionalBlockGained = 13,
+            OrnamentalFanTurnsEndedAt1Charge = 1,
+            OrnamentalFanTurnsEndedAt2Charges = 3,
+            OrnamentalFanTurnEndChargeTotal = 7,
+            OrnamentalFanTurnEndChargeCount = 5,
+        });
+        Assert.Contains("Attacks played", ornamentalFanBody);
+        Assert.Contains("Activations", ornamentalFanBody);
+        Assert.Contains("[img=16x16]res://images/ui/combat/block.png[/img] block gained", ornamentalFanBody);
+        Assert.Contains("block gained per activation", ornamentalFanBody);
+        Assert.Contains("Turns ended at 1 charge", ornamentalFanBody);
+        Assert.Contains("Turns ended at 2 charges", ornamentalFanBody);
+        Assert.Contains("Avg charge at turn end", ornamentalFanBody);
+        Assert.Contains("[b]4.33[/b]", ornamentalFanBody);
+        Assert.Contains("[b]1.4[/b]", ornamentalFanBody);
+
+        var shurikenBody = BuildBody(BuildShurikenBodyMethod, new RelicAggregate
+        {
+            ShurikenAttacksPlayed = 14,
+            Activations = 4,
+            StrengthAdded = 5m,
+            ShurikenTurnsEndedAt1Charge = 1,
+            ShurikenTurnsEndedAt2Charges = 2,
+            ShurikenTurnEndChargeTotal = 5,
+            ShurikenTurnEndChargeCount = 4,
+        });
+        Assert.Contains("Attacks played", shurikenBody);
+        Assert.Contains("Activations", shurikenBody);
+        Assert.Contains("Strength gained", shurikenBody);
+        Assert.Contains("Strength gained per activation", shurikenBody);
+        Assert.Contains("Turns ended at 1 charge", shurikenBody);
+        Assert.Contains("Turns ended at 2 charges", shurikenBody);
+        Assert.Contains("Avg charge at turn end", shurikenBody);
+        Assert.Contains("[b]1.25[/b]", shurikenBody);
+    }
+
+    [Fact]
+    public void RelicTooltips_UnlimitedAttackChargeRelics_DispatchForAllModels()
+    {
+        var kusarigama = (Kusarigama)RuntimeHelpers.GetUninitializedObject(typeof(Kusarigama));
+        var ornamentalFan = (OrnamentalFan)RuntimeHelpers.GetUninitializedObject(typeof(OrnamentalFan));
+        var shuriken = (Shuriken)RuntimeHelpers.GetUninitializedObject(typeof(Shuriken));
+
+        Assert.True(RelicHoverShowPatch.TryBuildBodyBBCode(
+            kusarigama,
+            new RelicAggregate(),
+            floorCount: null,
+            out var kusarigamaTitle,
+            out var kusarigamaBody));
+        Assert.Equal("Kusarigama", kusarigamaTitle);
+        Assert.Contains("Attacks played", kusarigamaBody);
+
+        Assert.True(RelicHoverShowPatch.TryBuildBodyBBCode(
+            ornamentalFan,
+            new RelicAggregate(),
+            floorCount: null,
+            out var ornamentalFanTitle,
+            out var ornamentalFanBody));
+        Assert.Equal("Ornamental Fan", ornamentalFanTitle);
+        Assert.Contains("Attacks played", ornamentalFanBody);
+
+        Assert.True(RelicHoverShowPatch.TryBuildBodyBBCode(
+            shuriken,
+            new RelicAggregate(),
+            floorCount: null,
+            out var shurikenTitle,
+            out var shurikenBody));
+        Assert.Equal("Shuriken", shurikenTitle);
+        Assert.Contains("Attacks played", shurikenBody);
+    }
+
+    [Fact]
+    public void RelicTooltips_UnlimitedAttackChargeRelics_ShowZeroRowsForEmptyAggregates()
+    {
+        var kusarigamaBody = BuildBody(BuildKusarigamaBodyMethod, new RelicAggregate());
+        var ornamentalFanBody = BuildBody(BuildOrnamentalFanBodyMethod, new RelicAggregate());
+        var shurikenBody = BuildBody(BuildShurikenBodyMethod, new RelicAggregate());
+
+        Assert.Contains("Damage per activation", kusarigamaBody);
+        Assert.Contains("Avg charge at turn end", kusarigamaBody);
+        Assert.Contains("[b]0[/b]", kusarigamaBody);
+        Assert.Contains("block gained per activation", ornamentalFanBody);
+        Assert.Contains("Avg charge at turn end", ornamentalFanBody);
+        Assert.Contains("[b]0[/b]", ornamentalFanBody);
+        Assert.Contains("Strength gained per activation", shurikenBody);
+        Assert.Contains("Avg charge at turn end", shurikenBody);
+        Assert.Contains("[b]0[/b]", shurikenBody);
+    }
+
+    [Fact]
+    public void RunData_OlderShapeWithoutUnlimitedAttackChargeFields_DeserializesWithZeroDefaults()
+    {
+        const string json = """
+            {
+              "run_id": "test",
+              "started_at": "2026-01-01T00:00:00Z",
+              "updated_at": "2026-01-01T00:00:00Z",
+              "outcome": "in_progress",
+              "aggregates": {},
+              "events": [],
+              "instance_numbers_by_def": {},
+              "def_counters": {},
+              "relic_aggregates": {
+                "RELIC.KUSARIGAMA": {},
+                "RELIC.ORNAMENTAL_FAN": {},
+                "RELIC.SHURIKEN": {}
+              }
+            }
+            """;
+
+        var run = JsonSerializer.Deserialize<RunData>(json, SerializerOptions);
+
+        Assert.NotNull(run);
+        var kusarigama = run!.RelicAggregates[KusarigamaRelicId];
+        Assert.Equal(0, kusarigama.KusarigamaAttacksPlayed);
+        Assert.Equal(0, kusarigama.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(0, kusarigama.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(0, kusarigama.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(0, kusarigama.KusarigamaTurnEndChargeCount);
+        Assert.Equal(0, kusarigama.TotalDamageAttempted);
+        Assert.Equal(0, kusarigama.TotalDamageDealt);
+
+        var ornamentalFan = run.RelicAggregates[OrnamentalFanRelicId];
+        Assert.Equal(0, ornamentalFan.OrnamentalFanAttacksPlayed);
+        Assert.Equal(0, ornamentalFan.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(0, ornamentalFan.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(0, ornamentalFan.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(0, ornamentalFan.OrnamentalFanTurnEndChargeCount);
+        Assert.Equal(0, ornamentalFan.AdditionalBlockGained);
+
+        var shuriken = run.RelicAggregates[ShurikenRelicId];
+        Assert.Equal(0, shuriken.ShurikenAttacksPlayed);
+        Assert.Equal(0, shuriken.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(0, shuriken.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(0, shuriken.ShurikenTurnEndChargeTotal);
+        Assert.Equal(0, shuriken.ShurikenTurnEndChargeCount);
+        Assert.Equal(0m, shuriken.StrengthAdded);
+    }
+
+    private static RunData BuildRepresentativeRun()
+    {
+        var run = new RunData();
+        run.RelicAggregates[KusarigamaRelicId] = new RelicAggregate
+        {
+            KusarigamaAttacksPlayed = 14,
+            Activations = 4,
+            TotalDamageAttempted = 24,
+            TotalDamageDealt = 17,
+            TotalDamageBlocked = 3,
+            TotalDamageOverkill = 4,
+            Kills = 2,
+            TotalTargets = 4,
+            KusarigamaTurnsEndedAt1Charge = 2,
+            KusarigamaTurnsEndedAt2Charges = 3,
+            KusarigamaTurnEndChargeTotal = 8,
+            KusarigamaTurnEndChargeCount = 7,
+        };
+        run.RelicAggregates[OrnamentalFanRelicId] = new RelicAggregate
+        {
+            OrnamentalFanAttacksPlayed = 11,
+            Activations = 3,
+            AdditionalBlockGained = 13,
+            OrnamentalFanTurnsEndedAt1Charge = 1,
+            OrnamentalFanTurnsEndedAt2Charges = 3,
+            OrnamentalFanTurnEndChargeTotal = 7,
+            OrnamentalFanTurnEndChargeCount = 5,
+        };
+        run.RelicAggregates[ShurikenRelicId] = new RelicAggregate
+        {
+            ShurikenAttacksPlayed = 17,
+            Activations = 5,
+            StrengthAdded = 5m,
+            ShurikenTurnsEndedAt1Charge = 2,
+            ShurikenTurnsEndedAt2Charges = 2,
+            ShurikenTurnEndChargeTotal = 6,
+            ShurikenTurnEndChargeCount = 6,
+        };
+        return run;
+    }
+
+    private static void AssertRepresentativeAggregates(RunData run)
+    {
+        var kusarigama = run.RelicAggregates[KusarigamaRelicId];
+        Assert.Equal(14, kusarigama.KusarigamaAttacksPlayed);
+        Assert.Equal(4, kusarigama.Activations);
+        Assert.Equal(24, kusarigama.TotalDamageAttempted);
+        Assert.Equal(17, kusarigama.TotalDamageDealt);
+        Assert.Equal(3, kusarigama.TotalDamageBlocked);
+        Assert.Equal(4, kusarigama.TotalDamageOverkill);
+        Assert.Equal(2, kusarigama.Kills);
+        Assert.Equal(4, kusarigama.TotalTargets);
+        Assert.Equal(2, kusarigama.KusarigamaTurnsEndedAt1Charge);
+        Assert.Equal(3, kusarigama.KusarigamaTurnsEndedAt2Charges);
+        Assert.Equal(8, kusarigama.KusarigamaTurnEndChargeTotal);
+        Assert.Equal(7, kusarigama.KusarigamaTurnEndChargeCount);
+
+        var ornamentalFan = run.RelicAggregates[OrnamentalFanRelicId];
+        Assert.Equal(11, ornamentalFan.OrnamentalFanAttacksPlayed);
+        Assert.Equal(3, ornamentalFan.Activations);
+        Assert.Equal(13, ornamentalFan.AdditionalBlockGained);
+        Assert.Equal(1, ornamentalFan.OrnamentalFanTurnsEndedAt1Charge);
+        Assert.Equal(3, ornamentalFan.OrnamentalFanTurnsEndedAt2Charges);
+        Assert.Equal(7, ornamentalFan.OrnamentalFanTurnEndChargeTotal);
+        Assert.Equal(5, ornamentalFan.OrnamentalFanTurnEndChargeCount);
+
+        var shuriken = run.RelicAggregates[ShurikenRelicId];
+        Assert.Equal(17, shuriken.ShurikenAttacksPlayed);
+        Assert.Equal(5, shuriken.Activations);
+        Assert.Equal(5m, shuriken.StrengthAdded);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt1Charge);
+        Assert.Equal(2, shuriken.ShurikenTurnsEndedAt2Charges);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeTotal);
+        Assert.Equal(6, shuriken.ShurikenTurnEndChargeCount);
+    }
+
+    private static MethodInfo GetBuilder(string name)
+        => typeof(RelicHoverShowPatch).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"{name} not found.");
+
+    private static string BuildBody(MethodInfo builder, RelicAggregate agg)
+        => (string)(builder.Invoke(null, new object?[] { agg })
+            ?? throw new InvalidOperationException($"{builder.Name} returned null."));
+}

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -426,6 +426,16 @@ to confirm the eligibility rule. Base Strikes are `IsBasicStrikeOrDefend` cards
 that also carry the Strike tag, while non-base Strike cards are every other
 permanent deck card with that tag.
 
+Kunai, Kusarigama, Ornamental Fan, and Shuriken share the same repeatable
+three-Attack counter shape: their owner-specific `AfterCardPlayed` callback
+increments a turn-local counter and activates at every threshold multiple.
+Count owner Attack plays at that callback, snapshot unused modulo charge from
+`Hook.BeforeSideTurnEnd` before the relic resets, and observe each payoff at its
+narrow outcome: power delta for Kunai/Shuriken, the resolved block-command
+result for Ornamental Fan, and the resolved single-target damage result for
+Kusarigama. Kusarigama only activates when its threshold play can choose a
+hittable enemy; do not infer an activation from the counter alone.
+
 Razor Tooth upgrades eligible Attack and Skill cards synchronously inside its
 owner-specific `AfterCardPlayed` callback, after the finished card-play history
 entry has already been emitted. Combat history has no upgrade entry for this

--- a/docs/sts2-runtime-primer.md
+++ b/docs/sts2-runtime-primer.md
@@ -376,7 +376,12 @@ Pael's sacrifice reward option is owned by `PaelsWing`, not `PaelsFlesh`.
 alternative and `PaelsWing.OnSacrifice` increments the saved sacrifice count.
 `PaelsFlesh` is a separate combat max-energy relic that activates after turn 3.
 Track consumed card reward rarities and skipped sacrifice opportunities from the
-card reward alternative flow, not from PaelsFlesh's energy hooks.
+card reward alternative flow, not from PaelsFlesh's energy hooks. Every second
+sacrifice pulls and obtains a normal `RelicModel`. Capture that direct artifact
+from the owner's first `RelicObtained` event during `OnSacrifice`; the event fires
+synchronously when the relic enters inventory, before its async `AfterObtained`
+callback. Store its id, display name, and count in Pael's Wing's `RelicsGranted`
+ledger.
 
 For relics that grant block after a specific owner-owned condition, arm a narrow block-gain window at the relic callback and let `Hook.AfterBlockGained` record the modified amount. Permafrost follows this pattern from `Permafrost.AfterCardPlayed`: mirror the first-owned-Power condition, count that combat trigger, then derive block per combat from observed block gained divided by triggers.
 


### PR DESCRIPTION
## Summary
- refine the relic Compendium taxonomy with nested charge categories, remove the empty energy group, and preserve the preferred filter defaults
- preserve relic/power hover behavior and add Pael's Wing artifact totals plus per-artifact details
- add complete stats for Kusarigama, Ornamental Fan, and Shuriken, including observed outcomes and turn-end charge pressure

## Validation
- `dotnet build Core/SpireLens.Core.csproj -c Debug` (succeeded with 0 errors; existing CS8601 warning remains)
- deployed and hot-reloaded SpireLens Core as reload 13
- tests and behavioral verification were not run, per the repo's user-owned verification policy